### PR TITLE
fix(relay): make Claude transcript asks reachable and honest

### DIFF
--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -133,7 +133,7 @@ async function loadPendingTmuxAsk(
   sessionIdValue: unknown,
   toolIdValue: unknown,
 ): Promise<PendingTmuxAsk> {
-  if (target.kind !== 'gjc' && target.kind !== 'codex' && target.kind !== 'omp') {
+  if (target.kind !== 'gjc' && target.kind !== 'codex' && target.kind !== 'omp' && target.kind !== 'claude') {
     throw new AppError('This CLI does not support transcript selections.', {
       code: 'TMUX_ASK_UNSUPPORTED',
       statusCode: 400,

--- a/src/components/chat/utils/pendingRelayAsk.test.ts
+++ b/src/components/chat/utils/pendingRelayAsk.test.ts
@@ -36,3 +36,15 @@ test('findPendingRelayAsk exposes the newest unanswered choice range', () => {
     },
   }]), null);
 });
+
+test('findPendingRelayAsk rejects multi-question asks so the screen-derived prompt stays active', () => {
+  assert.equal(findPendingRelayAsk([{
+    ...pending,
+    toolInput: {
+      questions: [
+        { question: 'Format?', options: [{ label: 'ONNX' }, { label: 'TensorRT' }] },
+        { question: 'Precision?', options: [{ label: 'FP16' }, { label: 'INT8' }] },
+      ],
+    },
+  }]), null);
+});

--- a/src/components/chat/utils/pendingRelayAsk.ts
+++ b/src/components/chat/utils/pendingRelayAsk.ts
@@ -15,9 +15,13 @@ function parseInput(value: unknown): unknown {
 }
 
 /**
- * Returns only the newest unanswered, single-select transcript question.
- * The server repeats these checks against persisted history and the active
- * native TUI before it sends any selector key.
+ * Returns only the newest unanswered, single-select transcript question, and
+ * only when the ask carries exactly one question. Multi-question asks lose
+ * the active-question identity in this summary, so they stay on the
+ * screen-derived interactive prompt, which always shows the question the
+ * native TUI is currently asking. The server repeats these checks against
+ * persisted history and the active native TUI before it sends any selector
+ * key.
  */
 export function findPendingRelayAsk(messages: readonly ChatMessage[]): PendingRelayAsk | null {
   for (let index = messages.length - 1; index >= 0; index -= 1) {
@@ -28,7 +32,7 @@ export function findPendingRelayAsk(messages: readonly ChatMessage[]): PendingRe
     const questions = input && typeof input === 'object' && !Array.isArray(input)
       ? (input as { questions?: unknown }).questions
       : null;
-    if (!Array.isArray(questions) || questions.length === 0) return null;
+    if (!Array.isArray(questions) || questions.length !== 1) return null;
     let maxChoiceNumber = 0;
     for (const rawQuestion of questions) {
       if (!rawQuestion || typeof rawQuestion !== 'object' || Array.isArray(rawQuestion)) return null;

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -352,7 +352,7 @@ function ChatInterface({
   const hasActivityIndicator = Boolean(sessionActivity && pendingPermissionRequests.length === 0);
   const pendingRelayAsk = useMemo(() => (
     isSessionReadOnly
-    && (liveSessionKind === 'gjc' || liveSessionKind === 'codex' || liveSessionKind === 'omp')
+    && (liveSessionKind === 'gjc' || liveSessionKind === 'codex' || liveSessionKind === 'omp' || liveSessionKind === 'claude')
       ? findPendingRelayAsk(chatMessages)
       : null
   ), [chatMessages, isSessionReadOnly, liveSessionKind]);

--- a/src/components/chat/view/subcomponents/LiveRelayComposer.test.tsx
+++ b/src/components/chat/view/subcomponents/LiveRelayComposer.test.tsx
@@ -157,6 +157,7 @@ test('relay translations exist in every supported locale', () => {
       'utf8',
     )) as { relay?: Record<string, string> };
     assert.deepEqual(Object.keys(translation.relay ?? {}).sort(), [
+      'claudeMultiSelectUnsupported',
       'currentSession',
       'customInputPlaceholder',
       'customInputReady',

--- a/src/components/chat/view/subcomponents/LiveRelayComposer.tsx
+++ b/src/components/chat/view/subcomponents/LiveRelayComposer.tsx
@@ -571,6 +571,23 @@ export default function LiveRelayComposer({
           });
           return;
         }
+        // The server intentionally rejects Claude multi-select toggling until
+        // the real key sequence is verified (TMUX_INTERACTIVE_CHOICE_UNSUPPORTED);
+        // only cancel (0) is deliverable. Surface that up front instead of
+        // letting every submission round-trip into a 400.
+        if (
+          relayKind === 'claude'
+          && interactivePrompt?.multiSelect
+          && !(interactiveNumbers.length === 1 && interactiveNumbers[0] === 0)
+        ) {
+          setStatus({
+            kind: 'error',
+            text: t('relay.claudeMultiSelectUnsupported', {
+              defaultValue: 'Claude multi-select answers must be made in the terminal. Enter 0 to cancel the prompt.',
+            }),
+          });
+          return;
+        }
       }
       if (interactivePrompt && isAwaitingInteractiveCustom) {
         response = relayKind === 'gjc'

--- a/src/i18n/locales/de/chat.json
+++ b/src/i18n/locales/de/chat.json
@@ -236,6 +236,7 @@
     "sendFailed": "Senden fehlgeschlagen",
     "selectionNumberRequired": "Geben Sie eine angezeigte Nummer ein (0-{{max}}).",
     "multiSelectionNumberRequired": "Geben Sie eine oder mehrere angezeigte Nummern durch Kommas getrennt ein.",
+    "claudeMultiSelectUnsupported": "Claude-Mehrfachauswahlen müssen im Terminal beantwortet werden. Geben Sie 0 ein, um die Eingabeaufforderung abzubrechen.",
     "customInputReady": "Geben Sie die eigene Antwort ein.",
     "selectionDelivered": "Auswahl übermittelt.",
     "selectionPlaceholder": "Auswahlnummer eingeben (0-{{max}})…",

--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -250,6 +250,7 @@
     "sendFailed": "Failed to send",
     "selectionNumberRequired": "Enter a displayed number (0-{{max}}).",
     "multiSelectionNumberRequired": "Enter one or more displayed numbers separated by commas.",
+    "claudeMultiSelectUnsupported": "Claude multi-select answers must be made in the terminal. Enter 0 to cancel the prompt.",
     "customInputReady": "Type the custom answer.",
     "selectionDelivered": "Selection delivered.",
     "selectionPlaceholder": "Enter a choice number (0-{{max}})…",

--- a/src/i18n/locales/fr/chat.json
+++ b/src/i18n/locales/fr/chat.json
@@ -238,6 +238,7 @@
     "sendFailed": "Échec de l'envoi",
     "selectionNumberRequired": "Saisissez un numéro affiché (0-{{max}}).",
     "multiSelectionNumberRequired": "Saisissez un ou plusieurs numéros affichés, séparés par des virgules.",
+    "claudeMultiSelectUnsupported": "Les sélections multiples de Claude doivent être effectuées dans le terminal. Saisissez 0 pour annuler l'invite.",
     "customInputReady": "Saisissez la réponse personnalisée.",
     "selectionDelivered": "Sélection transmise.",
     "selectionPlaceholder": "Numéro du choix (0-{{max}})…",

--- a/src/i18n/locales/it/chat.json
+++ b/src/i18n/locales/it/chat.json
@@ -236,6 +236,7 @@
     "sendFailed": "Invio non riuscito",
     "selectionNumberRequired": "Inserisci un numero visualizzato (0-{{max}}).",
     "multiSelectionNumberRequired": "Inserisci uno o più numeri visualizzati separati da virgole.",
+    "claudeMultiSelectUnsupported": "Le selezioni multiple di Claude devono essere effettuate nel terminale. Inserisci 0 per annullare il prompt.",
     "customInputReady": "Digita la risposta personalizzata.",
     "selectionDelivered": "Selezione inviata.",
     "selectionPlaceholder": "Inserisci il numero della scelta (0-{{max}})…",

--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -226,6 +226,7 @@
     "sendFailed": "送信に失敗しました",
     "selectionNumberRequired": "表示された番号を入力してください (0-{{max}})。",
     "multiSelectionNumberRequired": "カンマ区切りで表示された番号を1つ以上入力してください。",
+    "claudeMultiSelectUnsupported": "Claude の複数選択はターミナルで直接回答してください。0 を入力するとプロンプトをキャンセルします。",
     "customInputReady": "自由回答を入力してください。",
     "selectionDelivered": "選択を送信しました。",
     "selectionPlaceholder": "選択番号を入力 (0-{{max}})…",

--- a/src/i18n/locales/ko/chat.json
+++ b/src/i18n/locales/ko/chat.json
@@ -237,6 +237,7 @@
     "sendFailed": "전송 실패",
     "selectionNumberRequired": "표시된 번호를 입력하세요 (0-{{max}}).",
     "multiSelectionNumberRequired": "쉼표로 구분한 표시 번호를 하나 이상 입력하세요.",
+    "claudeMultiSelectUnsupported": "Claude 다중 선택은 터미널에서 직접 답해야 합니다. 0을 입력하면 프롬프트를 취소합니다.",
     "customInputReady": "직접 입력할 답변을 작성하세요.",
     "selectionDelivered": "선택을 전달했습니다.",
     "selectionPlaceholder": "선택 번호 입력 (0-{{max}})…",

--- a/src/i18n/locales/ru/chat.json
+++ b/src/i18n/locales/ru/chat.json
@@ -236,6 +236,7 @@
     "sendFailed": "Не удалось отправить",
     "selectionNumberRequired": "Введите отображаемый номер (0-{{max}}).",
     "multiSelectionNumberRequired": "Введите один или несколько отображаемых номеров через запятую.",
+    "claudeMultiSelectUnsupported": "Множественный выбор Claude нужно выполнять в терминале. Введите 0, чтобы отменить запрос.",
     "customInputReady": "Введите свой ответ.",
     "selectionDelivered": "Выбор отправлен.",
     "selectionPlaceholder": "Введите номер варианта (0-{{max}})…",

--- a/src/i18n/locales/tr/chat.json
+++ b/src/i18n/locales/tr/chat.json
@@ -236,6 +236,7 @@
     "sendFailed": "Gönderilemedi",
     "selectionNumberRequired": "Görüntülenen bir numara girin (0-{{max}}).",
     "multiSelectionNumberRequired": "Virgülle ayrılmış bir veya daha fazla görüntülenen numara girin.",
+    "claudeMultiSelectUnsupported": "Claude çoklu seçim yanıtları terminalde yapılmalıdır. İstemi iptal etmek için 0 girin.",
     "customInputReady": "Özel yanıtı yazın.",
     "selectionDelivered": "Seçim iletildi.",
     "selectionPlaceholder": "Seçim numarası girin (0-{{max}})…",

--- a/src/i18n/locales/zh-CN/chat.json
+++ b/src/i18n/locales/zh-CN/chat.json
@@ -236,6 +236,7 @@
     "sendFailed": "发送失败",
     "selectionNumberRequired": "请输入显示的编号 (0-{{max}})。",
     "multiSelectionNumberRequired": "请输入一个或多个显示的编号，用逗号分隔。",
+    "claudeMultiSelectUnsupported": "Claude 多选需要在终端中直接回答。输入 0 可取消该提示。",
     "customInputReady": "请输入自定义回答。",
     "selectionDelivered": "已发送选择。",
     "selectionPlaceholder": "输入选项编号 (0-{{max}})…",

--- a/src/i18n/locales/zh-TW/chat.json
+++ b/src/i18n/locales/zh-TW/chat.json
@@ -272,6 +272,7 @@
     "sendFailed": "傳送失敗",
     "selectionNumberRequired": "請輸入顯示的編號 (0-{{max}})。",
     "multiSelectionNumberRequired": "請輸入一個或多個顯示的編號，以逗號分隔。",
+    "claudeMultiSelectUnsupported": "Claude 多選需要在終端機中直接回答。輸入 0 可取消該提示。",
     "customInputReady": "請輸入自訂回答。",
     "selectionDelivered": "已送出選擇。",
     "selectionPlaceholder": "輸入選項編號 (0-{{max}})…",


### PR DESCRIPTION
Fixes three related defects in the Claude ask path found by the post-v1.7.0 review (HIGH #2/#3/#4). Ordered so the gate only opens after the correctness fix.

## 1. Multi-question asks no longer produce a chat card (#4)
`findPendingRelayAsk` collapsed multiple questions into a single max-choice number, losing which question the TUI is currently showing. A displayed "Q1" card could deliver its answer to Q2 after the TUI advanced. It now returns `null` unless the ask carries exactly one question; multi-question asks fall back to the screen-derived interactive prompt, which always shows the active question.

## 2. Claude enabled in both transcript-ask gates (#2)
The v1.7.0 Claude transcript-choice implementation (parsing + key dispatch in `tmux-ask-selection.service.ts`) was unreachable: `loadPendingTmuxAsk` (server) and the `pendingRelayAsk` memo (client) both rejected `claude`. Both gates now include it.

## 3. Claude multi-select numeric submission blocked client-side (#3)
The server intentionally rejects Claude multi-select toggling (`TMUX_INTERACTIVE_CHOICE_UNSUPPORTED`) until the real key sequence is verified, but the composer still accepted comma-separated numbers — every submission round-tripped into a 400. The composer now surfaces a clear message up front (cancel `0` still allowed, matching the server's Escape path). New `relay.claudeMultiSelectUnsupported` key added to all 11 locales.

## Tests
- New: multi-question ask returns `null` (regression for #4).
- Locale contract test updated for the new key; all 11 locales carry it.
- `pendingRelayAsk` + `LiveRelayComposer` 15/15, `provider-routes-contract` + `tmux-ask-selection` 26/26, both typecheck projects clean.