### PR TITLE
feat: tmux 에이전트의 RUN → INPUT 알림 지원

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,4 +54,5 @@ HOST=127.0.0.1
 VITE_CONTEXT_WINDOW=160000
 CONTEXT_WINDOW=160000
 
-
+# Contact URI included in Web Push VAPID authentication. Must use https: or mailto:.
+VAPID_SUBJECT=https://github.com/devswha/chatmux

--- a/server/index.js
+++ b/server/index.js
@@ -80,7 +80,12 @@ import providerRoutes from './modules/providers/provider.routes.js';
 import { sessionsService } from './modules/providers/services/sessions.service.js';
 import { assetsRoutes } from './modules/assets/index.js';
 import { initializeDatabase, projectsDb, sessionsDb, userDb } from './modules/database/index.js';
-import { startCompletionOutboxDispatcher, startExternalTurnMonitor, startLiveTurnMonitor } from './modules/notifications/index.js';
+import {
+    notifyTmuxInputRequiredIfWatched,
+    startCompletionOutboxDispatcher,
+    startExternalTurnMonitor,
+    startLiveTurnMonitor,
+} from './modules/notifications/index.js';
 import { filesRoutes } from './modules/files/index.js';
 import { configureWebPush } from './services/vapid-keys.js';
 import { authenticateToken, authenticateWebSocket, AUTH_MODE } from './middleware/auth.js';
@@ -130,7 +135,9 @@ const server = http.createServer(app);
 // The collector is inert until the first authenticated discovery subscription.
 const discoveryCollector = createDiscoveryCollector();
 app.locals.discoveryCollector = discoveryCollector;
-const tmuxOutputActivityMonitor = createTmuxOutputActivityMonitor(discoveryCollector);
+const tmuxOutputActivityMonitor = createTmuxOutputActivityMonitor(discoveryCollector, {
+    onInputRequired: notifyTmuxInputRequiredIfWatched,
+});
 tmuxOutputActivityMonitor.start();
 const stopTranscriptDiscoveryRefresh = onTranscriptChanged(() => {
     discoveryCollector.forceRefresh();

--- a/server/index.js
+++ b/server/index.js
@@ -136,7 +136,9 @@ const server = http.createServer(app);
 const discoveryCollector = createDiscoveryCollector();
 app.locals.discoveryCollector = discoveryCollector;
 const tmuxOutputActivityMonitor = createTmuxOutputActivityMonitor(discoveryCollector, {
-    onInputRequired: notifyTmuxInputRequiredIfWatched,
+    onInputRequired: process.env.CHATMUX_LIVE_NOTIFY === '0'
+        ? undefined
+        : notifyTmuxInputRequiredIfWatched,
 });
 tmuxOutputActivityMonitor.start();
 const stopTranscriptDiscoveryRefresh = onTranscriptChanged(() => {

--- a/server/modules/notifications/index.ts
+++ b/server/modules/notifications/index.ts
@@ -4,6 +4,7 @@ export {
   createNotificationEvent,
   notifyUserIfEnabled,
   notifyRunFailed,
+  notifyInputRequired,
   notifyRunStopped,
   notifyLiveTurnEnded,
   createCompletionDecision,
@@ -13,6 +14,7 @@ export {
   createExternalTurnMonitor,
   startExternalTurnMonitor,
 } from '@/modules/notifications/services/external-turn-monitor.service.js';
+export { notifyTmuxInputRequiredIfWatched } from '@/modules/notifications/services/tmux-input-notification.service.js';
 export {
   createRelayKeyDiagnosticEmitter,
   emitRelayKeyDiagnostic,

--- a/server/modules/notifications/services/external-turn-monitor.service.ts
+++ b/server/modules/notifications/services/external-turn-monitor.service.ts
@@ -14,6 +14,7 @@ import {
   type ExternalCliSession,
   type ExternalCliSessionsDetailedResult,
   type ExternalSessionActivityResolutionResult,
+  observeTmuxInputActivity,
 } from '@/modules/providers/index.js';
 
 import { wakeCompletionOutboxDispatcher } from './completion-outbox-dispatcher.service.js';
@@ -103,14 +104,14 @@ type MonitorDeps = {
   getDetailed: () => Promise<ExternalCliSessionsDetailedResult>;
   resolve: (session: ExternalCliSession) => Promise<ExternalSessionActivityResolutionResult>;
   getUserId: () => number | null;
-    resolveTargets?: ResolveTargets;
-    observeGeneration?: ObserveGeneration;
-    createTerminalDecision?: CreateTerminalDecision;
-    listGenerationTargets?: ListGenerationTargets;
-    touchObservedGenerations?: TouchObservedGenerations;
-    listStaleGenerationCandidates?: ListStaleGenerationCandidates;
-    pruneStaleGenerationCandidates?: PruneStaleGenerationCandidates;
-    generationCount?: GenerationCount;
+  resolveTargets?: ResolveTargets;
+  observeGeneration?: ObserveGeneration;
+  createTerminalDecision?: CreateTerminalDecision;
+  listGenerationTargets?: ListGenerationTargets;
+  touchObservedGenerations?: TouchObservedGenerations;
+  listStaleGenerationCandidates?: ListStaleGenerationCandidates;
+  pruneStaleGenerationCandidates?: PruneStaleGenerationCandidates;
+  generationCount?: GenerationCount;
   wake?: () => void;
   diagnostic?: (event: ExternalTurnMonitorDiagnostic) => void;
   notifyActionRequired?: (args: {
@@ -118,7 +119,8 @@ type MonitorDeps = {
     provider: string;
     sessionId: string;
     tmuxName: string;
-  }) => unknown;
+    occurrenceKey: string;
+  }) => void;
   now?: () => number;
   /** @deprecated Durable outbox decisions replace callback notifications. */
   notify?: (args: {
@@ -369,6 +371,14 @@ export function createExternalTurnMonitor(deps: MonitorDeps) {
         }
         if (activity === 'running') {
           lastActivities.set(identityKey, 'running');
+          if (session.agentPid !== undefined && session.startedAtMs !== undefined) {
+            observeTmuxInputActivity({
+              provider: session.kind,
+              tmux: session.tmux,
+              process: { pid: session.agentPid, startedAtMs: session.startedAtMs },
+              providerSessionId: session.providerSessionId ?? null,
+            }, 'transcript', false);
+          }
           try {
             const transition = observeGeneration(resolution.generationTargetId, cursor, 'running');
             if (!transition.replay && transition.sequence !== null) {
@@ -405,16 +415,27 @@ export function createExternalTurnMonitor(deps: MonitorDeps) {
           && previousActivity === 'running'
           && resolution.target.watched
         ) {
-          try {
-            await deps.notifyActionRequired?.({
-              userId,
+          const occurrenceKey = session.agentPid === undefined || session.startedAtMs === undefined
+            ? null
+            : observeTmuxInputActivity({
               provider: session.kind,
-              sessionId: resolution.appSessionId ?? resolution.target.alias,
-              tmuxName: session.tmuxName,
-            });
-          } catch {
-            // Action notifications are best-effort and must never interrupt
-            // durable completion state transitions.
+              tmux: session.tmux,
+              process: { pid: session.agentPid, startedAtMs: session.startedAtMs },
+              providerSessionId: session.providerSessionId ?? null,
+            }, 'transcript', true);
+          if (occurrenceKey) {
+            try {
+              await deps.notifyActionRequired?.({
+                userId,
+                provider: session.kind,
+                sessionId: resolution.appSessionId ?? resolution.target.alias,
+                tmuxName: session.tmuxName,
+                occurrenceKey,
+              });
+            } catch {
+              // Action notifications are best-effort and must never interrupt
+              // durable completion state transitions.
+            }
           }
         }
         lastActivities.set(identityKey, activity);
@@ -475,9 +496,14 @@ export function startExternalTurnMonitor(
         return null;
       }
     },
-    diagnostic: createRateLimitedProductionDiagnosticSink(),
-    notifyActionRequired: ({ userId, provider, sessionId, tmuxName }) => {
-      notifyInputRequired({ userId, provider, sessionId, sessionName: tmuxName });
+    notifyActionRequired: ({ userId, provider, sessionId, tmuxName, occurrenceKey }) => {
+      notifyInputRequired({
+        userId,
+        provider,
+        sessionId,
+        sessionName: tmuxName,
+        occurrenceKey,
+      });
     },
   });
   return startEventDrivenMonitorLoop({

--- a/server/modules/notifications/services/external-turn-monitor.service.ts
+++ b/server/modules/notifications/services/external-turn-monitor.service.ts
@@ -17,6 +17,7 @@ import {
 } from '@/modules/providers/index.js';
 
 import { wakeCompletionOutboxDispatcher } from './completion-outbox-dispatcher.service.js';
+import { notifyInputRequired } from './notification-orchestrator.service.js';
 import {
   startEventDrivenMonitorLoop,
   TURN_MONITOR_FALLBACK_MS,
@@ -112,6 +113,12 @@ type MonitorDeps = {
     generationCount?: GenerationCount;
   wake?: () => void;
   diagnostic?: (event: ExternalTurnMonitorDiagnostic) => void;
+  notifyActionRequired?: (args: {
+    userId: number;
+    provider: string;
+    sessionId: string;
+    tmuxName: string;
+  }) => unknown;
   now?: () => number;
   /** @deprecated Durable outbox decisions replace callback notifications. */
   notify?: (args: {
@@ -205,6 +212,7 @@ export function createExternalTurnMonitor(deps: MonitorDeps) {
     nextReadAt: number;
     providerBinding: string | null;
   }>();
+  const lastActivities = new Map<string, MonitorResolvedActivity['activity']>();
   const now = deps.now ?? Date.now;
 
   const emitDiagnostic = (detail: Omit<ExternalTurnMonitorDiagnostic, 'count'>): void => {
@@ -349,7 +357,9 @@ export function createExternalTurnMonitor(deps: MonitorDeps) {
         const outcome = result.terminalOutcome;
         const cursor = result.evidenceCursor;
         const activity = result.activity;
+        const previousActivity = lastActivities.get(identityKey);
         if (result.transcriptEnded) {
+          lastActivities.set(identityKey, 'unknown');
           try {
             observeGeneration(resolution.generationTargetId, cursor, 'unknown');
           } catch {
@@ -358,6 +368,7 @@ export function createExternalTurnMonitor(deps: MonitorDeps) {
           continue;
         }
         if (activity === 'running') {
+          lastActivities.set(identityKey, 'running');
           try {
             const transition = observeGeneration(resolution.generationTargetId, cursor, 'running');
             if (!transition.replay && transition.sequence !== null) {
@@ -369,6 +380,7 @@ export function createExternalTurnMonitor(deps: MonitorDeps) {
           continue;
         }
         if (outcome === 'reply_ready') {
+          lastActivities.set(identityKey, activity);
           try {
             const decision = createTerminalDecision({
               generationTargetId: resolution.generationTargetId,
@@ -388,6 +400,24 @@ export function createExternalTurnMonitor(deps: MonitorDeps) {
           }
           continue;
         }
+        if (
+          activity === 'asking_user'
+          && previousActivity === 'running'
+          && resolution.target.watched
+        ) {
+          try {
+            await deps.notifyActionRequired?.({
+              userId,
+              provider: session.kind,
+              sessionId: resolution.appSessionId ?? resolution.target.alias,
+              tmuxName: session.tmuxName,
+            });
+          } catch {
+            // Action notifications are best-effort and must never interrupt
+            // durable completion state transitions.
+          }
+        }
+        lastActivities.set(identityKey, activity);
         try {
           observeGeneration(
             resolution.generationTargetId,
@@ -399,6 +429,9 @@ export function createExternalTurnMonitor(deps: MonitorDeps) {
         }
       }
       if (completeScan && duplicateSessionIdentities.size === 0 && duplicateResolutionIdentities.size === 0) {
+        for (const identityKey of lastActivities.keys()) {
+          if (!sessionsByIdentity.has(identityKey)) lastActivities.delete(identityKey);
+        }
         try {
           const cutoff = now() - (30 * 24 * 60 * 60 * 1_000);
           const completeGenerationIds = new Set(completeObservations.map(({ generationTargetId }) => generationTargetId));
@@ -443,6 +476,9 @@ export function startExternalTurnMonitor(
       }
     },
     diagnostic: createRateLimitedProductionDiagnosticSink(),
+    notifyActionRequired: ({ userId, provider, sessionId, tmuxName }) => {
+      notifyInputRequired({ userId, provider, sessionId, sessionName: tmuxName });
+    },
   });
   return startEventDrivenMonitorLoop({
     tick: monitor.tick,

--- a/server/modules/notifications/services/live-turn-monitor.service.ts
+++ b/server/modules/notifications/services/live-turn-monitor.service.ts
@@ -16,6 +16,7 @@ import {
   IDLE_GJC_ID_PREFIX,
   onTranscriptChanged,
   type LiveGjcSessionsDetailedResult,
+  observeTmuxInputActivity,
 } from '@/modules/providers/index.js';
 
 import {
@@ -102,6 +103,7 @@ type MonitorDeps = {
     userId: number;
     sessionId: string;
     tmuxName: string | null;
+    occurrenceKey: string;
   }) => unknown;
   getUserId: () => number | null;
   readDelta?: (path: string, start: number, end: number) => Promise<string | Buffer>;
@@ -193,10 +195,15 @@ export function createLiveTurnMonitor(deps: MonitorDeps) {
               ));
             if (asksForInput) {
               try {
+                const fallbackOccurrenceKey = `gjc:${sessionId}:${byteEnd}:${createHash('sha256').update(line).digest('hex')}`;
                 await deps.notifyActionRequired?.({
                   userId,
                   sessionId,
                   tmuxName: cursor.tmuxName,
+                  occurrenceKey: observeTmuxInputActivity({
+                    provider: 'gjc',
+                    providerSessionId: sessionId,
+                  }, 'transcript', true) ?? fallbackOccurrenceKey,
                 });
               } catch {
                 cursor.offset = lineStart;
@@ -335,7 +342,7 @@ export function startLiveTurnMonitor(
         error: 'GJC turn ended with an error',
       });
     },
-    notifyActionRequired: ({ userId, sessionId, tmuxName }) => {
+    notifyActionRequired: ({ userId, sessionId, tmuxName, occurrenceKey }) => {
       const alias = completionAppAlias({ provider: 'gjc', sessionId });
       const target = completionNotificationTargetsDb.resolveAlias(alias);
       if (!target || !completionNotificationTargetsDb.getWatch(userId, target.id)) return;
@@ -344,6 +351,7 @@ export function startLiveTurnMonitor(
         provider: 'gjc',
         sessionId,
         sessionName: tmuxName,
+        occurrenceKey,
       });
     },
     getUserId: () => {

--- a/server/modules/notifications/services/live-turn-monitor.service.ts
+++ b/server/modules/notifications/services/live-turn-monitor.service.ts
@@ -1,9 +1,14 @@
 import { createHash } from 'node:crypto';
 import { open, stat } from 'node:fs/promises';
 
-import { userDb } from '@/modules/database/index.js';
+import {
+  completionAppAlias,
+  completionNotificationTargetsDb,
+  userDb,
+} from '@/modules/database/index.js';
 import {
   createCompletionDecision,
+  notifyInputRequired,
   notifyRunFailed,
 } from '@/modules/notifications/services/notification-orchestrator.service.js';
 import {
@@ -93,6 +98,11 @@ type MonitorDeps = {
     stopReason: LiveTurnEnd;
     occurrenceKey?: string;
   }) => unknown;
+  notifyActionRequired?: (args: {
+    userId: number;
+    sessionId: string;
+    tmuxName: string | null;
+  }) => unknown;
   getUserId: () => number | null;
   readDelta?: (path: string, start: number, end: number) => Promise<string | Buffer>;
   statSize?: (path: string) => Promise<number>;
@@ -161,11 +171,38 @@ export function createLiveTurnMonitor(deps: MonitorDeps) {
         const line = lineBytes.toString('utf8');
         if (line.includes('"stopReason"') && line.includes('"message"')) {
           try {
-            const record = JSON.parse(line) as { type?: unknown; message?: { role?: unknown; stopReason?: unknown } };
-            const { role, stopReason } = record.message ?? {};
+            const record = JSON.parse(line) as {
+              type?: unknown;
+              message?: { role?: unknown; stopReason?: unknown; content?: unknown };
+            };
+            const { role, stopReason, content } = record.message ?? {};
             const terminalStopReason: LiveTurnEnd | null = (
               stopReason === 'stop' || stopReason === 'error'
             ) ? stopReason : null;
+            const asksForInput = record.type === 'message'
+              && role === 'assistant'
+              && stopReason === 'toolUse'
+              && Array.isArray(content)
+              && content.some((item) => (
+                item
+                && typeof item === 'object'
+                && (item as { type?: unknown }).type === 'toolCall'
+                && ['ask', 'AskUserQuestion', 'request_user_input'].includes(
+                  String((item as { name?: unknown }).name ?? ''),
+                )
+              ));
+            if (asksForInput) {
+              try {
+                await deps.notifyActionRequired?.({
+                  userId,
+                  sessionId,
+                  tmuxName: cursor.tmuxName,
+                });
+              } catch {
+                cursor.offset = lineStart;
+                return;
+              }
+            }
             if (record.type === 'message' && role === 'assistant' && terminalStopReason) {
               const notification = {
                 userId,
@@ -296,6 +333,17 @@ export function startLiveTurnMonitor(
         sessionId,
         sessionName: tmuxName,
         error: 'GJC turn ended with an error',
+      });
+    },
+    notifyActionRequired: ({ userId, sessionId, tmuxName }) => {
+      const alias = completionAppAlias({ provider: 'gjc', sessionId });
+      const target = completionNotificationTargetsDb.resolveAlias(alias);
+      if (!target || !completionNotificationTargetsDb.getWatch(userId, target.id)) return;
+      notifyInputRequired({
+        userId,
+        provider: 'gjc',
+        sessionId,
+        sessionName: tmuxName,
       });
     },
     getUserId: () => {

--- a/server/modules/notifications/services/notification-orchestrator.service.js
+++ b/server/modules/notifications/services/notification-orchestrator.service.js
@@ -177,6 +177,7 @@ function buildNotificationPayload(event) {
     'permission.required': normalizedEvent.meta?.toolName
       ? `Action Required: Tool "${normalizedEvent.meta.toolName}" needs approval`
       : 'Action Required: A tool needs your approval',
+    'input.required': 'Input required — the tmux session is waiting for you',
     'run.stopped': normalizedEvent.meta?.stopReason || 'Run Stopped: The run has stopped',
     'run.failed': normalizedEvent.meta?.error ? `Run Failed: ${normalizedEvent.meta.error}` : 'Run Failed: The run encountered an error',
     'live.turn_end': normalizedEvent.meta?.stopReason === 'error'
@@ -366,6 +367,29 @@ function notifyRunFailed({ userId, provider, sessionId = null, error, sessionNam
 }
 
 /**
+ * A tmux-driven agent has stopped running and is waiting for a choice,
+ * approval, or direct answer. Per-session watch policy is checked by the
+ * producer because external generations and app sessions use different
+ * durable target identities.
+ *
+ * @param {{ userId: number, provider: string, sessionId?: string | null, sessionName?: string | null }} args
+ */
+function notifyInputRequired({ userId, provider, sessionId = null, sessionName = null }) {
+  notifyUserIfEnabled({
+    userId,
+    event: createNotificationEvent({
+      provider,
+      sessionId,
+      kind: 'action_required',
+      code: 'input.required',
+      meta: { sessionName },
+      severity: 'warning',
+      requiresUserAction: true,
+    }),
+  });
+}
+
+/**
  * Turn completion of a tmux-driven session. The monitor must provide its
  * durable generation occurrence key; no session-based fallback is permitted.
  *
@@ -404,6 +428,7 @@ export {
   notifyUserIfEnabled,
   notifyRunStopped,
   notifyRunFailed,
+  notifyInputRequired,
   notifyLiveTurnEnded,
   createCompletionDecision,
 };

--- a/server/modules/notifications/services/notification-orchestrator.service.js
+++ b/server/modules/notifications/services/notification-orchestrator.service.js
@@ -32,6 +32,7 @@ const PROVIDER_LABELS = {
 
 const recentEventKeys = new Map();
 const DEDUPE_WINDOW_MS = 20000;
+const seenInputOccurrences = new Set();
 
 const cleanupOldEventKeys = () => {
   const now = Date.now();
@@ -50,12 +51,19 @@ function isNotificationEventEnabled(preferences, event) {
 }
 
 function hasDuplicate(event) {
+  if (event.code === 'input.required') {
+    return Boolean(event.inputOccurrenceKey) && seenInputOccurrences.has(event.inputOccurrenceKey);
+  }
   cleanupOldEventKeys();
   const key = event.dedupeKey || `${event.provider}:${event.kind || 'info'}:${event.code || 'generic'}:${event.sessionId || 'none'}`;
   return recentEventKeys.has(key);
 }
 
 function rememberDuplicate(event) {
+  if (event.code === 'input.required') {
+    if (event.inputOccurrenceKey) seenInputOccurrences.add(event.inputOccurrenceKey);
+    return;
+  }
   const key = event.dedupeKey || `${event.provider}:${event.kind || 'info'}:${event.code || 'generic'}:${event.sessionId || 'none'}`;
   recentEventKeys.set(key, Date.now());
 }
@@ -74,7 +82,8 @@ function createNotificationEvent({
   meta = {},
   severity = 'info',
   dedupeKey = null,
-  requiresUserAction = false
+  requiresUserAction = false,
+  inputOccurrenceKey = null,
 }) {
   return {
     provider,
@@ -85,6 +94,7 @@ function createNotificationEvent({
     severity,
     requiresUserAction,
     dedupeKey,
+    inputOccurrenceKey,
     createdAt: new Date().toISOString()
   };
 }
@@ -372,9 +382,15 @@ function notifyRunFailed({ userId, provider, sessionId = null, error, sessionNam
  * producer because external generations and app sessions use different
  * durable target identities.
  *
- * @param {{ userId: number, provider: string, sessionId?: string | null, sessionName?: string | null }} args
+ * @param {{ userId: number, provider: string, sessionId?: string | null, sessionName?: string | null, occurrenceKey?: string | null }} args
  */
-function notifyInputRequired({ userId, provider, sessionId = null, sessionName = null }) {
+function notifyInputRequired({
+  userId,
+  provider,
+  sessionId = null,
+  sessionName = null,
+  occurrenceKey = null,
+}) {
   notifyUserIfEnabled({
     userId,
     event: createNotificationEvent({
@@ -385,6 +401,7 @@ function notifyInputRequired({ userId, provider, sessionId = null, sessionName =
       meta: { sessionName },
       severity: 'warning',
       requiresUserAction: true,
+      inputOccurrenceKey: occurrenceKey,
     }),
   });
 }

--- a/server/modules/notifications/services/tmux-input-notification.service.ts
+++ b/server/modules/notifications/services/tmux-input-notification.service.ts
@@ -1,0 +1,66 @@
+import {
+  completionAppAlias,
+  completionNotificationTargetsDb,
+  userDb,
+} from '@/modules/database/index.js';
+import type {
+  ExternalCliSession,
+  TmuxOutputActivityTarget,
+} from '@/modules/providers/index.js';
+
+import { completionTargetResolver } from './completion-target-resolver.service.js';
+import { notifyInputRequired } from './notification-orchestrator.service.js';
+
+/**
+ * Routes a tmux screen RUN -> INPUT edge through the same durable target used
+ * by the session bell. Transcript monitors may report the same edge; the
+ * notification orchestrator's short dedupe window collapses both producers.
+ */
+export function notifyTmuxInputRequiredIfWatched(target: TmuxOutputActivityTarget): void {
+  let userId: number | null;
+  try {
+    userId = userDb.getFirstUser()?.id ?? null;
+  } catch {
+    return;
+  }
+  if (userId == null) return;
+
+  if (target.kind === 'gjc') {
+    if (!target.providerSessionId) return;
+    const alias = completionAppAlias({
+      provider: 'gjc',
+      sessionId: target.providerSessionId,
+    });
+    const completionTarget = completionNotificationTargetsDb.resolveAlias(alias);
+    if (!completionTarget || !completionNotificationTargetsDb.getWatch(userId, completionTarget.id)) return;
+    notifyInputRequired({
+      userId,
+      provider: 'gjc',
+      sessionId: target.providerSessionId,
+      sessionName: target.tmuxName,
+    });
+    return;
+  }
+
+  const session: ExternalCliSession = {
+    tmuxName: target.tmuxName,
+    tmux: target.tmux,
+    kind: target.kind,
+    agentPid: target.process.pid,
+    startedAtMs: target.process.startedAtMs,
+    ...(target.providerSessionId ? { providerSessionId: target.providerSessionId } : {}),
+  };
+  let resolution;
+  try {
+    [resolution] = completionTargetResolver.resolveDetailedScan({ ok: true, sessions: [session] }, userId);
+  } catch {
+    return;
+  }
+  if (!resolution?.target.watched) return;
+  notifyInputRequired({
+    userId,
+    provider: target.kind,
+    sessionId: resolution.appSessionId ?? resolution.target.alias,
+    sessionName: target.tmuxName,
+  });
+}

--- a/server/modules/notifications/services/tmux-input-notification.service.ts
+++ b/server/modules/notifications/services/tmux-input-notification.service.ts
@@ -11,12 +11,20 @@ import type {
 import { completionTargetResolver } from './completion-target-resolver.service.js';
 import { notifyInputRequired } from './notification-orchestrator.service.js';
 
+/** Screen-derived INPUT notifications follow the live monitor kill switch. */
+export function tmuxInputNotificationsEnabled(): boolean {
+  return process.env.CHATMUX_LIVE_NOTIFY !== '0';
+}
+
 /**
  * Routes a tmux screen RUN -> INPUT edge through the same durable target used
- * by the session bell. Transcript monitors may report the same edge; the
- * notification orchestrator's short dedupe window collapses both producers.
+ * by the session bell.
  */
-export function notifyTmuxInputRequiredIfWatched(target: TmuxOutputActivityTarget): void {
+export function notifyTmuxInputRequiredIfWatched(
+  target: TmuxOutputActivityTarget,
+  occurrenceKey: string,
+): void {
+  if (!tmuxInputNotificationsEnabled()) return;
   let userId: number | null;
   try {
     userId = userDb.getFirstUser()?.id ?? null;
@@ -38,6 +46,7 @@ export function notifyTmuxInputRequiredIfWatched(target: TmuxOutputActivityTarge
       provider: 'gjc',
       sessionId: target.providerSessionId,
       sessionName: target.tmuxName,
+      occurrenceKey,
     });
     return;
   }
@@ -62,5 +71,6 @@ export function notifyTmuxInputRequiredIfWatched(target: TmuxOutputActivityTarge
     provider: target.kind,
     sessionId: resolution.appSessionId ?? resolution.target.alias,
     sessionName: target.tmuxName,
+    occurrenceKey,
   });
 }

--- a/server/modules/notifications/tests/external-turn-monitor.test.ts
+++ b/server/modules/notifications/tests/external-turn-monitor.test.ts
@@ -116,16 +116,21 @@ test('notifies once for each watched RUN to INPUT transition', async () => {
   h.setAnswer(resolved('asking_user', 'none', 'input-1')); await h.monitor.tick();
   await h.monitor.tick();
   assert.equal(h.actions.length, 1, 'the same prompt is not repeated');
-  assert.deepEqual(h.actions[0], {
-    userId: 1,
-    provider: 'claude',
-    sessionId: 'target',
-    tmuxName: 'pane',
-  });
+  assert.deepEqual(
+    { ...h.actions[0], occurrenceKey: typeof h.actions[0]?.occurrenceKey },
+    {
+      userId: 1,
+      provider: 'claude',
+      sessionId: 'target',
+      tmuxName: 'pane',
+      occurrenceKey: 'string',
+    },
+  );
 
   h.setAnswer(resolved('running', 'none', 'run-2')); await h.monitor.tick();
   h.setAnswer(resolved('asking_user', 'none', 'input-2')); await h.monitor.tick();
   assert.equal(h.actions.length, 2, 'a later RUN to INPUT transition notifies again');
+  assert.notEqual(h.actions[0]?.occurrenceKey, h.actions[1]?.occurrenceKey);
 });
 
 test('does not notify for an unwatched RUN to INPUT transition', async () => {

--- a/server/modules/notifications/tests/external-turn-monitor.test.ts
+++ b/server/modules/notifications/tests/external-turn-monitor.test.ts
@@ -27,6 +27,7 @@ function harness() {
   let stateRevision = 0;
   let lastEvidenceCursor: string | null = null;
   const observed: any[] = []; const decisions: any[] = []; const wakes: number[] = []; const pruned: number[] = [];
+  const actions: any[] = [];
   const touches: any[] = [];
   const operations: string[] = [];
   let staleCandidates: any[] = [];
@@ -48,7 +49,7 @@ function harness() {
     resolveTargets: ((detailed: any) => detailed.sessions.filter((item: any) => item.kind !== 'cursor').map((item: any) => ({
       generationIdentityKey: completionExternalGenerationIdentityKey(completionExternalGenerationIdentityFromSession(item)!),
       generationTargetId: item.generationTargetId ?? 17,
-      appSessionId: null, target: { alias: 'target' }, mappingState: item.mappingState ?? 'inactive_match',
+      appSessionId: null, target: { alias: 'target', watched: item.watched ?? true }, mappingState: item.mappingState ?? 'inactive_match',
     }))) as any,
     observeGeneration: (_id, cursor, observation) => {
       if (throwObserve) throw new Error('db');
@@ -93,10 +94,11 @@ function harness() {
       return ids.length;
     },
     generationCount: () => 0,
+    notifyActionRequired: (action) => { actions.push(action); },
     now: () => 30 * 24 * 60 * 60 * 1_000 + 1,
   });
   return {
-    monitor, observed, decisions, terminalResults, wakes, pruned, touches, operations,
+    monitor, observed, decisions, terminalResults, wakes, pruned, touches, operations, actions,
     setSessions: (value: any[]) => { sessions = value; },
     setDetailedOk: (value: boolean) => { detailedOk = value; },
     setStaleCandidates: (value: any[]) => { staleCandidates = value; },
@@ -104,6 +106,35 @@ function harness() {
     setThrowObserve: (value: boolean) => { throwObserve = value; }, primary,
   };
 }
+
+test('notifies once for each watched RUN to INPUT transition', async () => {
+  const h = harness();
+  h.setAnswer(resolved('asking_user', 'none', 'startup-input')); await h.monitor.tick();
+  assert.equal(h.actions.length, 0, 'startup INPUT is only a baseline');
+
+  h.setAnswer(resolved('running', 'none', 'run-1')); await h.monitor.tick();
+  h.setAnswer(resolved('asking_user', 'none', 'input-1')); await h.monitor.tick();
+  await h.monitor.tick();
+  assert.equal(h.actions.length, 1, 'the same prompt is not repeated');
+  assert.deepEqual(h.actions[0], {
+    userId: 1,
+    provider: 'claude',
+    sessionId: 'target',
+    tmuxName: 'pane',
+  });
+
+  h.setAnswer(resolved('running', 'none', 'run-2')); await h.monitor.tick();
+  h.setAnswer(resolved('asking_user', 'none', 'input-2')); await h.monitor.tick();
+  assert.equal(h.actions.length, 2, 'a later RUN to INPUT transition notifies again');
+});
+
+test('does not notify for an unwatched RUN to INPUT transition', async () => {
+  const h = harness();
+  h.setSessions([session({ watched: false })]);
+  h.setAnswer(resolved('running', 'none', 'run')); await h.monitor.tick();
+  h.setAnswer(resolved('asking_user', 'none', 'input')); await h.monitor.tick();
+  assert.equal(h.actions.length, 0);
+});
 
 test('external monitor silently persists a startup reply-ready baseline, then creates a durable decision after a running arm', async () => {
   const h = harness();

--- a/server/modules/notifications/tests/live-turn-monitor.test.ts
+++ b/server/modules/notifications/tests/live-turn-monitor.test.ts
@@ -4,17 +4,26 @@ import test from 'node:test';
 import { createLiveTurnMonitor, findAssistantTurnEnds } from '@/modules/notifications/services/live-turn-monitor.service.js';
 
 const line = (reason: 'stop' | 'error' = 'stop') => JSON.stringify({ type: 'message', message: { role: 'assistant', stopReason: reason } });
+const askLine = () => JSON.stringify({
+  type: 'message',
+  message: {
+    role: 'assistant',
+    stopReason: 'toolUse',
+    content: [{ type: 'toolCall', name: 'ask', id: 'ask-1', arguments: { question: 'Continue?' } }],
+  },
+});
 function harness() {
   let text = ''; let available = true; let rows: Array<any> = [{ id: 's1', tmuxName: 'pane', claim: 'lineage' }];
-  const notices: any[] = []; const diagnostics: any[] = []; let failStop = false;
+  const notices: any[] = []; const actionNotices: any[] = []; const diagnostics: any[] = []; let failStop = false;
   const monitor = createLiveTurnMonitor({
     getUserId: () => 1,
     getDetailed: async () => ({ ok: available, sessions: rows, transcriptPaths: new Map(rows.filter((row) => row.id !== 'no-path').map((row) => [row.id, `/tmp/${row.id}`])) }),
     statSize: async () => Buffer.byteLength(text), readDelta: async (_path, start, end) => Buffer.from(text).subarray(start, end).toString(),
     notify: async (notice) => { notices.push(notice); if (failStop && notice.stopReason === 'stop') throw new Error('outbox unavailable'); },
+    notifyActionRequired: async (notice) => { actionNotices.push(notice); },
     diagnostic: (diagnostic) => { diagnostics.push(diagnostic); },
   });
-  return { monitor, notices, diagnostics, append: (value: string) => { text += value; }, rows: (value: any[]) => { rows = value; }, available: (value: boolean) => { available = value; }, failStop: (value: boolean) => { failStop = value; } };
+  return { monitor, notices, actionNotices, diagnostics, append: (value: string) => { text += value; }, rows: (value: any[]) => { rows = value; }, available: (value: boolean) => { available = value; }, failStop: (value: boolean) => { failStop = value; } };
 }
 
 test('findAssistantTurnEnds preserves stable occurrence order and ignores incomplete or non-terminal records', () => {
@@ -31,6 +40,22 @@ test('monitor baselines then emits a byte-stable occurrence key for each appende
   h.append(`${line()}\n`); await h.monitor.tick();
   assert.equal(h.notices.length, 2);
   assert.notEqual(h.notices[1].occurrenceKey, first.occurrenceKey);
+});
+
+test('monitor baselines old prompts and emits one action event for each appended GJC ask', async () => {
+  const h = harness();
+  h.append(`${askLine()}\n`);
+  await h.monitor.tick();
+  assert.equal(h.actionNotices.length, 0, 'historical INPUT is not replayed');
+
+  h.append(`${askLine()}\n`);
+  await h.monitor.tick();
+  await h.monitor.tick();
+  assert.deepEqual(h.actionNotices, [{ userId: 1, sessionId: 's1', tmuxName: 'pane' }]);
+
+  h.append(`${line()}\n${askLine()}\n`);
+  await h.monitor.tick();
+  assert.equal(h.actionNotices.length, 2);
 });
 
 test('a failed completion notification retries the same post-commit cursor occurrence', async () => {

--- a/server/modules/notifications/tests/live-turn-monitor.test.ts
+++ b/server/modules/notifications/tests/live-turn-monitor.test.ts
@@ -51,10 +51,15 @@ test('monitor baselines old prompts and emits one action event for each appended
   h.append(`${askLine()}\n`);
   await h.monitor.tick();
   await h.monitor.tick();
-  assert.deepEqual(h.actionNotices, [{ userId: 1, sessionId: 's1', tmuxName: 'pane' }]);
+  assert.deepEqual(
+    { ...h.actionNotices[0], occurrenceKey: typeof h.actionNotices[0]?.occurrenceKey },
+    { userId: 1, sessionId: 's1', tmuxName: 'pane', occurrenceKey: 'string' },
+  );
+  assert.match(h.actionNotices[0]?.occurrenceKey ?? '', /^gjc:s1:\d+:[a-f0-9]{64}$/);
 
   h.append(`${line()}\n${askLine()}\n`);
   await h.monitor.tick();
+  assert.notEqual(h.actionNotices[0]?.occurrenceKey, h.actionNotices[1]?.occurrenceKey);
   assert.equal(h.actionNotices.length, 2);
 });
 

--- a/server/modules/notifications/tests/tmux-input-notification.test.ts
+++ b/server/modules/notifications/tests/tmux-input-notification.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  notifyTmuxInputRequiredIfWatched,
+  tmuxInputNotificationsEnabled,
+} from '@/modules/notifications/services/tmux-input-notification.service.js';
+
+test('CHATMUX_LIVE_NOTIFY=0 disables the screen INPUT notification producer', () => {
+  const previous = process.env.CHATMUX_LIVE_NOTIFY;
+  try {
+    process.env.CHATMUX_LIVE_NOTIFY = '0';
+    assert.equal(tmuxInputNotificationsEnabled(), false);
+    assert.doesNotThrow(() => notifyTmuxInputRequiredIfWatched(null as never, 'screen-occurrence'));
+    process.env.CHATMUX_LIVE_NOTIFY = '1';
+    assert.equal(tmuxInputNotificationsEnabled(), true);
+  } finally {
+    if (previous === undefined) delete process.env.CHATMUX_LIVE_NOTIFY;
+    else process.env.CHATMUX_LIVE_NOTIFY = previous;
+  }
+});

--- a/server/modules/providers/index.ts
+++ b/server/modules/providers/index.ts
@@ -79,3 +79,4 @@ export {
   type TmuxOutputActivityTarget,
   type TmuxOutputActivityMonitorOptions,
 } from './services/tmux-output-activity-monitor.service.js';
+export { observeTmuxInputActivity } from './services/tmux-input-occurrence.service.js';

--- a/server/modules/providers/services/tmux-input-occurrence.service.ts
+++ b/server/modules/providers/services/tmux-input-occurrence.service.ts
@@ -1,0 +1,93 @@
+import { createHash } from 'node:crypto';
+
+import type { TmuxPaneIdentity, TmuxProcessGeneration } from '../../../../shared/tmux.js';
+
+type TmuxInputActivityIdentity = Readonly<{
+  provider: string;
+  providerSessionId: string | null;
+  tmux?: TmuxPaneIdentity;
+  process?: TmuxProcessGeneration;
+}>;
+
+type ObserverSource = 'screen' | 'transcript';
+
+type OccurrenceState = {
+  hasObservedRun: boolean;
+  inputActive: boolean;
+  runSequence: number;
+  sourceState: Record<ObserverSource, 'unknown' | 'running' | 'input'>;
+};
+
+const occurrences = new Map<string, OccurrenceState>();
+
+function identityKey({
+  provider,
+  providerSessionId,
+  tmux,
+  process,
+}: TmuxInputActivityIdentity): string {
+  const hash = createHash('sha256')
+    .update('chatmux:tmux-input-occurrence:v1\0')
+    .update(provider)
+    .update('\0')
+    .update(providerSessionId ?? '');
+  if (providerSessionId) return hash.digest('hex');
+  if (!tmux || !process) throw new TypeError('tmux and process are required without a provider session id');
+  return hash
+    .update('\0')
+    .update(tmux.socketPath)
+    .update('\0')
+    .update(tmux.sessionId)
+    .update('\0')
+    .update(tmux.windowId)
+    .update('\0')
+    .update(tmux.paneId)
+    .update('\0')
+    .update(String(process.pid))
+    .update('\0')
+    .update(String(process.startedAtMs))
+    .digest('hex');
+}
+
+/**
+ * Assigns a stable key to one RUN -> INPUT occurrence for a provider session
+ * (or an unbound tmux process generation). Each observer keeps its own last
+ * state: only the first source to observe a new RUN after INPUT advances the
+ * sequence, while a lagging second observer joins that occurrence. An INPUT
+ * seen before any RUN only establishes a startup baseline.
+ */
+export function observeTmuxInputActivity(
+  identity: TmuxInputActivityIdentity,
+  source: ObserverSource,
+  inputActive: boolean,
+): string | null {
+  const key = identityKey(identity);
+  let state = occurrences.get(key);
+  if (!state) {
+    state = {
+      hasObservedRun: false,
+      inputActive: false,
+      runSequence: 0,
+      sourceState: { screen: 'unknown', transcript: 'unknown' },
+    };
+    occurrences.set(key, state);
+  }
+
+  if (!inputActive) {
+    const priorSourceState = state.sourceState[source];
+    if (!state.hasObservedRun) {
+      state.hasObservedRun = true;
+      state.runSequence += 1;
+      state.inputActive = false;
+    } else if (priorSourceState === 'input' && state.inputActive) {
+      state.runSequence += 1;
+      state.inputActive = false;
+    }
+    state.sourceState[source] = 'running';
+    return null;
+  }
+
+  state.sourceState[source] = 'input';
+  state.inputActive = true;
+  return state.hasObservedRun ? `${key}:${state.runSequence}` : null;
+}

--- a/server/modules/providers/services/tmux-output-activity-monitor.service.ts
+++ b/server/modules/providers/services/tmux-output-activity-monitor.service.ts
@@ -62,6 +62,7 @@ export type TmuxOutputActivityMonitorOptions = {
   observerFactory?: TmuxControlObserverFactory;
   canObserveSession?: (session: SessionIdentity) => Promise<boolean>;
   subscribeTranscript?: (listener: (change: TranscriptChange) => void) => () => void;
+  onInputRequired?: (target: TmuxOutputActivityTarget) => unknown;
   warn?: (message: string) => void;
 };
 
@@ -270,6 +271,13 @@ export function createTmuxOutputActivityMonitor(
   const publishPrompt = (pane: PaneState, active: boolean, syncObservers = true): void => {
     const activityChanged = pane.observedPrompt !== active;
     pane.observedPrompt = active;
+    if (activityChanged && active && pane.row.activity === 'running') {
+      try {
+        void Promise.resolve(options.onInputRequired?.(pane.target)).catch(() => undefined);
+      } catch {
+        // Notification delivery must never interrupt INPUT state publication.
+      }
+    }
     if (setObservedTmuxInteractiveActivity(pane.target, active)) {
       collector.forceRefresh();
     }

--- a/server/modules/providers/services/tmux-output-activity-monitor.service.ts
+++ b/server/modules/providers/services/tmux-output-activity-monitor.service.ts
@@ -18,6 +18,7 @@ import {
   setObservedTmuxInteractiveActivity,
   tmuxScreenHasInteractivePrompt,
 } from './tmux-interactive-prompt.service.js';
+import { observeTmuxInputActivity } from './tmux-input-occurrence.service.js';
 import {
   onTranscriptChanged,
   type TranscriptChange,
@@ -62,7 +63,7 @@ export type TmuxOutputActivityMonitorOptions = {
   observerFactory?: TmuxControlObserverFactory;
   canObserveSession?: (session: SessionIdentity) => Promise<boolean>;
   subscribeTranscript?: (listener: (change: TranscriptChange) => void) => () => void;
-  onInputRequired?: (target: TmuxOutputActivityTarget) => unknown;
+  onInputRequired?: (target: TmuxOutputActivityTarget, occurrenceKey: string) => unknown;
   warn?: (message: string) => void;
 };
 
@@ -72,6 +73,7 @@ type PaneState = {
   target: TmuxOutputActivityTarget;
   screenHash: string | null;
   observedPrompt: boolean;
+  hasObservedRun: boolean;
   clearMisses: number;
   quietTimer: Timer | null;
   maxTimer: Timer | null;
@@ -268,12 +270,33 @@ export function createTmuxOutputActivityMonitor(
     pane.maxTimer = null;
   };
 
-  const publishPrompt = (pane: PaneState, active: boolean, syncObservers = true): void => {
+  const publishPrompt = (
+    pane: PaneState,
+    active: boolean,
+    syncObservers = true,
+    observedScreen = false,
+  ): void => {
     const activityChanged = pane.observedPrompt !== active;
     pane.observedPrompt = active;
-    if (activityChanged && active && pane.row.activity === 'running') {
+    let occurrenceKey: string | null = null;
+    if (observedScreen) {
+      occurrenceKey = observeTmuxInputActivity({
+        provider: pane.target.kind,
+        providerSessionId: pane.target.providerSessionId,
+        tmux: pane.target.tmux,
+        process: pane.target.process,
+      }, 'screen', active);
+      if (!active && pane.row.activity === 'running') pane.hasObservedRun = true;
+    }
+    if (
+      activityChanged
+      && active
+      && pane.hasObservedRun
+      && pane.row.activity === 'running'
+      && occurrenceKey
+    ) {
       try {
-        void Promise.resolve(options.onInputRequired?.(pane.target)).catch(() => undefined);
+        void Promise.resolve(options.onInputRequired?.(pane.target, occurrenceKey)).catch(() => undefined);
       } catch {
         // Notification delivery must never interrupt INPUT state publication.
       }
@@ -302,7 +325,7 @@ export function createTmuxOutputActivityMonitor(
       const promptActive = tmuxScreenHasInteractivePrompt(pane.target, screen);
       if (promptActive) {
         pane.clearMisses = 0;
-        publishPrompt(pane, true);
+        publishPrompt(pane, true, true, true);
       } else if (pane.observedPrompt && pane.clearMisses === 0) {
         pane.clearMisses = 1;
         pane.forceParse = true;
@@ -313,7 +336,7 @@ export function createTmuxOutputActivityMonitor(
         pane.quietTimer.unref?.();
       } else {
         pane.clearMisses = 0;
-        publishPrompt(pane, false);
+        publishPrompt(pane, false, true, true);
       }
     } catch {
       // Discovery and the fallback loop will retry. Never clear a known INPUT
@@ -486,6 +509,7 @@ export function createTmuxOutputActivityMonitor(
         existing.row = row;
         existing.target = targetFor(row);
         if (kindChanged || bindingChanged) {
+          existing.hasObservedRun = false;
           existing.screenHash = null;
           existing.clearMisses = 0;
           publishPrompt(existing, false, false);
@@ -500,6 +524,7 @@ export function createTmuxOutputActivityMonitor(
         screenHash: null,
         observedPrompt: false,
         clearMisses: 0,
+        hasObservedRun: false,
         quietTimer: null,
         maxTimer: null,
         inFlight: false,

--- a/server/modules/providers/tests/tmux-input-occurrence.service.test.ts
+++ b/server/modules/providers/tests/tmux-input-occurrence.service.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { observeTmuxInputActivity } from '@/modules/providers/services/tmux-input-occurrence.service.js';
+
+test('shares a stable INPUT occurrence between screen and transcript observers', () => {
+  const identity = {
+    provider: 'codex',
+    providerSessionId: `cross-producer-${Date.now()}`,
+  };
+
+  observeTmuxInputActivity(identity, 'screen', false);
+  const screenOccurrence = observeTmuxInputActivity(identity, 'screen', true);
+  // The transcript's delayed RUN snapshot is stale; it must join the current
+  // occurrence rather than advancing the sequence.
+  observeTmuxInputActivity(identity, 'transcript', false);
+  const transcriptOccurrence = observeTmuxInputActivity(identity, 'transcript', true);
+  assert.ok(screenOccurrence);
+  assert.equal(transcriptOccurrence, screenOccurrence);
+
+  observeTmuxInputActivity(identity, 'screen', false);
+  // Both observers see the real next RUN; only the first transition advances.
+  observeTmuxInputActivity(identity, 'transcript', false);
+  const nextScreenOccurrence = observeTmuxInputActivity(identity, 'screen', true);
+  const nextTranscriptOccurrence = observeTmuxInputActivity(identity, 'transcript', true);
+  assert.ok(nextScreenOccurrence);
+  assert.notEqual(nextScreenOccurrence, screenOccurrence);
+  assert.equal(nextTranscriptOccurrence, nextScreenOccurrence);
+});

--- a/server/modules/providers/tests/tmux-output-activity-monitor.service.test.ts
+++ b/server/modules/providers/tests/tmux-output-activity-monitor.service.test.ts
@@ -383,6 +383,53 @@ test('uses the transcript bell for a mapped RUN pane without keeping a control c
   monitor.dispose();
 });
 
+test('emits one action edge when a RUN pane becomes INPUT', async () => {
+  const session = row('codex', 26);
+  const collector = fakeCollector(snapshot([session]));
+  const transcriptRef: { current: ((change: {
+    provider: SupportedKind;
+    providerSessionId: string | null;
+    changedAtMs: number;
+  }) => void) | null } = { current: null };
+  let screen = 'Working';
+  const actions: string[] = [];
+  const monitor = createTmuxOutputActivityMonitor(collector.source, {
+    quietMs: 5,
+    clearConfirmMs: 5,
+    fallbackMs: 60_000,
+    canObserveSession: async () => true,
+    observerFactory: () => ({ close: () => undefined }),
+    capture: async () => screen,
+    subscribeTranscript: (listener) => {
+      transcriptRef.current = listener;
+      return () => { transcriptRef.current = null; };
+    },
+    onInputRequired: (target) => { actions.push(target.tmux.paneId); },
+  });
+  const emitTranscript = () => transcriptRef.current?.({
+    provider: 'codex',
+    providerSessionId: session.providerSessionId,
+    changedAtMs: Date.now(),
+  });
+
+  monitor.start();
+  await waitFor(() => transcriptRef.current !== null);
+  screen = SCREENS.codex;
+  emitTranscript();
+  await waitFor(() => actions.length === 1);
+  emitTranscript();
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.deepEqual(actions, [session.tmux.paneId], 'the same visible prompt is not repeated');
+
+  screen = 'Working';
+  emitTranscript();
+  await waitFor(() => getCachedTmuxInteractiveActivity(targetFor(session)) === null);
+  screen = SCREENS.codex;
+  emitTranscript();
+  await waitFor(() => actions.length === 2);
+  monitor.dispose();
+});
+
 test('keeps INPUT while every provider switches from Other to direct input', async () => {
   const rows = (Object.keys(CUSTOM_SCREENS) as SupportedKind[])
     .map((kind, index) => row(kind, index + 40));

--- a/server/modules/providers/tests/tmux-output-activity-monitor.service.test.ts
+++ b/server/modules/providers/tests/tmux-output-activity-monitor.service.test.ts
@@ -430,6 +430,65 @@ test('emits one action edge when a RUN pane becomes INPUT', async () => {
   monitor.dispose();
 });
 
+test('baselines startup and rebound INPUT panes until their RUN state is observed', async () => {
+  const session = row('codex', 27);
+  const collector = fakeCollector(snapshot([session]));
+  const transcriptRef: { current: ((change: {
+    provider: SupportedKind;
+    providerSessionId: string | null;
+    changedAtMs: number;
+  }) => void) | null } = { current: null };
+  let screen: string = SCREENS.codex;
+  const occurrences: string[] = [];
+  const monitor = createTmuxOutputActivityMonitor(collector.source, {
+    quietMs: 5,
+    clearConfirmMs: 5,
+    fallbackMs: 60_000,
+    canObserveSession: async () => true,
+    observerFactory: () => ({ close: () => undefined }),
+    capture: async () => screen,
+    subscribeTranscript: (listener) => {
+      transcriptRef.current = listener;
+      return () => { transcriptRef.current = null; };
+    },
+    onInputRequired: (_target, occurrenceKey) => { occurrences.push(occurrenceKey); },
+  });
+  const emitTranscript = (providerSessionId = session.providerSessionId) => transcriptRef.current?.({
+    provider: 'codex',
+    providerSessionId,
+    changedAtMs: Date.now(),
+  });
+
+  monitor.start();
+  await waitFor(() => (
+    getCachedTmuxInteractiveActivity(targetFor(session)) === 'asking_user'
+  ));
+  assert.deepEqual(occurrences, [], 'startup INPUT is a baseline');
+
+  screen = 'Working';
+  emitTranscript();
+  await waitFor(() => getCachedTmuxInteractiveActivity(targetFor(session)) === null);
+  screen = SCREENS.codex;
+  emitTranscript();
+  await waitFor(() => occurrences.length === 1);
+
+  const rebound = { ...session, providerSessionId: 'codex-session-27-rebound' };
+  collector.emit(snapshot([rebound], 2));
+  await waitFor(() => (
+    getCachedTmuxInteractiveActivity(targetFor(rebound)) === 'asking_user'
+  ));
+  assert.equal(occurrences.length, 1, 'rebound INPUT is a baseline');
+
+  screen = 'Working';
+  emitTranscript(rebound.providerSessionId);
+  await waitFor(() => getCachedTmuxInteractiveActivity(targetFor(rebound)) === null);
+  screen = SCREENS.codex;
+  emitTranscript(rebound.providerSessionId);
+  await waitFor(() => occurrences.length === 2);
+  assert.notEqual(occurrences[0], occurrences[1]);
+  monitor.dispose();
+});
+
 test('keeps INPUT while every provider switches from Other to direct input', async () => {
   const rows = (Object.keys(CUSTOM_SCREENS) as SupportedKind[])
     .map((kind, index) => row(kind, index + 40));

--- a/server/services/notification-orchestrator.js
+++ b/server/services/notification-orchestrator.js
@@ -4,5 +4,6 @@ export {
   notifyUserIfEnabled,
   notifyRunStopped,
   notifyRunFailed,
+  notifyInputRequired,
   notifyLiveTurnEnded,
 } from '../modules/notifications/services/notification-orchestrator.service.js';

--- a/server/services/tests/notification-orchestrator.test.js
+++ b/server/services/tests/notification-orchestrator.test.js
@@ -18,7 +18,11 @@ import {
   sessionsDb,
   userDb,
 } from '../../modules/database/index.js';
-import { notifyLiveTurnEnded, notifyRunStopped } from '../notification-orchestrator.js';
+import {
+  notifyInputRequired,
+  notifyLiveTurnEnded,
+  notifyRunStopped,
+} from '../notification-orchestrator.js';
 
 async function withIsolatedDatabase(runTest) {
   const previousDatabasePath = process.env.DATABASE_PATH;
@@ -100,6 +104,44 @@ test('push payload uses the app session id when notified with a provider session
       assert.equal(payload?.navigation?.href, `/session/${encodeURIComponent('app-session-1')}`);
       assert.equal(payload?.navigation?.title, 'ChatMux');
       assert.equal(sentPayloads.length, 0, 'completion producers only create durable outbox decisions');
+    });
+  } finally {
+    webPush.sendNotification = originalSendNotification;
+  }
+});
+
+test('INPUT notification uses the action preference and navigates to the mapped app session', async () => {
+  const originalSendNotification = webPush.sendNotification;
+  const sentPayloads = [];
+  webPush.sendNotification = async (_subscription, payload) => {
+    sentPayloads.push(JSON.parse(payload));
+    return {};
+  };
+
+  try {
+    await withIsolatedDatabase(async () => {
+      const userId = Number(userDb.createUser('input-user', 'hash').id);
+      notificationPreferencesDb.updateCompletionPreferencesAndDeliveryState(userId, {
+        channels: { webPush: true },
+        events: { actionRequired: true, stop: false, liveStop: false, error: false },
+      }, Date.now(), true);
+      pushSubscriptionsDb.saveSubscription(userId, 'https://example.test/input-push', 'p256dh', 'auth');
+      sessionsDb.createAppSession('input-app-session', 'codex', '/workspace/demo');
+      sessionsDb.assignProviderSessionId('input-app-session', 'codex', 'codex-native-input');
+
+      notifyInputRequired({
+        userId,
+        provider: 'codex',
+        sessionId: 'codex-native-input',
+        sessionName: 'codex-pane',
+      });
+      await new Promise((resolve) => setImmediate(resolve));
+
+      assert.equal(sentPayloads.length, 1);
+      assert.equal(sentPayloads[0].title, 'codex-pane');
+      assert.equal(sentPayloads[0].body, 'Codex: Input required — the tmux session is waiting for you');
+      assert.equal(sentPayloads[0].data.sessionId, 'input-app-session');
+      assert.equal(sentPayloads[0].data.code, 'input.required');
     });
   } finally {
     webPush.sendNotification = originalSendNotification;

--- a/server/services/tests/notification-orchestrator.test.js
+++ b/server/services/tests/notification-orchestrator.test.js
@@ -20,6 +20,7 @@ import {
 } from '../../modules/database/index.js';
 import {
   notifyInputRequired,
+  createNotificationEvent,
   notifyLiveTurnEnded,
   notifyRunStopped,
 } from '../notification-orchestrator.js';
@@ -110,6 +111,16 @@ test('push payload uses the app session id when notified with a provider session
   }
 });
 
+test('preserves an explicit dedupe key for distinct permission requests', () => {
+  const event = createNotificationEvent({
+    provider: 'codex',
+    sessionId: 'permission-session',
+    code: 'permission.required',
+    dedupeKey: 'permission-request-2',
+  });
+  assert.equal(event.dedupeKey, 'permission-request-2');
+});
+
 test('INPUT notification uses the action preference and navigates to the mapped app session', async () => {
   const originalSendNotification = webPush.sendNotification;
   const sentPayloads = [];
@@ -134,6 +145,7 @@ test('INPUT notification uses the action preference and navigates to the mapped 
         provider: 'codex',
         sessionId: 'codex-native-input',
         sessionName: 'codex-pane',
+        occurrenceKey: 'input-navigation-occurrence',
       });
       await new Promise((resolve) => setImmediate(resolve));
 
@@ -144,6 +156,57 @@ test('INPUT notification uses the action preference and navigates to the mapped 
       assert.equal(sentPayloads[0].data.code, 'input.required');
     });
   } finally {
+    webPush.sendNotification = originalSendNotification;
+  }
+});
+
+test('collapses duplicate input occurrences across producers without suppressing a later RUN to INPUT edge', async () => {
+  const originalSendNotification = webPush.sendNotification;
+  const originalNow = Date.now;
+  const sentPayloads = [];
+  const occurrence = `cross-producer-${originalNow()}`;
+  webPush.sendNotification = async (_subscription, payload) => {
+    sentPayloads.push(JSON.parse(payload));
+    return {};
+  };
+
+  try {
+    await withIsolatedDatabase(async () => {
+      const userId = Number(userDb.createUser('input-dedupe-user', 'hash').id);
+      notificationPreferencesDb.updateCompletionPreferencesAndDeliveryState(userId, {
+        channels: { webPush: true },
+        events: { actionRequired: true, stop: false, liveStop: false, error: false },
+      }, Date.now(), true);
+      pushSubscriptionsDb.saveSubscription(userId, 'https://example.test/input-dedupe-push', 'p256dh', 'auth');
+
+      let now = originalNow();
+      Date.now = () => now;
+      notifyInputRequired({
+        userId,
+        provider: 'codex',
+        sessionId: 'input-dedupe-session',
+        occurrenceKey: occurrence,
+      });
+      now += 20_001;
+      notifyInputRequired({
+        userId,
+        provider: 'codex',
+        sessionId: 'input-dedupe-session',
+        occurrenceKey: occurrence,
+      });
+      notifyInputRequired({
+        userId,
+        provider: 'codex',
+        sessionId: 'input-dedupe-session',
+        occurrenceKey: `${occurrence}-next-run`,
+      });
+      Date.now = originalNow;
+      await new Promise((resolve) => setImmediate(resolve));
+
+      assert.equal(sentPayloads.length, 2);
+    });
+  } finally {
+    Date.now = originalNow;
     webPush.sendNotification = originalSendNotification;
   }
 });

--- a/server/services/vapid-keys.js
+++ b/server/services/vapid-keys.js
@@ -2,6 +2,7 @@ import webPush from 'web-push';
 
 import { getConnection } from '../modules/database/connection.js';
 
+const DEFAULT_VAPID_SUBJECT = 'https://github.com/devswha/chatmux';
 let cachedKeys = null;
 const db = getConnection();
 
@@ -27,7 +28,7 @@ function getPublicKey() {
 function configureWebPush() {
   const keys = ensureVapidKeys();
   webPush.setVapidDetails(
-    'mailto:noreply@chatmux.local',
+    process.env.VAPID_SUBJECT?.trim() || DEFAULT_VAPID_SUBJECT,
     keys.publicKey,
     keys.privateKey
   );

--- a/src/components/sidebar/context/CompletionNotificationsContext.test.tsx
+++ b/src/components/sidebar/context/CompletionNotificationsContext.test.tsx
@@ -1,17 +1,24 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { createElement } from 'react';
+import TestRenderer, { act, type ReactTestRenderer } from 'react-test-renderer';
+
 import type { CompletionNotificationDescriptor, CompletionNotificationDevice, CompletionNotificationTarget } from '../../../../shared/completion-notifications';
+import { api } from '../../../utils/api';
+import { useCompletionNotifications } from '../hooks/useCompletionNotifications';
+import type { CompletionNotificationsHookApi } from '../types/types';
 
 import {
   applicationServerKeysEqual,
   canCommitPassiveCompletionNotificationStatus,
+  CompletionNotificationsProvider,
   completionNotificationDescriptorKey,
   completionNotificationReducer,
   startClickGatedPreparation,
 } from './CompletionNotificationsContext';
 
-test('application server key comparison accepts matching buffers and rejects stale subscriptions', () => {
+test('VAPID subscription comparison detects stale application-server keys', () => {
   const expected = Uint8Array.from([4, 12, 28, 44]);
   assert.equal(applicationServerKeysEqual(expected.buffer, expected), true);
 
@@ -37,12 +44,13 @@ const target = (alias: string, watched = false): CompletionNotificationTarget =>
   revision: 1,
   watched,
 });
-const statusRecord = (item: ReturnType<typeof target>) => ({
+const statusRecord = (item: CompletionNotificationTarget) => ({
   item: { alias: item.alias, mappingState: 'one_active' as const, reason: 'eligible' as const, target: item },
   target: item,
 });
 
 const initial = () => ({ records: new Map(), globalPaused: false, device: null });
+const tick = () => new Promise<void>((resolve) => setImmediate(resolve));
 function deferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (reason?: unknown) => void;
@@ -238,4 +246,231 @@ test('a passive permission denial surfaces only on watched sessions', () => {
 
   assert.equal(refreshed.records.get(watchedKey)?.error, 'permission_denied', 'a watched session keeps the actionable denial');
   assert.equal(refreshed.records.get(idleKey)?.error, null, 'an unwatched session stays quiet');
+});
+
+test('a passive stale VAPID check exposes repair only for existing watched targets', () => {
+  const watchedKey = completionNotificationDescriptorKey(descriptor('watched'));
+  const idleKey = completionNotificationDescriptorKey(descriptor('idle'));
+  const refreshed = completionNotificationReducer(initial(), {
+    type: 'status',
+    records: new Map([
+      [watchedKey, statusRecord(target('watched', true))],
+      [idleKey, statusRecord(target('idle'))],
+    ]),
+    globalPaused: false,
+    device,
+    reason: null,
+    deviceRepairRequired: true,
+  });
+
+  assert.equal(refreshed.records.get(watchedKey)?.deviceRepairRequired, true);
+  assert.equal(
+    refreshed.records.get(idleKey)?.deviceRepairRequired,
+    false,
+    'an unwatched row never advertises a device repair action',
+  );
+});
+
+
+test('a failed device registration keeps a fresh watched subscription repairable on passive refresh', async () => {
+  const expectedKey = Uint8Array.from([4, 12, 28, 44]);
+  const staleKey = Uint8Array.from([4, 12, 28, 45]);
+  const watchedTarget = target('watched', true);
+  let currentSubscription: {
+    endpoint: string;
+    options: { applicationServerKey: BufferSource };
+    unsubscribe: () => Promise<boolean>;
+    toJSON: () => { endpoint: string; keys: { p256dh: string; auth: string } };
+  } | null;
+  let browserSubscriptions = 0;
+  let serverRegistrations = 0;
+  let permissionRequests = 0;
+  let remainingServerRegistrationFailures = 1;
+  const staleSubscription = {
+    endpoint: 'https://push.example/stale',
+    options: { applicationServerKey: staleKey },
+    unsubscribe: async () => {
+      currentSubscription = null;
+      return true;
+    },
+    toJSON: () => ({ endpoint: 'https://push.example/stale', keys: { p256dh: 'stale-p256dh', auth: 'stale-auth' } }),
+  };
+  const freshSubscription = {
+    endpoint: 'https://push.example/fresh',
+    options: { applicationServerKey: expectedKey },
+    unsubscribe: async () => false,
+    toJSON: () => ({ endpoint: 'https://push.example/fresh', keys: { p256dh: 'fresh-p256dh', auth: 'fresh-auth' } }),
+  };
+  currentSubscription = staleSubscription;
+  const registration = {
+    pushManager: {
+      getSubscription: async () => currentSubscription,
+      subscribe: async () => {
+        browserSubscriptions += 1;
+        currentSubscription = freshSubscription;
+        return freshSubscription;
+      },
+    },
+  };
+  const notificationApi = api.completionNotifications as unknown as {
+    status: (descriptors: unknown, endpoint?: string, options?: unknown) => Promise<Response>;
+    vapidPublicKey: (options?: unknown) => Promise<Response>;
+    subscribe: (subscription: unknown, options?: unknown) => Promise<Response>;
+    register: (subscription: unknown, options?: unknown) => Promise<Response>;
+    setWatch: (mutation: unknown, endpoint?: string, options?: unknown) => Promise<Response>;
+  };
+  const originalApi = {
+    status: notificationApi.status,
+    vapidPublicKey: notificationApi.vapidPublicKey,
+    subscribe: notificationApi.subscribe,
+    register: notificationApi.register,
+    setWatch: notificationApi.setWatch,
+  };
+  const globalDescriptors = new Map(
+    ['window', 'document', 'navigator', 'Notification', 'PushManager'].map((name) => [
+      name,
+      Object.getOwnPropertyDescriptor(globalThis, name),
+    ]),
+  );
+  const restoreGlobal = (name: string) => {
+    const descriptor = globalDescriptors.get(name);
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+    else delete (globalThis as Record<string, unknown>)[name];
+  };
+  Object.defineProperties(globalThis, {
+    window: {
+      configurable: true,
+      value: {
+        isSecureContext: true,
+        setTimeout: (callback: () => void) => setTimeout(callback, 0),
+        clearTimeout,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        matchMedia: () => ({ matches: false }),
+        Notification: {},
+        PushManager: class PushManager {},
+      },
+    },
+    document: {
+      configurable: true,
+      value: {
+        visibilityState: 'visible',
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      },
+    },
+    navigator: {
+      configurable: true,
+      value: {
+        userAgent: 'test browser',
+        maxTouchPoints: 0,
+        serviceWorker: {
+          getRegistration: async () => registration,
+          ready: Promise.resolve(registration),
+        },
+      },
+    },
+    Notification: {
+      configurable: true,
+      value: {
+        permission: 'granted',
+        requestPermission: async () => {
+          permissionRequests += 1;
+          return 'granted';
+        },
+      },
+    },
+    PushManager: { configurable: true, value: class PushManager {} },
+  });
+  notificationApi.status = async (_descriptors, endpoint) => new Response(JSON.stringify({
+    globalPaused: false,
+    targets: [{
+      alias: watchedTarget.alias,
+      mappingState: 'one_active',
+      reason: 'eligible',
+      target: watchedTarget,
+    }],
+    device: endpoint === freshSubscription.endpoint
+      ? { ...device, registered: false, setupRequired: true, reason: 'endpoint_not_registered' }
+      : device,
+  }), { status: 200, headers: { 'content-type': 'application/json' } });
+  notificationApi.vapidPublicKey = async () => new Response(JSON.stringify({ publicKey: 'BAwcLA' }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+  notificationApi.subscribe = async (subscription) => {
+    serverRegistrations += 1;
+    assert.deepEqual(subscription, {
+      endpoint: freshSubscription.endpoint,
+      keys: { p256dh: 'fresh-p256dh', auth: 'fresh-auth' },
+    });
+    if (remainingServerRegistrationFailures > 0) {
+      remainingServerRegistrationFailures -= 1;
+      return new Response('{}', { status: 503, headers: { 'content-type': 'application/json' } });
+    }
+    return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+  };
+  notificationApi.register = async () => new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+  notificationApi.setWatch = async () => new Response(JSON.stringify({
+    target: watchedTarget,
+    globalPaused: false,
+    device,
+  }), { status: 200, headers: { 'content-type': 'application/json' } });
+
+  const snapshots: CompletionNotificationsHookApi[] = [];
+  let renderer: ReactTestRenderer | null = null;
+  function Probe() {
+    snapshots.push(useCompletionNotifications(descriptor('watched')));
+    return null;
+  }
+
+  try {
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(
+        CompletionNotificationsProvider,
+        null,
+        createElement(Probe),
+      ));
+      await tick();
+      await tick();
+      await tick();
+    });
+    const latest = snapshots.at(-1);
+    assert.ok(latest);
+    assert.equal(latest.status?.deviceRepairRequired, true, 'the passive refresh exposes a stale watched subscription');
+    assert.equal(browserSubscriptions, 0, 'a passive stale-key refresh never changes the browser subscription');
+    assert.equal(serverRegistrations, 0, 'a passive stale-key refresh never re-registers the device');
+    assert.equal(permissionRequests, 0, 'a passive stale-key refresh never requests notification permission');
+
+    await act(async () => {
+      await latest.repairDevice(descriptor('watched'));
+      await tick();
+    });
+
+    assert.equal(browserSubscriptions, 1, 'repair replaces the stale browser subscription only after the explicit action');
+    assert.equal(serverRegistrations, 1, 'the first server registration attempt failed transiently');
+
+    await act(async () => {
+      await snapshots.at(-1)!.refresh();
+      await tick();
+    });
+    const retry = snapshots.at(-1);
+    assert.ok(retry);
+    assert.equal(retry.status?.deviceRepairRequired, true, 'the unregistered fresh endpoint remains repairable after passive refresh');
+
+    await act(async () => {
+      await retry.repairDevice(descriptor('watched'));
+      await tick();
+    });
+    assert.equal(browserSubscriptions, 1, 'retrying registration does not churn the matching browser subscription');
+    assert.equal(serverRegistrations, 2, 'the explicit retry re-registers the fresh endpoint');
+  } finally {
+    if (renderer) await act(async () => { renderer!.unmount(); });
+    notificationApi.status = originalApi.status;
+    notificationApi.vapidPublicKey = originalApi.vapidPublicKey;
+    notificationApi.subscribe = originalApi.subscribe;
+    notificationApi.register = originalApi.register;
+    notificationApi.setWatch = originalApi.setWatch;
+    for (const name of globalDescriptors.keys()) restoreGlobal(name);
+  }
 });

--- a/src/components/sidebar/context/CompletionNotificationsContext.test.tsx
+++ b/src/components/sidebar/context/CompletionNotificationsContext.test.tsx
@@ -4,11 +4,22 @@ import test from 'node:test';
 import type { CompletionNotificationDescriptor, CompletionNotificationDevice, CompletionNotificationTarget } from '../../../../shared/completion-notifications';
 
 import {
+  applicationServerKeysEqual,
   canCommitPassiveCompletionNotificationStatus,
   completionNotificationDescriptorKey,
   completionNotificationReducer,
   startClickGatedPreparation,
 } from './CompletionNotificationsContext';
+
+test('application server key comparison accepts matching buffers and rejects stale subscriptions', () => {
+  const expected = Uint8Array.from([4, 12, 28, 44]);
+  assert.equal(applicationServerKeysEqual(expected.buffer, expected), true);
+
+  const padded = Uint8Array.from([99, ...expected, 100]);
+  assert.equal(applicationServerKeysEqual(padded.subarray(1, 5), expected), true);
+  assert.equal(applicationServerKeysEqual(Uint8Array.from([4, 12, 28, 45]), expected), false);
+  assert.equal(applicationServerKeysEqual(null, expected), false);
+});
 
 const device: CompletionNotificationDevice = {
   supported: true,

--- a/src/components/sidebar/context/CompletionNotificationsContext.tsx
+++ b/src/components/sidebar/context/CompletionNotificationsContext.tsx
@@ -185,6 +185,17 @@ function vapidKey(value: string) {
   const binary = atob(value.replace(/-/g, '+').replace(/_/g, '/').padEnd(Math.ceil(value.length / 4) * 4, '='));
   return Uint8Array.from(binary, (character) => character.charCodeAt(0));
 }
+export function applicationServerKeysEqual(
+  actual: BufferSource | null | undefined,
+  expected: Uint8Array,
+) {
+  if (!actual) return false;
+  const bytes = ArrayBuffer.isView(actual)
+    ? new Uint8Array(actual.buffer, actual.byteOffset, actual.byteLength)
+    : new Uint8Array(actual);
+  return bytes.byteLength === expected.byteLength
+    && bytes.every((value, index) => value === expected[index]);
+}
 function mutationId() {
   return typeof crypto.randomUUID === 'function' ? crypto.randomUUID() : `${Date.now()}-${crypto.getRandomValues(new Uint32Array(2)).join('-')}`;
 }
@@ -384,12 +395,21 @@ export function CompletionNotificationsProvider({ children }: { children: ReactN
     if (permission !== 'granted') throw new CompletionNotificationError(permission === 'denied' ? 'permission_denied' : 'permission_not_granted');
     const registration = await bounded(navigator.serviceWorker.ready, signal, 'Service worker readiness timed out.', SERVICE_WORKER_READY_TIMEOUT_MS);
     if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+    const vapid = await deadline((requestSignal) => json<{ publicKey: string }>(api.completionNotifications.vapidPublicKey({ signal: requestSignal })), signal);
+    const expectedApplicationServerKey = vapidKey(vapid.publicKey);
+    if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
     let subscription = await bounded(registration.pushManager.getSubscription(), signal, 'Push subscription lookup timed out.');
     if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
+    if (subscription && !applicationServerKeysEqual(
+      subscription.options.applicationServerKey,
+      expectedApplicationServerKey,
+    )) {
+      const removed = await bounded(subscription.unsubscribe(), signal, 'Stale push subscription removal timed out.');
+      if (!removed) throw new CompletionNotificationError('invalid_subscription');
+      subscription = null;
+    }
     if (!subscription) {
-      const vapid = await deadline((requestSignal) => json<{ publicKey: string }>(api.completionNotifications.vapidPublicKey({ signal: requestSignal })), signal);
-      if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
-      subscription = await bounded(registration.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: vapidKey(vapid.publicKey) }), signal, 'Push subscription setup timed out.');
+      subscription = await bounded(registration.pushManager.subscribe({ userVisibleOnly: true, applicationServerKey: expectedApplicationServerKey }), signal, 'Push subscription setup timed out.');
       if (signal.aborted) throw new DOMException('Aborted', 'AbortError');
     }
     return payload(subscription);

--- a/src/components/sidebar/context/CompletionNotificationsContext.tsx
+++ b/src/components/sidebar/context/CompletionNotificationsContext.tsx
@@ -39,10 +39,11 @@ type StoredRecord = {
   target: CompletionNotificationTarget | null;
   pending: boolean;
   error: CompletionNotificationReason | null;
+  deviceRepairRequired: boolean;
 };
 type State = { records: ReadonlyMap<string, StoredRecord>; globalPaused: boolean; device: CompletionNotificationDevice | null };
 type Action =
-  | { type: 'status'; records: ReadonlyMap<string, Pick<StoredRecord, 'item' | 'target'>>; globalPaused: boolean; device: CompletionNotificationDevice; reason: CompletionNotificationReason | null; clearPending?: boolean }
+  | { type: 'status'; records: ReadonlyMap<string, Pick<StoredRecord, 'item' | 'target'>>; globalPaused: boolean; device: CompletionNotificationDevice; reason: CompletionNotificationReason | null; clearPending?: boolean; deviceRepairRequired?: boolean }
   | { type: 'pending'; key: string; pending: boolean }
   | { type: 'error'; key: string; error: CompletionNotificationReason | null }
   | { type: 'remove'; key: string };
@@ -60,7 +61,14 @@ export function completionNotificationReducer(state: State, action: Action): Sta
       const error = action.reason === 'permission_denied' && record.target?.watched !== true
         ? null
         : action.reason;
-      records.set(key, { ...record, pending: action.clearPending ? false : (current?.pending ?? false), error });
+      records.set(key, {
+        ...record,
+        pending: action.clearPending ? false : (current?.pending ?? false),
+        error,
+        deviceRepairRequired: action.deviceRepairRequired === undefined
+          ? (current?.deviceRepairRequired ?? false)
+          : action.deviceRepairRequired && record.target?.watched === true,
+      });
     }
     return { records, globalPaused: action.globalPaused, device: action.device };
   }
@@ -68,7 +76,9 @@ export function completionNotificationReducer(state: State, action: Action): Sta
     records.delete(action.key);
     return { ...state, records };
   }
-  const current = records.get(action.key) ?? { item: null, target: null, pending: false, error: null };
+  const current = records.get(action.key) ?? {
+    item: null, target: null, pending: false, error: null, deviceRepairRequired: false,
+  };
   records.set(action.key, action.type === 'pending'
     ? { ...current, pending: action.pending }
     : { ...current, error: action.error, pending: false });
@@ -196,6 +206,7 @@ export function applicationServerKeysEqual(
   return bytes.byteLength === expected.byteLength
     && bytes.every((value, index) => value === expected[index]);
 }
+
 function mutationId() {
   return typeof crypto.randomUUID === 'function' ? crypto.randomUUID() : `${Date.now()}-${crypto.getRandomValues(new Uint32Array(2)).join('-')}`;
 }
@@ -267,13 +278,16 @@ export function CompletionNotificationsProvider({ children }: { children: ReactN
   }, []);
 
 
-  const passiveEndpoint = useCallback(async (isLive: () => boolean) => {
+  const passiveSubscription = useCallback(async (isLive: () => boolean) => {
     if (!isLive() || !('serviceWorker' in navigator)) return undefined;
     const registration = await navigator.serviceWorker.getRegistration();
     if (!isLive() || !registration) return undefined;
     const subscription = await registration.pushManager.getSubscription();
-    if (!isLive()) return undefined;
-    return subscription?.endpoint;
+    if (!isLive() || !subscription) return undefined;
+    return {
+      endpoint: subscription.endpoint,
+      applicationServerKey: subscription.options.applicationServerKey,
+    };
   }, []);
 
   const requestStatus = useCallback(async (
@@ -322,7 +336,10 @@ export function CompletionNotificationsProvider({ children }: { children: ReactN
       }
     }
     try {
-      const resolvedEndpoint = endpoint ?? await bounded(passiveEndpoint(hasLiveEntry), requestSignal, 'Push subscription lookup timed out.');
+      const localSubscription = endpoint === undefined
+        ? await bounded(passiveSubscription(hasLiveEntry), requestSignal, 'Push subscription lookup timed out.')
+        : undefined;
+      const resolvedEndpoint = endpoint ?? localSubscription?.endpoint;
       if (!entries.some(([key]) => isCurrent(key))) return undefined;
       const result = await deadline((networkSignal) => json<CompletionNotificationStatus>(
         api.completionNotifications.status(entries.map(([, descriptor]) => descriptor), resolvedEndpoint, { signal: networkSignal }),
@@ -334,11 +351,47 @@ export function CompletionNotificationsProvider({ children }: { children: ReactN
         const item = result.targets[index] ?? null;
         records.set(key, { item, target: item?.target ?? null });
       });
+      let hasWatchedTarget = false;
+      for (const record of records.values()) {
+        if (record.target?.watched === true) {
+          hasWatchedTarget = true;
+          break;
+        }
+      }
+      const deviceRequiresRegistration = result.device.setupRequired || !result.device.registered;
+      let deviceRepairRequired: boolean | undefined = hasWatchedTarget && deviceRequiresRegistration
+        ? true
+        : passive && localSubscription && hasWatchedTarget
+          ? undefined
+          : false;
+      if (passive && localSubscription && hasWatchedTarget) {
+        try {
+          const vapid = await deadline((networkSignal) => json<{ publicKey: string }>(
+            api.completionNotifications.vapidPublicKey({ signal: networkSignal }),
+          ), requestSignal);
+          if (!entries.some(([key]) => isCurrent(key))) return undefined;
+          deviceRepairRequired = deviceRepairRequired === true || !applicationServerKeysEqual(
+            localSubscription.applicationServerKey,
+            vapidKey(vapid.publicKey),
+          );
+        } catch {
+          // Status remains useful when a passive VAPID comparison cannot complete.
+          if (!entries.some(([key]) => isCurrent(key))) return undefined;
+        }
+      }
       if (records.size && entries.some(([key]) => isCurrent(key))) {
         const statusReason = reason ?? (typeof Notification !== 'undefined' && Notification.permission === 'denied'
           ? 'permission_denied' as const
           : null);
-        dispatch({ type: 'status', records, globalPaused: result.globalPaused, device: result.device, reason: statusReason, clearPending });
+        dispatch({
+          type: 'status',
+          records,
+          globalPaused: result.globalPaused,
+          device: result.device,
+          reason: statusReason,
+          clearPending,
+          deviceRepairRequired,
+        });
       }
       return { result, records, endpoint: resolvedEndpoint };
     } catch (error) {
@@ -350,7 +403,7 @@ export function CompletionNotificationsProvider({ children }: { children: ReactN
       }
       return undefined;
     }
-  }, [abortPassiveRead, passiveEndpoint]);
+  }, [abortPassiveRead, passiveSubscription]);
   const refresh = useCallback(async () => {
     const entries = uniqueDescriptors(descriptorsRef.current.values());
     for (let index = 0; index < entries.length; index += STATUS_BATCH_LIMIT) {

--- a/src/components/sidebar/types/types.ts
+++ b/src/components/sidebar/types/types.ts
@@ -65,6 +65,8 @@ export type CompletionNotificationDescriptorStatus = {
   globalPaused: boolean;
   pending: boolean;
   error: CompletionNotificationReason | null;
+  /** A passive check found a subscription registered with an obsolete VAPID key. */
+  deviceRepairRequired?: boolean;
 };
 
 export type CompletionNotificationsHookApi = {

--- a/src/components/sidebar/view/subcomponents/SessionCompletionBell.test.tsx
+++ b/src/components/sidebar/view/subcomponents/SessionCompletionBell.test.tsx
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import i18next from 'i18next';
 import { createElement } from 'react';
+import TestRenderer, { act, type ReactTestRenderer } from 'react-test-renderer';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { I18nextProvider } from 'react-i18next';
 
@@ -33,7 +34,7 @@ async function renderBell(overrides: Partial<CompletionNotificationDescriptorSta
   const eligibleItem = item();
   const status: CompletionNotificationDescriptorStatus = {
     item: eligibleItem,
-    target: eligibleItem.mappingState === 'one_active' ? eligibleItem.target : null,
+    target: eligibleItem.mappingState === 'one_active' ? (eligibleItem.target ?? null) : null,
     pending: false,
     error: null,
     globalPaused: false,
@@ -74,7 +75,7 @@ test('SessionCompletionBell uses only slashed-off and plain-on bell states', asy
   const watchedItem = item(true);
   const on = await renderBell({
     item: watchedItem,
-    target: watchedItem.target,
+    target: watchedItem.target ?? null,
     device: { ...device, registered: false, reason: 'endpoint_not_registered' },
     error: 'invalid_subscription',
   });
@@ -82,6 +83,55 @@ test('SessionCompletionBell uses only slashed-off and plain-on bell states', asy
   assert.doesNotMatch(on, /lucide-bell-off|lucide-wrench|animate-spin/);
   assert.equal((on.match(/<button/g) ?? []).length, 1);
   assert.match(on, new RegExp(enSidebar.completionNotifications.disable));
+});
+
+test('SessionCompletionBell exposes and invokes the VAPID repair action without toggling an existing watch', async () => {
+  const watchedItem = item(true);
+  const status: CompletionNotificationDescriptorStatus = {
+    item: watchedItem,
+    target: watchedItem.target ?? null,
+    pending: false,
+    error: null,
+    globalPaused: false,
+    device,
+    deviceRepairRequired: true,
+  };
+  const i18n = i18next.createInstance();
+  await i18n.init({ lng: 'en', resources: { en: { sidebar: enSidebar } }, ns: ['sidebar'], defaultNS: 'sidebar' });
+  const repaired: CompletionNotificationDescriptor[] = [];
+  let renderer: ReactTestRenderer | null = null;
+
+  try {
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(I18nextProvider, { i18n }, createElement(
+        CompletionNotificationsContext.Provider,
+        {
+          value: {
+            status: null,
+            statuses: new Map([[completionNotificationDescriptorKey(descriptor), status]]),
+            registerDescriptors: () => () => {},
+            setWatch: noop,
+            repairDevice: async (selected: CompletionNotificationDescriptor) => { repaired.push(selected); },
+            refresh: noop,
+          } as never,
+        },
+        createElement(SessionCompletionBell, { descriptor }),
+      )));
+    });
+    const repairButton = renderer!.root.findAllByType('button').find(
+      (button) => button.props['aria-label'] === enSidebar.completionNotifications.repair,
+    );
+    assert.ok(repairButton, 'a watched device with a stale key has a dedicated repair action');
+    assert.equal(renderer!.root.findAllByType('button').length, 2, 'repair does not replace the watched-state bell');
+
+    await act(async () => {
+      repairButton!.props.onClick({ preventDefault: () => {}, stopPropagation: () => {} });
+    });
+
+    assert.deepEqual(repaired, [descriptor], 'the explicit action invokes device re-registration for the watched descriptor');
+  } finally {
+    if (renderer) await act(async () => { renderer!.unmount(); });
+  }
 });
 test('SessionCompletionBell shows localized environmental guidance without a repair action', async () => {
   for (const [error, message] of [
@@ -104,7 +154,7 @@ test('SessionCompletionBell announces errors without changing pressed owner inte
     ['settings_changed', enSidebar.completionNotifications.conflict],
   ] as const satisfies readonly (readonly [CompletionNotificationReason, string])[]) {
     const watchedItem = item(true);
-    const html = await renderBell({ error, item: watchedItem, target: watchedItem.target });
+    const html = await renderBell({ error, item: watchedItem, target: watchedItem.target ?? null });
     assert.match(html, new RegExp(message.replace(/[.?]/g, '\\$&')));
     assert.match(html, /role="status" aria-live="polite"/);
     assert.match(html, /aria-pressed="true"/);
@@ -115,7 +165,7 @@ test('SessionCompletionBell composes paused status with concurrent error and pen
   const watchedItem = item(true);
   const pausedWithError = await renderBell({
     item: watchedItem,
-    target: watchedItem.target,
+    target: watchedItem.target ?? null,
     globalPaused: true,
     error: 'settings_changed',
   });
@@ -136,7 +186,7 @@ test('SessionCompletionBell keeps its two-state icon while a mutation is pending
   const watchedItem = item(true);
   const on = await renderBell({
     item: watchedItem,
-    target: watchedItem.target,
+    target: watchedItem.target ?? null,
     pending: true,
   });
   assert.match(on, /lucide-bell h-3\.5 w-3\.5/);
@@ -147,7 +197,7 @@ test('SessionCompletionBell retains keyboard semantics and 44px touch targets', 
   const watchedItem = item(true);
   const html = await renderBell({
     item: watchedItem,
-    target: watchedItem.target,
+    target: watchedItem.target ?? null,
     device: { ...device, registered: false, reason: 'endpoint_not_registered' },
   });
   assert.match(html, /type="button"/);

--- a/src/components/sidebar/view/subcomponents/SessionCompletionBell.tsx
+++ b/src/components/sidebar/view/subcomponents/SessionCompletionBell.tsx
@@ -1,4 +1,4 @@
-import { Bell, BellOff } from 'lucide-react';
+import { Bell, BellOff, Wrench } from 'lucide-react';
 import { type MouseEvent, useId } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -71,7 +71,7 @@ const ENVIRONMENTAL_REASONS: readonly CompletionNotificationReason[] = [
 export default function SessionCompletionBell({ descriptor, className }: SessionCompletionBellProps) {
   const { t } = useTranslation('sidebar');
   const statusId = useId();
-  const { status, setWatch } = useCompletionNotifications(descriptor);
+  const { status, setWatch, repairDevice } = useCompletionNotifications(descriptor);
 
   // Do not flash a speculative control: only an authoritative, eligible target
   // can be watched. This also keeps stale/ambiguous external generations inert.
@@ -81,16 +81,21 @@ export default function SessionCompletionBell({ descriptor, className }: Session
   const pending = status.pending;
   const paused = status.globalPaused;
   const reason = status.error as CompletionNotificationReason | null;
+  const repairRequired = status.deviceRepairRequired === true;
   const reasonLabel = reason
     ? t(REASON_LABELS[reason].key, REASON_LABELS[reason].defaultValue)
     : null;
+  const repairLabel = t(
+    'completionNotifications.repair',
+    'Repair notifications when the assistant has a reply ready on this device',
+  );
   const watchLabel = watched
     ? t('completionNotifications.disable', 'Disable completion notifications for this session')
     : t('completionNotifications.enable', 'Enable completion notifications for this session');
   const statusText = [
     pending ? t('completionNotifications.pending', 'Updating completion notifications') : null,
     paused ? t('completionNotifications.paused', 'Completion notifications are paused globally') : null,
-    reasonLabel,
+    repairRequired ? repairLabel : reasonLabel,
   ].filter((text): text is string => text !== null).join(' ') || null;
   const Icon = watched ? Bell : BellOff;
 
@@ -98,15 +103,16 @@ export default function SessionCompletionBell({ descriptor, className }: Session
     event.preventDefault();
     event.stopPropagation();
   };
-
   const environmentalReason = reason !== null && ENVIRONMENTAL_REASONS.includes(reason);
+
+  const statusRequiresAction = environmentalReason || repairRequired;
 
   return (
     <span className={cn('flex shrink-0 items-center gap-1', className)}>
       {statusText && (
         <span
           id={statusId}
-          className={environmentalReason ? 'max-w-48 text-xs text-destructive' : 'sr-only'}
+          className={statusRequiresAction ? 'max-w-48 text-xs text-destructive' : 'sr-only'}
           role="status"
           aria-live="polite"
         >
@@ -132,6 +138,22 @@ export default function SessionCompletionBell({ descriptor, className }: Session
       >
         <Icon className="h-3.5 w-3.5" aria-hidden />
       </button>
+      {repairRequired && (
+        <button
+          type="button"
+          title={repairLabel}
+          aria-label={repairLabel}
+          aria-describedby={statusText ? statusId : undefined}
+          disabled={pending}
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded text-destructive transition-colors hover:bg-destructive/10 hover:text-destructive focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-not-allowed disabled:opacity-50 md:h-6 md:w-6"
+          onClick={(event) => {
+            stopRowNavigation(event);
+            if (!pending) void repairDevice(descriptor);
+          }}
+        >
+          <Wrench className="h-3.5 w-3.5" aria-hidden />
+        </button>
+      )}
     </span>
   );
 }


### PR DESCRIPTION
## 배경

기존 tmux 라이브 알림은 주로 답변 완료(RUN → READY)에 맞춰져 있어, 에이전트가 승인·선택·직접 입력을 기다리는 `INPUT` 상태로 전환되어도 Web Push 알림이 오지 않았습니다. 사용자가 ChatMux를 보고 있지 않을 때는 작업이 멈춘 사실을 늦게 알게 되는 문제가 있었습니다.

또한 기존 PushSubscription이 현재 서버의 VAPID 공개키와 달라진 경우, 브라우저 권한과 ChatMux 설정이 모두 켜져 있어도 알림이 전달되지 않을 수 있었습니다. 기본 VAPID subject의 `.local` mailto 주소도 일부 Push 서비스와 호환성이 좋지 않았습니다.

## 변경 내용

### 1. RUN → INPUT 알림

- `action_required / input.required` 알림 이벤트를 추가했습니다.
- Claude Code, Codex, Oh My Pi 등 외부 tmux 에이전트는 transcript activity가 `running`에서 `asking_user`로 바뀔 때 알림을 보냅니다.
- GJC는 transcript에 새로 기록된 `ask` 계열 tool call을 감지해 알림을 보냅니다.
- transcript에 충분한 상태가 없는 TUI 승인창도 tmux 화면의 INPUT 전환 감지 결과를 같은 알림 경로로 전달합니다.
- 화면 감지와 transcript 감지가 동시에 같은 요청을 발견해도 기존 짧은 dedupe window를 통해 한 번만 전송됩니다.

### 2. 기존 알림 정책과 세션 매핑 유지

- 현재 completion target resolver를 그대로 사용해 tmux 실행 세대와 앱 대화 매핑을 따릅니다.
- 해당 세션의 종(bell)이 켜진 경우에만 알림을 보냅니다.
- 전역 `actionRequired` 및 Web Push 설정도 기존과 동일하게 적용됩니다.
- 서버 시작 시 이미 INPUT인 transcript 기록은 재전송하지 않고 기준점으로만 사용합니다.
- INPUT 알림 전송 실패가 상태 판정이나 완료 알림 outbox를 막지 않도록 best-effort 경로로 분리했습니다.
- DB 스키마나 기존 RUN → READY 완료 알림 outbox는 변경하지 않았습니다.

### 3. VAPID/PushSubscription 복구

- 기본 VAPID subject를 유효한 HTTPS URI로 변경했습니다.
- `VAPID_SUBJECT` 환경변수로 운영자가 subject를 덮어쓸 수 있으며 `.env.example`에 사용법을 추가했습니다.
- 브라우저의 기존 PushSubscription 공개키와 서버 공개키를 비교합니다.
- 키가 다르면 오래된 subscription을 해제하고 현재 키로 자동 재등록합니다.
- typed-array view의 offset/length도 정확히 비교하도록 처리했습니다.

## 사용자 동작

1. tmux 에이전트가 RUN 상태로 작업합니다.
2. 승인, 선택지 또는 직접 입력이 필요해 INPUT 상태가 됩니다.
3. 해당 세션의 종이 켜져 있으면 `Input required` Web Push 알림이 한 번 도착합니다.
4. 사용자가 답변해 다시 RUN으로 전환한 뒤 새로운 INPUT 요청이 생기면 다시 알림이 옵니다.

## 검증

- 관련 단위 테스트 48개 통과
  - 외부 에이전트 RUN → INPUT 전환 및 반복 억제
  - 세션 watch 해제 시 미전송
  - GJC 과거 prompt baseline 및 신규 ask 감지
  - tmux 화면 기반 INPUT edge와 중복 억제
  - 알림 payload/session 정규화
  - VAPID application server key 비교 및 stale subscription 판정
- `npm run typecheck` 통과
- `npm run lint` 통과
- `npm run build` 통과
  - client
  - server
  - Rust core release build
- 로컬 release 설치본에서 iPhone Web Push 수신과 서버 health를 확인했습니다.
