### PR TITLE
fix(opencode): preserve the session model on resume

### DIFF
--- a/server/modules/providers/list/opencode/opencode-models.provider.ts
+++ b/server/modules/providers/list/opencode/opencode-models.provider.ts
@@ -357,7 +357,7 @@ export const buildOpenCodeDefinitionFromVerboseModels = (
   };
 };
 
-const parseOpenCodeSessionModelValue = (rawModel: unknown): string | null => {
+export const parseOpenCodeSessionModelValue = (rawModel: unknown): string | null => {
   if (typeof rawModel === 'string') {
     const trimmed = rawModel.trim();
     if (!trimmed) {
@@ -376,8 +376,13 @@ const parseOpenCodeSessionModelValue = (rawModel: unknown): string | null => {
     return null;
   }
 
-  return readOptionalString(record.id)
-    ?? readOptionalString(record.model)
+  const id = readOptionalString(record.id);
+  const providerId = readOptionalString(record.providerID);
+  if (id) {
+    return id.includes('/') || !providerId ? id : `${providerId}/${id}`;
+  }
+
+  return readOptionalString(record.model)
     ?? readOptionalString(record.name)
     ?? readOptionalString(record.value)
     ?? null;

--- a/server/modules/providers/services/provider-models.service.ts
+++ b/server/modules/providers/services/provider-models.service.ts
@@ -335,6 +335,11 @@ export const createProviderModelsService = (dependencies: ProviderModelsServiceD
       return changedModel.model.trim();
     }
 
+    const currentModel = await getCurrentActiveModel(provider, sessionId);
+    if (currentModel.model?.trim()) {
+      return currentModel.model.trim();
+    }
+
     return normalizedRequestedModel || undefined;
   };
 

--- a/server/modules/providers/tests/opencode-models.test.ts
+++ b/server/modules/providers/tests/opencode-models.test.ts
@@ -5,8 +5,26 @@ import {
   buildOpenCodeDefinitionFromVerboseModels,
   buildOpenCodeDefinitionFromIds,
   parseOpenCodeModelsStdout,
+  parseOpenCodeSessionModelValue,
   parseOpenCodeVerboseModelsStdout,
 } from '@/modules/providers/list/opencode/opencode-models.provider.js';
+
+test('OpenCode session model parser preserves the provider-qualified model id', () => {
+  assert.equal(
+    parseOpenCodeSessionModelValue(JSON.stringify({
+      id: 'gpt-5.5',
+      providerID: 'openai',
+    })),
+    'openai/gpt-5.5',
+  );
+  assert.equal(
+    parseOpenCodeSessionModelValue({
+      id: 'anthropic/claude-sonnet-4-5',
+      providerID: 'anthropic',
+    }),
+    'anthropic/claude-sonnet-4-5',
+  );
+});
 
 test('OpenCode models provider parses plain CLI output and removes duplicates', () => {
   const ids = parseOpenCodeModelsStdout(`

--- a/server/modules/providers/tests/provider-models.service.test.ts
+++ b/server/modules/providers/tests/provider-models.service.test.ts
@@ -347,3 +347,23 @@ test('resolveResumeModel prefers a stored changed model over the requested one',
     await rm(tempRoot, { recursive: true, force: true });
   }
 });
+
+test('resolveResumeModel prefers the provider session model over the requested default', async () => {
+  const service = createProviderModelsService({
+    resolveProvider: (provider) => ({
+      models: {
+        getSupportedModels: async () => createModels(`${provider}-models`),
+        getCurrentActiveModel: async () => createCurrentActiveModel('openai/gpt-5.5'),
+        changeActiveModel: async (input) => createSessionActiveModelChange(provider, input),
+      },
+    }),
+  });
+
+  const model = await service.resolveResumeModel(
+    'opencode',
+    'session-native-opencode',
+    'anthropic/claude-sonnet-4-5',
+  );
+
+  assert.equal(model, 'openai/gpt-5.5');
+});


### PR DESCRIPTION
## Summary

- prefer an explicit ChatMux model change, then the provider session's actual model, when resuming
- preserve OpenCode's `providerID/id` model identifier from its session database
- add regression coverage for both precedence and OpenCode model parsing

## Root cause

The native OpenCode session used `openai/gpt-5.5`, but ChatMux resumed it with the new-session UI default `anthropic/claude-sonnet-4-5`. OpenCode stores the model as `{ providerID, id }`; ChatMux also discarded `providerID`, so it could not reconstruct the CLI model argument correctly.

## Verification

- targeted provider/OpenCode tests (15/15)
- `npm run typecheck`
- `npm run lint`
- `npm run build`

