### PR TITLE
feat(chat): answer ask prompts by tapping choices

### DIFF
--- a/src/components/chat/tools/ToolRenderer.tsx
+++ b/src/components/chat/tools/ToolRenderer.tsx
@@ -28,6 +28,7 @@ interface ToolRendererProps {
   rawToolInput?: string;
   isSubagentContainer?: boolean;
   pendingAsk?: boolean;
+  onAskChoiceSelect?: (choiceNumber: number) => void;
   subagentState?: {
     childTools: SubagentChildTool[];
     currentToolIndex: number;
@@ -85,6 +86,7 @@ export const ToolRenderer: React.FC<ToolRendererProps> = memo(({
   isSubagentContainer,
   subagentState,
   pendingAsk = false,
+  onAskChoiceSelect,
 }) => {
   const config = getToolConfig(toolName);
   const displayConfig: any = mode === 'input' ? config.input : config.result;
@@ -274,6 +276,7 @@ export const ToolRenderer: React.FC<ToolRendererProps> = memo(({
             questions={contentProps.questions || []}
             answers={contentProps.answers || {}}
             pending={pendingAsk}
+            onSelectChoice={pendingAsk ? onAskChoiceSelect : undefined}
           />
         );
         break;

--- a/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.test.tsx
+++ b/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.test.tsx
@@ -94,6 +94,40 @@ test('pending transcript question renders numbered choices, direct input, and ca
   assert.ok(!html.includes('Skipped'));
 });
 
+test('pending single-select choices become buttons only when a choice handler is provided', () => {
+  const withHandler = renderToStaticMarkup(
+    React.createElement(QuestionAnswerContent, {
+      questions: [{ question: 'Pick one?', options: [{ label: 'Allow' }, { label: 'Reject' }] }],
+      answers: {},
+      pending: true,
+      onSelectChoice: () => {},
+    }),
+  );
+  // Option rows, the direct-input row, and the cancel affordance are all tappable.
+  assert.ok((withHandler.match(/<button type="button"/g) ?? []).length >= 4);
+  assert.ok(withHandler.includes('Cancel (0)'));
+
+  const withoutHandler = renderToStaticMarkup(
+    React.createElement(QuestionAnswerContent, {
+      questions: [{ question: 'Pick one?', options: [{ label: 'Allow' }, { label: 'Reject' }] }],
+      answers: {},
+      pending: true,
+    }),
+  );
+  assert.ok(!withoutHandler.includes('Cancel (0)'));
+
+  const multiSelect = renderToStaticMarkup(
+    React.createElement(QuestionAnswerContent, {
+      questions: [{ question: 'Pick many?', options: [{ label: 'A' }, { label: 'B' }], multiSelect: true }],
+      answers: {},
+      pending: true,
+      onSelectChoice: () => {},
+    }),
+  );
+  // Multi-select stays typed: no tappable option rows, no cancel button.
+  assert.ok(!multiSelect.includes('Cancel (0)'));
+});
+
 test('a provider-native custom option does not add a second direct-input row', () => {
   const html = renderToStaticMarkup(
     React.createElement(QuestionAnswerContent, {

--- a/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.tsx
+++ b/src/components/chat/tools/components/ContentRenderers/QuestionAnswerContent.tsx
@@ -10,6 +10,11 @@ interface QuestionAnswerContentProps {
   pending?: boolean;
   allowDirectInput?: boolean;
   directInputNumber?: number;
+  /**
+   * When set (pending, single-select only), option and direct-input rows
+   * become tap targets that submit the displayed choice number directly.
+   */
+  onSelectChoice?: (choiceNumber: number) => void;
 }
 
 // Exception to the stateless ContentRenderer pattern: multi-question navigation requires local state.
@@ -20,6 +25,7 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
   pending = false,
   allowDirectInput = true,
   directInputNumber,
+  onSelectChoice,
 }) => {
   const { t } = useTranslation('chat');
   const [expandedIdx, setExpandedIdx] = useState<number | null>(pending ? 0 : null);
@@ -141,13 +147,22 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
                 <div className="ml-6.5 space-y-1">
                   {options.map((opt, optionIndex) => {
                     const wasSelected = answerLabels.includes(opt.label);
+                    const clickable = pending && !q.multiSelect && Boolean(onSelectChoice);
+                    const RowTag = clickable ? 'button' : 'div';
                     return (
-                      <div
+                      <RowTag
                         key={opt.label}
+                        {...(clickable
+                          ? { type: 'button' as const, onClick: () => onSelectChoice?.(optionIndex + 1) }
+                          : {})}
                         className={`flex items-start gap-2 rounded-lg px-2.5 py-1.5 text-[12px] ${
+                          clickable
+                            ? 'w-full cursor-pointer text-left text-gray-600 transition-colors hover:bg-blue-50 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-blue-900/20 dark:hover:text-gray-100'
+                            : ''
+                        } ${
                           wasSelected
                             ? 'border border-blue-200/60 bg-blue-50/80 dark:border-blue-800/40 dark:bg-blue-900/20'
-                            : 'text-gray-400 dark:text-gray-500'
+                            : clickable ? '' : 'text-gray-400 dark:text-gray-500'
                         }`}
                       >
                         {pending && (
@@ -178,18 +193,32 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
                             </span>
                           )}
                         </div>
-                      </div>
+                      </RowTag>
                     );
                   })}
 
                   {pending && allowDirectInput && (directInputNumber ?? options.length + 1) > options.length && (
-                    <div className="flex items-start gap-2 rounded-lg border border-dashed border-blue-300/70 px-2.5 py-1.5 text-[12px] text-blue-700 dark:border-blue-700/60 dark:text-blue-300">
-                      <span className="w-4 flex-shrink-0 pt-0.5 text-right font-mono text-[11px] font-semibold">
-                        {directInputNumber ?? options.length + 1}.
-                      </span>
-                      <div className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 rounded-full border-[1.5px] border-blue-300 dark:border-blue-700" />
-                      <span>{t('interactive.directInput', { defaultValue: 'Direct input (Other)' })}</span>
-                    </div>
+                    onSelectChoice && !q.multiSelect ? (
+                      <button
+                        type="button"
+                        onClick={() => onSelectChoice(directInputNumber ?? options.length + 1)}
+                        className="flex w-full cursor-pointer items-start gap-2 rounded-lg border border-dashed border-blue-300/70 px-2.5 py-1.5 text-left text-[12px] text-blue-700 transition-colors hover:bg-blue-50 dark:border-blue-700/60 dark:text-blue-300 dark:hover:bg-blue-900/20"
+                      >
+                        <span className="w-4 flex-shrink-0 pt-0.5 text-right font-mono text-[11px] font-semibold">
+                          {directInputNumber ?? options.length + 1}.
+                        </span>
+                        <div className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 rounded-full border-[1.5px] border-blue-300 dark:border-blue-700" />
+                        <span>{t('interactive.directInput', { defaultValue: 'Direct input (Other)' })}</span>
+                      </button>
+                    ) : (
+                      <div className="flex items-start gap-2 rounded-lg border border-dashed border-blue-300/70 px-2.5 py-1.5 text-[12px] text-blue-700 dark:border-blue-700/60 dark:text-blue-300">
+                        <span className="w-4 flex-shrink-0 pt-0.5 text-right font-mono text-[11px] font-semibold">
+                          {directInputNumber ?? options.length + 1}.
+                        </span>
+                        <div className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 rounded-full border-[1.5px] border-blue-300 dark:border-blue-700" />
+                        <span>{t('interactive.directInput', { defaultValue: 'Direct input (Other)' })}</span>
+                      </div>
+                    )
                   )}
 
                   {answerLabels.filter(lbl => !options.some(o => o.label === lbl)).map(lbl => (
@@ -222,7 +251,8 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
       })}
 
       {pending && (
-        <div className="rounded-md bg-blue-50 px-2.5 py-1.5 text-[11px] text-blue-700 dark:bg-blue-950/30 dark:text-blue-300">
+        <div className="flex items-center justify-between gap-2 rounded-md bg-blue-50 px-2.5 py-1.5 text-[11px] text-blue-700 dark:bg-blue-950/30 dark:text-blue-300">
+          <span>
           {questions.some((question) => question?.multiSelect)
             ? t('interactive.multiNumberInstruction', {
                 defaultValue: 'Send one or more numbers separated by commas · 0: cancel',
@@ -239,6 +269,16 @@ export const QuestionAnswerContent: React.FC<QuestionAnswerContentProps> = ({
               : t('interactive.numberInstructionNoCustom', {
                   defaultValue: 'Send the displayed number in chat · 0: cancel',
                 })}
+          </span>
+          {onSelectChoice && !questions.some((question) => question?.multiSelect) && (
+            <button
+              type="button"
+              onClick={() => onSelectChoice(0)}
+              className="flex-shrink-0 cursor-pointer rounded border border-blue-200/80 px-1.5 py-0.5 font-medium transition-colors hover:bg-blue-100 dark:border-blue-800/60 dark:hover:bg-blue-900/40"
+            >
+              {t('interactive.cancelChoice', { defaultValue: 'Cancel (0)' })}
+            </button>
+          )}
         </div>
       )}
 

--- a/src/components/chat/view/ChatInterface.tsx
+++ b/src/components/chat/view/ChatInterface.tsx
@@ -357,6 +357,14 @@ function ChatInterface({
       : null
   ), [chatMessages, isSessionReadOnly, liveSessionKind]);
 
+  // Bridges transcript-rendered ask cards to the relay composer: the composer
+  // registers its choice submitter here, and tapped choices reuse the same
+  // validated relay path as typed numbers.
+  const askChoiceSubmitRef = useRef<((choiceNumber: number) => void) | null>(null);
+  const handleAskChoiceSelect = useCallback((choiceNumber: number) => {
+    askChoiceSubmitRef.current?.(choiceNumber);
+  }, []);
+
   if (!selectedProject) {
     const selectedProviderLabel =
       provider === 'cursor'
@@ -434,6 +442,7 @@ function ChatInterface({
           selectedProject={selectedProject}
           transcriptView={Boolean(liveSessionKind && liveSessionKind !== 'gjc')}
           pendingAskToolId={pendingRelayAsk?.toolId ?? null}
+          onAskChoiceSelect={handleAskChoiceSelect}
         />
 
         <div className="relative flex-shrink-0">
@@ -473,6 +482,7 @@ function ChatInterface({
                 isProcessing={liveSessionProcessing}
                 transcriptSessionId={selectedSession?.id ?? null}
                 pendingAsk={pendingRelayAsk}
+                choiceSubmitRef={askChoiceSubmitRef}
               />
             ) : (
               <div className="chat-composer-shell relative flex-shrink-0 px-2 pb-3 pt-2 sm:px-4">

--- a/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
+++ b/src/components/chat/view/subcomponents/ChatMessagesPane.tsx
@@ -65,6 +65,7 @@ interface ChatMessagesPaneProps {
   selectedProject: Project;
   transcriptView?: boolean;
   pendingAskToolId?: string | null;
+  onAskChoiceSelect?: (choiceNumber: number) => void;
 }
 
 function ChatMessagesPane({
@@ -113,6 +114,7 @@ function ChatMessagesPane({
   selectedProject,
   transcriptView = false,
   pendingAskToolId = null,
+  onAskChoiceSelect,
 }: ChatMessagesPaneProps) {
   const { t } = useTranslation('chat');
   const groupedVisibleMessages = useMemo(
@@ -265,6 +267,7 @@ function ChatMessagesPane({
                     provider={provider}
                     transcriptView={transcriptView}
                     pendingAskToolId={pendingAskToolId}
+                    onAskChoiceSelect={onAskChoiceSelect}
                   />
                 );
               }
@@ -287,6 +290,7 @@ function ChatMessagesPane({
                   provider={provider}
                   transcriptView={transcriptView}
                   pendingAskToolId={pendingAskToolId}
+                  onAskChoiceSelect={onAskChoiceSelect}
                 />
               );
             });

--- a/src/components/chat/view/subcomponents/LiveRelayComposer.tsx
+++ b/src/components/chat/view/subcomponents/LiveRelayComposer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { ClipboardEvent, DragEvent, FormEvent, KeyboardEvent, MouseEvent } from 'react';
+import type { ClipboardEvent, DragEvent, FormEvent, KeyboardEvent, MouseEvent, MutableRefObject } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { api } from '../../../../utils/api';
@@ -85,6 +85,7 @@ export default function LiveRelayComposer({
   isProcessing = false,
   transcriptSessionId = null,
   pendingAsk = null,
+  choiceSubmitRef,
 }: {
   target: TmuxPaneTarget;
   model?: string | null;
@@ -96,6 +97,12 @@ export default function LiveRelayComposer({
   isProcessing?: boolean;
   transcriptSessionId?: string | null;
   pendingAsk?: PendingRelayAsk | null;
+  /**
+   * Receives the composer's choice submitter so transcript-rendered ask cards
+   * (which live outside this component) can deliver a tapped choice number
+   * through the same validated relay path as typed answers.
+   */
+  choiceSubmitRef?: MutableRefObject<((choiceNumber: number) => void) | null>;
 }) {
   const commandTrigger = relayKind === 'codex' ? '$' : '/';
   const { t } = useTranslation('chat');
@@ -512,8 +519,8 @@ export default function LiveRelayComposer({
     }
   }, []);
 
-  const send = useCallback(async () => {
-    const message = input.trim();
+  const send = useCallback(async (overrideMessage?: string) => {
+    const message = (overrideMessage ?? input).trim();
     if (!message || status.kind === 'sending') {
       return;
     }
@@ -702,7 +709,8 @@ export default function LiveRelayComposer({
         });
         return;
       }
-      setInput('');
+      // A tapped choice must not discard an unrelated typed draft.
+      if (overrideMessage === undefined) setInput('');
       if (interactiveRoute && interactivePrompt && !isAwaitingInteractiveCustom && data.action === 'other') {
         setCustomInputPromptId(interactivePrompt.id);
         setStatus({
@@ -743,6 +751,17 @@ export default function LiveRelayComposer({
     relayKind,
     t,
   ]);
+
+  // Expose the choice submitter to the transcript-rendered pending ask card.
+  useEffect(() => {
+    if (!choiceSubmitRef) return undefined;
+    choiceSubmitRef.current = (choiceNumber: number) => {
+      void send(String(choiceNumber));
+    };
+    return () => {
+      choiceSubmitRef.current = null;
+    };
+  }, [choiceSubmitRef, send]);
   const interrupt = useCallback(async () => {
     if (!canInterrupt || isInterrupting) {
       return;
@@ -873,6 +892,9 @@ export default function LiveRelayComposer({
               pending
               allowDirectInput={interactivePrompt.customOptionNumber !== null}
               directInputNumber={interactivePrompt.customOptionNumber ?? undefined}
+              onSelectChoice={interactivePrompt.multiSelect
+                ? undefined
+                : (choiceNumber) => { void send(String(choiceNumber)); }}
             />
           </div>
         )}

--- a/src/components/chat/view/subcomponents/MessageComponent.tsx
+++ b/src/components/chat/view/subcomponents/MessageComponent.tsx
@@ -36,6 +36,7 @@ type MessageComponentProps = {
   provider: Provider | string;
   transcriptView?: boolean;
   pendingAskToolId?: string | null;
+  onAskChoiceSelect?: (choiceNumber: number) => void;
 };
 
 type InteractiveOption = {
@@ -50,7 +51,7 @@ const compactErrorSummary = (content: string, fallback: string): string => {
   return firstLine.length > 160 ? `${firstLine.slice(0, 157)}...` : firstLine;
 };
 
-const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, showRawParameters, showThinking, selectedProject, provider, transcriptView = false, pendingAskToolId = null }: MessageComponentProps) => {
+const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, showRawParameters, showThinking, selectedProject, provider, transcriptView = false, pendingAskToolId = null, onAskChoiceSelect }: MessageComponentProps) => {
   const { t } = useTranslation('chat');
   const isGrouped = prevMessage && prevMessage.type === message.type &&
     ((prevMessage.type === 'assistant') ||
@@ -195,6 +196,7 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, s
                     isSubagentContainer={message.isSubagentContainer}
                     subagentState={message.subagentState}
                     pendingAsk={pendingAskToolId === message.toolId}
+                    onAskChoiceSelect={onAskChoiceSelect}
                   />
                 )}
 

--- a/src/components/chat/view/subcomponents/ToolGroupContainer.tsx
+++ b/src/components/chat/view/subcomponents/ToolGroupContainer.tsx
@@ -28,6 +28,7 @@ interface ToolGroupContainerProps {
   provider: Provider | string;
   transcriptView?: boolean;
   pendingAskToolId?: string | null;
+  onAskChoiceSelect?: (choiceNumber: number) => void;
 }
 
 function parseToolInput(toolInput: unknown): unknown {
@@ -73,6 +74,7 @@ export default function ToolGroupContainer({
   provider,
   transcriptView = false,
   pendingAskToolId = null,
+  onAskChoiceSelect,
 }: ToolGroupContainerProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const config = getToolConfig(group.toolName).input;
@@ -141,6 +143,7 @@ export default function ToolGroupContainer({
               provider={provider}
               transcriptView={transcriptView}
               pendingAskToolId={pendingAskToolId}
+              onAskChoiceSelect={onAskChoiceSelect}
             />
           ))}
         </div>


### PR DESCRIPTION
Choice cards previously displayed options but answers had to be typed as numbers into the composer — clunky on mobile, where ChatMux is primarily used. Options are now tap targets.

## What changed
- **QuestionAnswerContent**: new optional `onSelectChoice(choiceNumber)` prop. When set and the question is pending single-select, option rows and the direct-input row render as buttons, and the instruction footer gains a `Cancel (0)` button. Multi-select and completed/read-only cards are unchanged (multi-select answers stay typed).
- **LiveRelayComposer**: `send()` accepts an override message; tapped choices submit through the exact same validated relay path as typed numbers (same routing, status handling, custom-input 'other' transition). A tapped choice no longer clears an unrelated typed draft. The composer's own screen-parsed prompt card is clickable directly.
- **Transcript path**: the composer registers a choice submitter into `choiceSubmitRef`; `ChatInterface` bridges it to transcript-rendered pending ask cards via `onAskChoiceSelect`, threaded through ChatMessagesPane → MessageComponent/ToolGroupContainer → ToolRenderer. Only the card matching `pendingAskToolId` receives the handler.

## Safety
- No server changes; a tap produces the identical request a typed number would.
- Landed after #18 on purpose: multi-question asks no longer render cards and Claude multi-select is blocked client-side, so a tap can never target a question the TUI has moved past.

## Verification
- New render-contract test: rows become buttons (incl. direct input + cancel) only when a handler is provided and the question is pending single-select; multi-select never gains tap targets.
- QuestionAnswerContent 9/9, LiveRelayComposer 21/21 (combined run), lint and both typecheck projects clean.
- Not exercised against a live tmux prompt in-browser — the submit path is shared byte-for-byte with the existing typed flow (`send(String(n))`), which route contract tests cover server-side.