### PR TITLE
test(gjc): stabilize worker guard timeout coverage

### DIFF
--- a/server/gjc-worker-client.test.ts
+++ b/server/gjc-worker-client.test.ts
@@ -202,10 +202,17 @@ test('fails closed when the Windows job guard never proves app ownership', async
     initializeTimeoutMs: 5,
   });
 
-  await assert.rejects(
-    supervisor.spawn('hello', {}, { send() {} }),
-    /GJC worker failed/,
-  );
+  // Production deliberately unrefs the guard timer. Keep the test process
+  // alive independently so an isolated run can observe the timeout rejection.
+  const keepAlive = setTimeout(() => {}, 1_000);
+  try {
+    await assert.rejects(
+      supervisor.spawn('hello', {}, { send() {} }),
+      /GJC worker failed/,
+    );
+  } finally {
+    clearTimeout(keepAlive);
+  }
 
   assert.equal(child.killed, true);
 });


### PR DESCRIPTION
## Summary
- keep the production guard timer unref behavior unchanged
- add a test-only referenced timer while the timeout rejection is asserted
- allow the isolated worker supervisor test process to reach all remaining cases

## Verification
- isolated worker client tests: 19/19, 0 cancelled
- full npm test: 0 cancelled (the three known live-session fixture failures are addressed separately in #1)
- npm run typecheck
- npm run lint
- npm run build