### PR TITLE
fix(codex): map fresh sessions on macOS

### DIFF
--- a/server/modules/providers/services/external-cli-sessions.service.ts
+++ b/server/modules/providers/services/external-cli-sessions.service.ts
@@ -415,6 +415,12 @@ function descendants(rootPid: number, children: ReadonlyMap<number, number[]>): 
   return result;
 }
 
+export function selectPrimaryCodexProcessPid(codexPids: readonly number[]): number | null {
+  // `descendants` is breadth-first, so the first match is the CLI process that
+  // owns any native Codex child. Current npm installs commonly expose both.
+  return codexPids[0] ?? null;
+}
+
 function readFreshCodexThreads(minCreatedAtMs: number): FreshCodexThread[] {
   let db: Database.Database | null = null;
   try {
@@ -466,8 +472,9 @@ async function inferFreshCodexThreadIds(args: {
         && !proc.args?.includes(' app-server')
         && !proc.args?.includes('code-mode');
     });
-    if (codexPids.length !== 1) continue;
-    const startedAtMs = await processStartMs(codexPids[0]);
+    const primaryCodexPid = selectPrimaryCodexProcessPid(codexPids);
+    if (primaryCodexPid === null) continue;
+    const startedAtMs = await processStartMs(primaryCodexPid);
     if (startedAtMs !== null) {
       processes.push({ tmuxName: pane.name, cwd: pane.cwd, startedAtMs });
     }

--- a/server/modules/providers/services/external-cli-sessions.service.ts
+++ b/server/modules/providers/services/external-cli-sessions.service.ts
@@ -382,11 +382,22 @@ function runCommand(command: string, cmdArgs: string[], timeoutMs = 4000): Promi
   });
 }
 
+export function parseProcessStartTime(output: string): number | null {
+  const parsed = Date.parse(output.trim());
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 async function processStartMs(pid: number): Promise<number | null> {
   try {
     return (await stat(`/proc/${pid}`)).mtimeMs;
   } catch {
-    return null;
+    try {
+      return parseProcessStartTime(await runCommand('ps', [
+        '-p', String(pid), '-o', 'lstart=',
+      ]));
+    } catch {
+      return null;
+    }
   }
 }
 

--- a/server/modules/providers/services/external-cli-sessions.service.ts
+++ b/server/modules/providers/services/external-cli-sessions.service.ts
@@ -242,6 +242,14 @@ function processCliKind(proc: Pick<ProcessTreeEntry, 'comm' | 'args'>): External
   if (executable('ssh')) return 'ssh';
   return null;
 }
+
+export function isCodexRuntimeProcess(
+  proc: Pick<ProcessTreeEntry, 'comm' | 'args'>,
+): boolean {
+  return processCliKind(proc) === 'codex'
+    && !proc.args?.includes(' app-server')
+    && !proc.args?.includes('code-mode');
+}
 /**
  * Foreground-aware process classification. A GJC descendant excludes the tmux
  * session from this lane. Other agents must own the pane foreground (or carry
@@ -468,9 +476,7 @@ async function inferFreshCodexThreadIds(args: {
     if (!unresolvedNames.has(pane.name) || !pane.cwd) continue;
     const codexPids = descendants(pane.pid, children).filter((pid) => {
       const proc = procByPid.get(pid);
-      return proc?.comm === 'codex'
-        && !proc.args?.includes(' app-server')
-        && !proc.args?.includes('code-mode');
+      return proc ? isCodexRuntimeProcess(proc) : false;
     });
     const primaryCodexPid = selectPrimaryCodexProcessPid(codexPids);
     if (primaryCodexPid === null) continue;

--- a/server/modules/providers/tests/external-cli-sessions.service.test.ts
+++ b/server/modules/providers/tests/external-cli-sessions.service.test.ts
@@ -8,6 +8,7 @@ import {
   classifyExternalSessions,
   extractCodexResumeThreadId,
   extractExternalResumeSessionId,
+  isCodexRuntimeProcess,
   parseClaudeRuntimeSession,
   parseExternalPanes,
   parseProcessStartTime,
@@ -24,6 +25,14 @@ test('parseProcessStartTime reads the portable ps lstart format used on macOS', 
 });
 
 test('Codex process selection accepts the npm wrapper and native child pair', () => {
+  assert.equal(isCodexRuntimeProcess({
+    comm: 'node',
+    args: 'node /opt/homebrew/bin/codex',
+  }), true);
+  assert.equal(isCodexRuntimeProcess({
+    comm: '/opt/homebrew/li',
+    args: '/opt/homebrew/lib/node_modules/@openai/codex/vendor/aarch64-apple-darwin/bin/codex',
+  }), true);
   assert.equal(selectPrimaryCodexProcessPid([89009, 89076]), 89009);
   assert.equal(selectPrimaryCodexProcessPid([]), null);
 });

--- a/server/modules/providers/tests/external-cli-sessions.service.test.ts
+++ b/server/modules/providers/tests/external-cli-sessions.service.test.ts
@@ -12,6 +12,7 @@ import {
   parseExternalPanes,
   parseProcessStartTime,
   parsePsTree,
+  selectPrimaryCodexProcessPid,
 } from '@/modules/providers/services/external-cli-sessions.service.js';
 
 test('parseProcessStartTime reads the portable ps lstart format used on macOS', () => {
@@ -21,6 +22,12 @@ test('parseProcessStartTime reads the portable ps lstart format used on macOS', 
   );
   assert.equal(parseProcessStartTime('not a process time'), null);
 });
+
+test('Codex process selection accepts the npm wrapper and native child pair', () => {
+  assert.equal(selectPrimaryCodexProcessPid([89009, 89076]), 89009);
+  assert.equal(selectPrimaryCodexProcessPid([]), null);
+});
+
 test('parseExternalPanes splits session_name<TAB>pane_pid<TAB>pane_current_command', () => {
   const out = parseExternalPanes('patina\t113501\tclaude\ntest\t360992\tnode\n\nbad-line\n');
   assert.deepEqual(out, [

--- a/server/modules/providers/tests/external-cli-sessions.service.test.ts
+++ b/server/modules/providers/tests/external-cli-sessions.service.test.ts
@@ -10,9 +10,17 @@ import {
   extractExternalResumeSessionId,
   parseClaudeRuntimeSession,
   parseExternalPanes,
+  parseProcessStartTime,
   parsePsTree,
 } from '@/modules/providers/services/external-cli-sessions.service.js';
 
+test('parseProcessStartTime reads the portable ps lstart format used on macOS', () => {
+  assert.equal(
+    parseProcessStartTime('Wed Jul 22 23:16:35 2026\n'),
+    new Date('2026-07-22T23:16:35').getTime(),
+  );
+  assert.equal(parseProcessStartTime('not a process time'), null);
+});
 test('parseExternalPanes splits session_name<TAB>pane_pid<TAB>pane_current_command', () => {
   const out = parseExternalPanes('patina\t113501\tclaude\ntest\t360992\tnode\n\nbad-line\n');
   assert.deepEqual(out, [


### PR DESCRIPTION
## Summary

- keep the Linux `/proc` process-start lookup
- fall back to portable `ps -o lstart=` parsing when `/proc` is unavailable
- restore fresh Codex thread-to-tmux matching on macOS

## Root cause

Fresh thread inference requires the Codex process start time, but ChatMux only read `/proc/<pid>`. macOS has no `/proc`, so every fresh Codex tmux remained an unindexed pending row even after its rollout and DB session were created. This was reproduced on two separate QA tmux sessions.

## Verification

- external session service tests (including macOS `lstart` regression)
- actual Codex 0.144.6 T1 transcript creation observed in the isolated QA DB
- `npm run typecheck`
- `npm run lint`
- `npm run build`

