### PR TITLE
fix(claude): detect macOS Keychain authentication

### DIFF
--- a/server/modules/providers/list/claude/claude-auth.provider.ts
+++ b/server/modules/providers/list/claude/claude-auth.provider.ts
@@ -16,19 +16,53 @@ type ClaudeCredentialsStatus = {
   error?: string;
 };
 
+type ClaudeAuthRuntime = {
+  platform?: NodeJS.Platform;
+  runVersionProbe?: typeof spawn.sync;
+  runKeychainProbe?: typeof spawn.sync;
+};
+
 const hasErrorCode = (error: unknown, code: string): boolean => (
   error instanceof Error && 'code' in error && error.code === code
 );
 
+export const hasClaudeKeychainCredentials = (
+  platform: NodeJS.Platform = process.platform,
+  runKeychainProbe: typeof spawn.sync = spawn.sync,
+): boolean => {
+  if (platform !== 'darwin') {
+    return false;
+  }
+
+  try {
+    // Claude Code 2.x stores OAuth credentials in the macOS Keychain. Probe
+    // metadata only: omitting -w/-g ensures no credential value is returned.
+    const result = runKeychainProbe(
+      '/usr/bin/security',
+      ['find-generic-password', '-s', 'Claude Code-credentials'],
+      { stdio: 'ignore', timeout: 5000 },
+    );
+    return !result.error && result.status === 0;
+  } catch {
+    return false;
+  }
+};
+
 export class ClaudeProviderAuth implements IProviderAuth {
+  constructor(private readonly runtime: ClaudeAuthRuntime = {}) {}
+
   /**
    * Checks whether the Claude Code CLI is available on this host.
    */
   private checkInstalled(): boolean {
     const cliPath = resolveClaudeCodeExecutablePath(process.env.CLAUDE_CLI_PATH);
     try {
-      spawn.sync(cliPath, ['--version'], { stdio: 'ignore', timeout: 5000 });
-      return true;
+      const result = (this.runtime.runVersionProbe ?? spawn.sync)(
+        cliPath,
+        ['--version'],
+        { stdio: 'ignore', timeout: 5000 },
+      );
+      return !result.error && result.status === 0;
     } catch {
       return false;
     }
@@ -98,6 +132,13 @@ export class ClaudeProviderAuth implements IProviderAuth {
 
     if (readOptionalString(settingsEnv.ANTHROPIC_AUTH_TOKEN)) {
       return { authenticated: true, email: 'Configured via settings.json', method: 'api_key' };
+    }
+
+    if (hasClaudeKeychainCredentials(
+      this.runtime.platform,
+      this.runtime.runKeychainProbe,
+    )) {
+      return { authenticated: true, email: null, method: 'keychain' };
     }
 
     try {

--- a/server/modules/providers/tests/claude-auth.test.ts
+++ b/server/modules/providers/tests/claude-auth.test.ts
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import spawn from 'cross-spawn';
+
+import {
+  ClaudeProviderAuth,
+  hasClaudeKeychainCredentials,
+} from '@/modules/providers/list/claude/claude-auth.provider.js';
+
+const probeResult = (
+  overrides: Record<string, unknown> = {},
+): ReturnType<typeof spawn.sync> => ({
+  pid: 123,
+  output: [null, null, null],
+  stdout: null,
+  stderr: null,
+  status: 0,
+  signal: null,
+  ...overrides,
+} as unknown as ReturnType<typeof spawn.sync>);
+
+const probe = (result: ReturnType<typeof spawn.sync>) => (
+  (() => result) as typeof spawn.sync
+);
+
+test('Claude keychain probe accepts the current macOS credential service', () => {
+  assert.equal(hasClaudeKeychainCredentials('darwin', probe(probeResult())), true);
+});
+
+test('Claude keychain probe rejects missing items and non-macOS hosts', () => {
+  const missing = probe(probeResult({ status: 44 }));
+  assert.equal(hasClaudeKeychainCredentials('darwin', missing), false);
+  assert.equal(hasClaudeKeychainCredentials('linux', probe(probeResult())), false);
+});
+
+test('Claude provider reports a macOS Keychain login without reading its secret', async () => {
+  const calls: Array<{ command: string; args: readonly string[] }> = [];
+  const keychainProbe = ((command: string, args: readonly string[]) => {
+    calls.push({ command, args });
+    return probeResult();
+  }) as typeof spawn.sync;
+  const provider = new ClaudeProviderAuth({
+    platform: 'darwin',
+    runVersionProbe: probe(probeResult()),
+    runKeychainProbe: keychainProbe,
+  });
+
+  assert.deepEqual(await provider.getStatus(), {
+    installed: true,
+    provider: 'claude',
+    authenticated: true,
+    email: 'Authenticated',
+    method: 'keychain',
+    error: undefined,
+  });
+  assert.deepEqual(calls, [{
+    command: '/usr/bin/security',
+    args: ['find-generic-password', '-s', 'Claude Code-credentials'],
+  }]);
+});


### PR DESCRIPTION
## Summary
- recognize Claude Code 2.x OAuth credentials stored in the macOS Keychain
- probe only Keychain item metadata and never request the secret value
- retain environment, settings.json, and legacy credentials-file precedence
- make the Claude version probe reject spawn errors and non-zero exits

## Reproduction
1. Complete Claude Code 2.1.31 OAuth login on macOS
2. Confirm the Claude Code-credentials Keychain item exists
3. Request /api/providers/claude/auth/status
4. Before this change the endpoint returns authenticated:false because only the legacy credentials JSON file is inspected

Reproduced twice after a successful OAuth login.

## Verification
- Claude Keychain auth tests: 3/3
- npm run typecheck
- npm run lint
- npm run build