### PR TITLE
fix(relay): include the approval body in interactive prompt identity

### DIFF
--- a/server/modules/providers/services/tmux-interactive-prompt.service.ts
+++ b/server/modules/providers/services/tmux-interactive-prompt.service.ts
@@ -112,12 +112,14 @@ function normalizeText(value: string): string {
 
 function promptId(input: Omit<TmuxInteractivePrompt, 'id' | 'cancelNumber'>, provider: PromptProvider): string {
   return createHash('sha256')
-    .update('chatmux:tmux-interactive-prompt:v1\0')
+    .update('chatmux:tmux-interactive-prompt:v2\0')
     .update(provider)
     .update('\0')
     .update(input.kind)
     .update('\0')
     .update(normalizeText(input.question))
+    .update('\0')
+    .update(normalizeText(input.body ?? ''))
     .update('\0')
     .update(input.options.map((option) => normalizeText(option.label)).join('\0'))
     .update(input.multiSelect ? '\0multi' : '\0single')

--- a/server/modules/providers/tests/tmux-interactive-prompt.service.test.ts
+++ b/server/modules/providers/tests/tmux-interactive-prompt.service.test.ts
@@ -288,6 +288,56 @@ up/down navigate  enter select  esc cancel
   assert.equal(first.id, second?.id);
 });
 
+const codexApprovalScreen = (command: string) => `
+Would you like to run the following command?
+
+Environment: local
+$ ${command}
+
+› 1. Yes, proceed (y)
+  2. No, and tell Codex what to do differently (esc)
+
+Press enter to confirm or esc to cancel
+`;
+
+test('prompt id changes when the approval body changes', () => {
+  const first = parseTmuxInteractivePrompt('codex', codexApprovalScreen('curl -I https://example.com'));
+  const second = parseTmuxInteractivePrompt('codex', codexApprovalScreen('git push --force origin main'));
+  assert.ok(first);
+  assert.ok(second);
+  assert.notEqual(first.id, second.id);
+});
+
+test('answers are rejected as stale when a same-shaped prompt with a different body replaces the original', async () => {
+  const original = parseTmuxInteractivePrompt('codex', codexApprovalScreen('curl -I https://example.com'));
+  assert.ok(original);
+  const replacement = codexApprovalScreen('git push --force origin main');
+  const calls: string[][] = [];
+  const run: TmuxRunner = async (args) => {
+    calls.push(args);
+    if (args.includes('capture-pane')) return { code: 0, output: replacement };
+    if (args.includes('display-message')) return { code: 0, output: '$7\t@8\t%9\n' };
+    return { code: 0, output: '' };
+  };
+  const target = createVerifiedTmuxActionTarget(
+    {
+      socketPath: '/tmp/chatmux-interactive-test.sock',
+      sessionId: '$7',
+      windowId: '@8',
+      paneId: '%9',
+    },
+    { pid: 42, startedAtMs: 1234 },
+    'codex',
+    null,
+  );
+
+  await assert.rejects(
+    answerTmuxInteractivePrompt(target, original.id, [1], run),
+    (error: { code?: string }) => error.code === 'TMUX_INTERACTIVE_PROMPT_STALE',
+  );
+  assert.equal(calls.some((args) => args.includes('send-keys')), false);
+});
+
 test('Claude multi-select answers are rejected without injecting keys until the toggle sequence is verified', async () => {
   const screen = `
 ☐ Checks


### PR DESCRIPTION
## Problem
`promptId` hashes provider, kind, question, option labels, and the multi-select flag — but omits `body`, which is where Codex/OMP/Claude approval prompts carry the actual command or plan being approved. Approval prompts reuse identical headers and options ("Would you like to run the following command?" / "1. Yes / 2. No"), so two prompts that differ only in the command they approve produce the **same prompt ID**.

If prompt A is replaced by prompt B (same shape, different command) between the user seeing the card and the answer arriving, `assertPromptId` re-parses B, computes the same ID, and the approval intended for A is delivered to B — i.e. **the wrong command gets approved**. The stale-prompt safeguard (409 `TMUX_INTERACTIVE_PROMPT_STALE`) exists but is blind to body-only changes.

Found by full-codebase review after v1.7.0 (highest-priority finding).

## Fix
- Include `normalizeText(input.body ?? '')` in the `promptId` hash; bump the hash domain tag `v1` → `v2`.
- Body-only replacement now changes the ID, so the existing `assertPromptId` check rejects the answer with 409 as designed. Whitespace/rewrap differences are absorbed by `normalizeText`; cursor/checked-state changes still leave the ID stable (existing test unchanged and passing).

## Tests
- New: same-shaped approval prompts with different bodies produce different IDs.
- New: answering with a stale ID while the pane shows a different-body prompt → 409 `TMUX_INTERACTIVE_PROMPT_STALE`, no `send-keys` injected.
- `tmux-interactive-prompt.service.test.ts` 10/10, `provider-routes-contract.test.ts` 20/20 pass.
- No consumer hardcodes prompt IDs (verified — all pass the ID opaquely; routes only validate the 32-hex format).