### PR TITLE
fix(cli): surface pending interactive prompts

### DIFF
--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -11,6 +11,7 @@ import { sessionsService } from '@/modules/providers/services/sessions.service.j
 import { sessionSynchronizerService } from '@/modules/providers/services/session-synchronizer.service.js';
 import { getLiveGjcSessions, IDLE_GJC_ID_PREFIX } from '@/modules/providers/services/live-sessions.service.js';
 import {
+  captureExternalCliSessionOutput,
   getCurrentTmuxSessionName,
   getExternalCliSessions,
   killExternalCliSession,
@@ -646,6 +647,27 @@ router.get(
       };
     }));
     res.json(createApiSuccessResponse({ externalSessions }));
+  }),
+);
+
+router.get(
+  '/sessions/external/output',
+  asyncHandler(async (req: Request, res: Response) => {
+    const tmuxName = typeof req.query.tmuxName === 'string' ? req.query.tmuxName : '';
+    if (!isValidTmuxName(tmuxName)) {
+      throw new AppError('A valid tmuxName is required.', { code: 'INVALID_TMUX_NAME', statusCode: 400 });
+    }
+    const external = (await getExternalCliSessions()).find(
+      (session) => session.tmuxName === tmuxName && session.kind !== 'ssh',
+    );
+    if (!external) {
+      throw new AppError('The selected tmux session is no longer a supported local CLI session.', {
+        code: 'EXTERNAL_CLI_SESSION_MISMATCH',
+        statusCode: 409,
+      });
+    }
+    const output = await captureExternalCliSessionOutput(tmuxName);
+    res.json(createApiSuccessResponse({ output }));
   }),
 );
 

--- a/server/modules/providers/services/external-cli-sessions.service.ts
+++ b/server/modules/providers/services/external-cli-sessions.service.ts
@@ -617,6 +617,22 @@ export async function sendToExternalCliSession(tmuxName: string, message: string
   await runCommand('tmux', ['send-keys', '-t', target, 'Enter']);
 }
 
+export function normalizeExternalPaneOutput(output: string, maxChars = 32_768): string {
+  const plain = output
+    .replace(/\r/g, '')
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '')
+    .trimEnd();
+  return plain.length > maxChars ? plain.slice(-maxChars) : plain;
+}
+
+/** Reads a bounded, plain-text tail of one exact local CLI tmux pane. */
+export async function captureExternalCliSessionOutput(tmuxName: string): Promise<string> {
+  const output = await runCommand('tmux', [
+    'capture-pane', '-p', '-S', '-80', '-t', `=${tmuxName}:`,
+  ]);
+  return normalizeExternalPaneOutput(output);
+}
+
 /** Resolves a web spawn cwd and rejects traversal/symlink escape outside HOME. */
 export async function resolveExternalCliCwd(input: string): Promise<string | null> {
   const home = await realpath(homedir()).catch(() => null);

--- a/server/modules/providers/tests/external-cli-sessions.service.test.ts
+++ b/server/modules/providers/tests/external-cli-sessions.service.test.ts
@@ -8,10 +8,18 @@ import {
   classifyExternalSessions,
   extractCodexResumeThreadId,
   extractExternalResumeSessionId,
+  normalizeExternalPaneOutput,
   parseClaudeRuntimeSession,
   parseExternalPanes,
   parsePsTree,
 } from '@/modules/providers/services/external-cli-sessions.service.js';
+
+test('normalizeExternalPaneOutput removes control bytes and bounds the pane tail', () => {
+  assert.equal(
+    normalizeExternalPaneOutput('old\r\n\u0000Trust this folder?\u0007\n1. Yes\n', 24),
+    'Trust this folder?\n1. Yes'.slice(-24),
+  );
+});
 
 test('parseExternalPanes splits session_name<TAB>pane_pid<TAB>pane_current_command', () => {
   const out = parseExternalPanes('patina\t113501\tclaude\ntest\t360992\tnode\n\nbad-line\n');

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -15,6 +15,7 @@ import type { Project } from '../../../types/app';
 import MainContentHeader from './subcomponents/MainContentHeader';
 import MainContentStateView from './subcomponents/MainContentStateView';
 import ErrorBoundary from './ErrorBoundary';
+import PendingExternalCliOutput from './subcomponents/PendingExternalCliOutput';
 
 const PluginTabContent = lazy(() => import('../../plugins/view/PluginTabContent'));
 const ChatInterface = lazy(() => import('../../chat/view/ChatInterface'));
@@ -72,6 +73,7 @@ function MainContent({
   const { currentProject, setCurrentProject } = useTaskMaster() as TaskMasterContextValue;
   const { tasksEnabled, isTaskMasterInstalled } = useTasksSettings() as TasksSettingsContextValue;
   const [browserUseEnabled, setBrowserUseEnabled] = useState(false);
+  const [externalPaneOutput, setExternalPaneOutput] = useState('');
   const [filesPanelOpen, setFilesPanelOpen] = useState(() => {
     try {
       return localStorage.getItem('files-panel-open') === 'true';
@@ -152,6 +154,45 @@ function MainContent({
   }, [loadBrowserUseSettings]);
 
   useEffect(() => {
+    const terminal = externalTerminal;
+    if (!terminal || terminal.cliKind === 'ssh') {
+      setExternalPaneOutput('');
+      return undefined;
+    }
+
+    let cancelled = false;
+    let controller: AbortController | null = null;
+    const loadOutput = async () => {
+      controller?.abort();
+      controller = new AbortController();
+      try {
+        const params = new URLSearchParams({ tmuxName: terminal.tmuxName });
+        const response = await authenticatedFetch(
+          `/api/providers/sessions/external/output?${params}`,
+          { signal: controller.signal },
+        );
+        const payload = await response.json();
+        if (!cancelled && response.ok) {
+          setExternalPaneOutput(typeof payload?.data?.output === 'string' ? payload.data.output : '');
+        }
+      } catch (error) {
+        if (!cancelled && !(error instanceof DOMException && error.name === 'AbortError')) {
+          setExternalPaneOutput('');
+        }
+      }
+    };
+
+    setExternalPaneOutput('');
+    void loadOutput();
+    const interval = window.setInterval(() => void loadOutput(), 1_000);
+    return () => {
+      cancelled = true;
+      controller?.abort();
+      window.clearInterval(interval);
+    };
+  }, [externalTerminal]);
+
+  useEffect(() => {
     if (!shouldShowBrowserTab && activeTab === 'browser') {
       setActiveTab('chat');
     }
@@ -214,11 +255,7 @@ function MainContent({
             <X className="h-4 w-4" />
           </button>
         </div>
-        <div className="min-h-0 flex-1 overflow-y-auto px-4">
-          <div className="mx-auto flex h-full max-w-[54.25rem] items-center justify-center text-center text-sm text-muted-foreground">
-            첫 지시를 보내면 {providerLabel} transcript가 생성되어 이 화면에 자동으로 연결됩니다.
-          </div>
-        </div>
+        <PendingExternalCliOutput providerLabel={providerLabel} output={externalPaneOutput} />
         <LiveRelayComposer
           key={`pending-${externalTerminal.cliKind}:${externalTerminal.tmuxName}`}
           tmuxName={externalTerminal.tmuxName}

--- a/src/components/main-content/view/subcomponents/PendingExternalCliOutput.test.tsx
+++ b/src/components/main-content/view/subcomponents/PendingExternalCliOutput.test.tsx
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import PendingExternalCliOutput from './PendingExternalCliOutput';
+
+test('pending external CLI output exposes interactive terminal prompts', () => {
+  const html = renderToStaticMarkup(
+    <PendingExternalCliOutput providerLabel="Codex" output="Do you trust this folder?\n1. Yes" />,
+  );
+
+  assert.ok(html.includes('aria-label="Codex live terminal output"'));
+  assert.ok(html.includes('Do you trust this folder?'));
+  assert.ok(html.includes('1. Yes'));
+});
+
+test('pending external CLI output keeps the transcript guidance before pane output arrives', () => {
+  const html = renderToStaticMarkup(
+    <PendingExternalCliOutput providerLabel="Claude" output="" />,
+  );
+
+  assert.ok(html.includes('Claude transcript'));
+});

--- a/src/components/main-content/view/subcomponents/PendingExternalCliOutput.tsx
+++ b/src/components/main-content/view/subcomponents/PendingExternalCliOutput.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+type PendingExternalCliOutputProps = {
+  providerLabel: string;
+  output: string;
+};
+
+export default function PendingExternalCliOutput({
+  providerLabel,
+  output,
+}: PendingExternalCliOutputProps) {
+  if (!output) {
+    return (
+      <div className="min-h-0 flex-1 overflow-y-auto px-4">
+        <div className="mx-auto flex h-full max-w-[54.25rem] items-center justify-center text-center text-sm text-muted-foreground">
+          첫 지시를 보내면 {providerLabel} transcript가 생성되어 이 화면에 자동으로 연결됩니다.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-auto bg-black px-4 py-3 text-left">
+      <pre
+        aria-label={`${providerLabel} live terminal output`}
+        className="mx-auto max-w-6xl whitespace-pre-wrap break-words font-mono text-xs leading-relaxed text-zinc-100"
+      >
+        {output}
+      </pre>
+    </div>
+  );
+}

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -113,6 +113,8 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ tmuxName, sessionId, message }),
     }),
+  externalCliSessionOutput: (tmuxName, options = {}) =>
+    authenticatedFetch(`/api/providers/sessions/external/output?${new URLSearchParams({ tmuxName })}`, options),
   // Create a supported local coding-agent tmux session from the unified sessions tab.
   externalCliSessionSpawn: (cli, name, cwd) =>
     authenticatedFetch('/api/providers/sessions/external/spawn', {


### PR DESCRIPTION
## Summary

- add an authenticated, exact-target endpoint for a bounded plain-text tmux pane tail
- poll it only while a local CLI is waiting for its first transcript
- render trust, permission, and other interactive TUI prompts above the existing relay composer

## Root cause

Fresh Codex, Claude, and Cursor sessions could stop at workspace-trust or command-approval prompts, but ChatMux's pending transcript surface only displayed generic guidance. Users could send selections but could not see which selection the CLI requested.

## Safety

- validates the tmux name and verifies that it is currently a supported local CLI session
- uses an exact tmux target
- captures only the last 80 lines
- strips control bytes and caps the response at 32 KiB

## Verification

- external session service tests (28/28)
- pending-output component tests (2/2)
- `npm run typecheck`
- `npm run lint`
- `npm run build`

