### PR TITLE
fix(codex): align SDK with supported models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@codemirror/theme-one-dark": "^6.1.2",
         "@iarna/toml": "^2.2.5",
         "@octokit/rest": "^22.0.0",
-        "@openai/codex-sdk": "^0.141.0",
+        "@openai/codex-sdk": "0.144.6",
         "@replit/codemirror-minimap": "^0.5.2",
         "@tailwindcss/typography": "^0.5.16",
         "@uiw/react-codemirror": "^4.23.13",
@@ -4316,9 +4316,9 @@
       }
     },
     "node_modules/@openai/codex": {
-      "version": "0.141.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0.tgz",
-      "integrity": "sha512-ACpAn/Z7JwBg431040zKOLpBtNdP024ixqwC/R2YM5tPrLG0wfSmrd/AVHPUExt6hOO6fEHwxM/ixAyzFleQXw==",
+      "version": "0.144.6",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6.tgz",
+      "integrity": "sha512-wk+2CWiBNXiJLBoN2D08N9RceWkSBnlgk5g2K1a4CXrP/C0gdlHyRUG7RFzm9y41DCK/7tvCct233JVxyFmznw==",
       "license": "Apache-2.0",
       "bin": {
         "codex": "bin/codex.js"
@@ -4327,19 +4327,19 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.141.0-darwin-arm64",
-        "@openai/codex-darwin-x64": "npm:@openai/codex@0.141.0-darwin-x64",
-        "@openai/codex-linux-arm64": "npm:@openai/codex@0.141.0-linux-arm64",
-        "@openai/codex-linux-x64": "npm:@openai/codex@0.141.0-linux-x64",
-        "@openai/codex-win32-arm64": "npm:@openai/codex@0.141.0-win32-arm64",
-        "@openai/codex-win32-x64": "npm:@openai/codex@0.141.0-win32-x64"
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.144.6-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.144.6-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.144.6-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.144.6-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.144.6-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.144.6-win32-x64"
       }
     },
     "node_modules/@openai/codex-darwin-arm64": {
       "name": "@openai/codex",
-      "version": "0.141.0-darwin-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-darwin-arm64.tgz",
-      "integrity": "sha512-BuroZvQQLJYLfQEG7MKMdxHtggDDlxeJCTot//MwEnbW8ga7P319EPos/FyOK9r/gh+E/KGxk+YAzEoHZPRGEg==",
+      "version": "0.144.6-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-darwin-arm64.tgz",
+      "integrity": "sha512-6zgvh70MzBNSeT17HEhSOrmmGGZGAKzSC7x6JAq+edkJkdPYA9P0I1tG7aJ49GlBkBxuC+MKBH1qm6+2Cghcww==",
       "cpu": [
         "arm64"
       ],
@@ -4354,9 +4354,9 @@
     },
     "node_modules/@openai/codex-darwin-x64": {
       "name": "@openai/codex",
-      "version": "0.141.0-darwin-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-darwin-x64.tgz",
-      "integrity": "sha512-kDP+egfjp3cuao1r9AdD8/skBxM7saT007VE82DB9mRUcqgKaxYHoPaHmKhlYOlFwPam0zsD6ORT6GJJhvGAKg==",
+      "version": "0.144.6-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-darwin-x64.tgz",
+      "integrity": "sha512-THRyPG0zSU6M8NQAge1LHEHsJDnoH4BpKsfJHB/qe3Fm+Wf6zqAmWJFlOKzBm27m0K2Hq3za4Ac2I5p5i4yp/A==",
       "cpu": [
         "x64"
       ],
@@ -4371,9 +4371,9 @@
     },
     "node_modules/@openai/codex-linux-arm64": {
       "name": "@openai/codex",
-      "version": "0.141.0-linux-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-linux-arm64.tgz",
-      "integrity": "sha512-jXAOSjMqAUUgfMo9ciAkioJKKAYDwOE40bLx4/2jR7Tfu4u9409X5fQlLuNLMgnlfuzUEk/UiibQE62a70bQaw==",
+      "version": "0.144.6-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-linux-arm64.tgz",
+      "integrity": "sha512-PGiLXMN+2IQRkf7tOLi64dMInjU1pRLbz0Rwfj/yt2Y97SZQqAjFQoi2wmswmqtqMDnfwCPTC1DRXVQkvU6T6Q==",
       "cpu": [
         "arm64"
       ],
@@ -4388,9 +4388,9 @@
     },
     "node_modules/@openai/codex-linux-x64": {
       "name": "@openai/codex",
-      "version": "0.141.0-linux-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-linux-x64.tgz",
-      "integrity": "sha512-q3xv538DT/Sb8rRq8apdKgrgA/isqs1fDfE5JhRDMmojYFA3zwDldlmdWWGdS3APtjf5UrDsqljSE9JHxnlWNA==",
+      "version": "0.144.6-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-linux-x64.tgz",
+      "integrity": "sha512-4E7EnzCg0OnBxCyYnwJ+qnZwWHYe0YScr5ucKWbngE9u4+0XrpWELqq2Kn9jl5GZK8MDjU7PrJwFIwusHOHjuw==",
       "cpu": [
         "x64"
       ],
@@ -4404,12 +4404,12 @@
       }
     },
     "node_modules/@openai/codex-sdk": {
-      "version": "0.141.0",
-      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.141.0.tgz",
-      "integrity": "sha512-VCLsSJGSoOHcVAC/2+NrhtiBiCP/XF8YmCzzGocm8qNkAPN3a/+CcrvwUmvNSH53dU3TVi5Hp5zddov16BXLHw==",
+      "version": "0.144.6",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.144.6.tgz",
+      "integrity": "sha512-jFgXHjFq2//PTfJa8CySqhUilRBPVmCLuQoH5F+iJ2x4owZwPlnqmIbCkWIJJ6IxDuQdjf3ewg0LaDtc3i6h9Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@openai/codex": "0.141.0"
+        "@openai/codex": "0.144.6"
       },
       "engines": {
         "node": ">=18"
@@ -4417,9 +4417,9 @@
     },
     "node_modules/@openai/codex-win32-arm64": {
       "name": "@openai/codex",
-      "version": "0.141.0-win32-arm64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-win32-arm64.tgz",
-      "integrity": "sha512-87X5tvH1RmKQOHbgO5Cv+S0aXJ+saHTSSHEasJjbB1FtUoLbao29NTnkpkB2dAV3xtUJ/dmE8NgvbFEeWuMqUQ==",
+      "version": "0.144.6-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-win32-arm64.tgz",
+      "integrity": "sha512-SpMjXJLW43JzMP0K62mVcYfmFcpk0BK4AOgYmWSfyZHs3iRtHMd0UYw7605n/9lwkT2EqbwQLT2omZFeKJFzwA==",
       "cpu": [
         "arm64"
       ],
@@ -4434,9 +4434,9 @@
     },
     "node_modules/@openai/codex-win32-x64": {
       "name": "@openai/codex",
-      "version": "0.141.0-win32-x64",
-      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.141.0-win32-x64.tgz",
-      "integrity": "sha512-4gur4DgFQIOc+DopNOI90IpNA66qBIyc5Lb5QYy66OOCXOvXpbOCpScuEFmT1xpaTzNUYhlRGA2NFWqSHQrKUQ==",
+      "version": "0.144.6-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.144.6-win32-x64.tgz",
+      "integrity": "sha512-dN39VnjEthKz5io1RNWwZDtErdSn07nW3pGUgvlA6DMxgm/nuGaIAZO/sG/Hgxq/x5j9HteAENfrFgVkpZ0lFg==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
     "@codemirror/theme-one-dark": "^6.1.2",
     "@iarna/toml": "^2.2.5",
     "@octokit/rest": "^22.0.0",
-    "@openai/codex-sdk": "^0.141.0",
+    "@openai/codex-sdk": "0.144.6",
     "@replit/codemirror-minimap": "^0.5.2",
     "@tailwindcss/typography": "^0.5.16",
     "@uiw/react-codemirror": "^4.23.13",

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -7,6 +8,17 @@ import test from 'node:test';
 import { closeConnection, initializeDatabase, sessionsDb } from '@/modules/database/index.js';
 import { CodexSessionSynchronizer } from '@/modules/providers/list/codex/codex-session-synchronizer.provider.js';
 import { CodexSessionsProvider } from '@/modules/providers/list/codex/codex-sessions.provider.js';
+
+test('Codex SDK stays pinned to the CLI version required by synchronized models', () => {
+  const packageJson = JSON.parse(readFileSync(path.join(process.cwd(), 'package.json'), 'utf8'));
+  const packageLock = JSON.parse(readFileSync(path.join(process.cwd(), 'package-lock.json'), 'utf8'));
+  const sdkVersion = packageLock.packages['node_modules/@openai/codex-sdk'].version;
+  const cliVersion = packageLock.packages['node_modules/@openai/codex'].version;
+
+  assert.equal(packageJson.dependencies['@openai/codex-sdk'], '0.144.6');
+  assert.equal(sdkVersion, '0.144.6');
+  assert.equal(cliVersion, sdkVersion);
+});
 
 const patchHomeDir = (nextHomeDir: string) => {
   const original = os.homedir;


### PR DESCRIPTION
## Summary

- pin `@openai/codex-sdk` and its bundled CLI to 0.144.6
- keep ChatMux history/resume turns compatible with models recorded by current Codex CLI sessions
- add a regression guard that prevents SDK and bundled CLI versions from drifting

## Reproduction

1. Create a Codex 0.144.6 tmux session using `gpt-5.6-sol`.
2. Let ChatMux synchronize the transcript, terminate the tmux session, and reopen it from history.
3. Send a follow-up prompt.
4. The previous 0.141.0 SDK fails with: `The 'gpt-5.6-sol' model requires a newer version of Codex`.

## Verification

- Codex provider tests: 5/5
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- actual browser E2E follow-up on the synchronized Codex transcript
