### PR TITLE
fix(cursor): report missing cursor agent correctly

### DIFF
--- a/server/modules/providers/list/cursor/cursor-auth.provider.ts
+++ b/server/modules/providers/list/cursor/cursor-auth.provider.ts
@@ -10,17 +10,30 @@ type CursorLoginStatus = {
   error?: string;
 };
 
+type CursorVersionProbe = typeof spawn.sync;
+
+export const isCursorAgentInstalled = (
+  runVersionProbe: CursorVersionProbe = spawn.sync,
+): boolean => {
+  try {
+    const result = runVersionProbe('cursor-agent', ['--version'], {
+      stdio: 'ignore',
+      timeout: 5000,
+    });
+    return !result.error && result.status === 0;
+  } catch {
+    return false;
+  }
+};
+
 export class CursorProviderAuth implements IProviderAuth {
+  constructor(private readonly runVersionProbe: CursorVersionProbe = spawn.sync) {}
+
   /**
    * Checks whether the cursor-agent CLI is available on this host.
    */
   private checkInstalled(): boolean {
-    try {
-      spawn.sync('cursor-agent', ['--version'], { stdio: 'ignore', timeout: 5000 });
-      return true;
-    } catch {
-      return false;
-    }
+    return isCursorAgentInstalled(this.runVersionProbe);
   }
 
   /**

--- a/server/modules/providers/tests/cursor-auth.test.ts
+++ b/server/modules/providers/tests/cursor-auth.test.ts
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import spawn from 'cross-spawn';
+
+import {
+  CursorProviderAuth,
+  isCursorAgentInstalled,
+} from '@/modules/providers/list/cursor/cursor-auth.provider.js';
+
+const probeResult = (
+  overrides: Record<string, unknown>,
+): ReturnType<typeof spawn.sync> => ({
+  pid: 123,
+  output: [null, null, null],
+  stdout: null,
+  stderr: null,
+  status: 0,
+  signal: null,
+  ...overrides,
+} as unknown as ReturnType<typeof spawn.sync>);
+
+const probe = (result: ReturnType<typeof spawn.sync>) => (
+  (() => result) as typeof spawn.sync
+);
+
+test('cursor installation probe accepts a successful version command', () => {
+  assert.equal(isCursorAgentInstalled(probe(probeResult({ status: 0 }))), true);
+});
+
+test('cursor installation probe rejects a non-zero version command', () => {
+  assert.equal(isCursorAgentInstalled(probe(probeResult({ status: 1 }))), false);
+});
+
+test('cursor installation probe rejects ENOENT and reports the provider as missing', async () => {
+  const missing = Object.assign(new Error('spawnSync cursor-agent ENOENT'), { code: 'ENOENT' });
+  const runVersionProbe = probe(probeResult({ error: missing, status: null }));
+
+  assert.equal(isCursorAgentInstalled(runVersionProbe), false);
+  assert.deepEqual(await new CursorProviderAuth(runVersionProbe).getStatus(), {
+    installed: false,
+    provider: 'cursor',
+    authenticated: false,
+    email: null,
+    method: null,
+    error: 'Cursor CLI is not installed',
+  });
+});


### PR DESCRIPTION
## Summary
- inspect the synchronous version probe result instead of assuming non-throwing means installed
- treat spawn errors, ENOENT, signals, and non-zero exits as missing/unusable
- keep the existing auth status response schema while correcting installed semantics

## Verification
- Cursor install detection tests: success, non-zero exit, and ENOENT (3/3)
- missing-provider status returns installed:false and authenticated:false
- npm run typecheck
- npm run lint
- npm run build