### PR TITLE
fix(native-core): recover stale leases and watcher failures

### DIFF
--- a/native/chatmux-core/src/jobs.rs
+++ b/native/chatmux-core/src/jobs.rs
@@ -163,7 +163,10 @@ impl JobAuthority {
             return Err(AuthorityError::StaleLease);
         }
         if let Some(index) = job.event_sequences.get(event_id).copied() {
-            let existing = &job.events[index];
+            let existing = job.events.get(index).ok_or(AuthorityError::Storage)?;
+            if existing.event_id != event_id {
+                return Err(AuthorityError::Storage);
+            }
             return if existing.payload == payload {
                 Ok(existing.clone())
             } else {
@@ -196,9 +199,16 @@ impl JobAuthority {
         let mut changed = Vec::new();
         for job_id in ids {
             let job = self.jobs.get_mut(&job_id).expect("collected job exists");
-            if matches!(job.state, JobState::Running | JobState::Aborting) {
+            let was_active = matches!(job.state, JobState::Running | JobState::Aborting);
+            let had_lease = job.lease.is_some();
+            let cleared_lease = had_lease && !job.state.is_terminal();
+            if was_active {
                 job.state = JobState::Interrupted;
+            }
+            if cleared_lease {
                 job.lease = None;
+            }
+            if was_active || cleared_lease {
                 changed.push(self.snapshot(&job_id).expect("collected job exists"));
             }
         }
@@ -214,6 +224,20 @@ impl JobAuthority {
             lease: job.lease.clone(),
             last_sequence: job.events.len() as u64,
         })
+    }
+
+    fn validate_event_sequences(&self) -> Result<(), AuthorityError> {
+        for job in self.jobs.values() {
+            if job.event_sequences.len() != job.events.len() {
+                return Err(AuthorityError::Storage);
+            }
+            for (index, event) in job.events.iter().enumerate() {
+                if job.event_sequences.get(&event.event_id) != Some(&index) {
+                    return Err(AuthorityError::Storage);
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -246,6 +270,7 @@ impl PersistentAuthority {
             Some(encoded) => serde_json::from_str(&encoded).map_err(|_| AuthorityError::Storage)?,
             None => JobAuthority::default(),
         };
+        authority.validate_event_sequences()?;
         let mut persistent = Self {
             authority,
             connection,
@@ -596,6 +621,20 @@ mod tests {
     }
 
     #[test]
+    fn clears_queued_leases_during_reconciliation() {
+        let mut authority = JobAuthority::default();
+        authority.create("job-1").unwrap();
+        authority.acquire("job-1", "owner-1").unwrap();
+
+        let changed = authority.reconcile();
+
+        assert_eq!(changed.len(), 1);
+        assert_eq!(changed[0].state, JobState::Queued);
+        assert!(changed[0].lease.is_none());
+        assert!(authority.acquire("job-1", "owner-2").is_ok());
+    }
+
+    #[test]
     fn persists_state_and_reconciles_active_jobs_on_reopen() {
         let directory = std::env::temp_dir().join(format!(
             "chatmux-core-jobs-{}-{}",
@@ -635,6 +674,54 @@ mod tests {
         assert_eq!(version, 1);
         drop(second);
 
+        std::fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn rejects_persisted_event_sequence_indexes_that_do_not_match_events() {
+        let directory = std::env::temp_dir().join(format!(
+            "chatmux-core-jobs-events-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        std::fs::create_dir(&directory).unwrap();
+        let database = directory.join("jobs.sqlite3");
+
+        let mut first = PersistentAuthority::open(&database).unwrap();
+        first.mutate(|inner| inner.create("job-1")).unwrap();
+        let lease = first
+            .mutate(|inner| inner.acquire("job-1", "owner-1"))
+            .unwrap();
+        first
+            .mutate(|inner| inner.append_event("job-1", &lease, "event-1", json!({"value": 1})))
+            .unwrap();
+        drop(first);
+
+        let connection = rusqlite::Connection::open(&database).unwrap();
+        let encoded: String = connection
+            .query_row(
+                "SELECT state_json FROM job_authority WHERE id = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let mut state: serde_json::Value = serde_json::from_str(&encoded).unwrap();
+        state["jobs"]["job-1"]["event_sequences"]["event-1"] = json!(1);
+        connection
+            .execute(
+                "UPDATE job_authority SET state_json = ?1 WHERE id = 1",
+                [serde_json::to_string(&state).unwrap()],
+            )
+            .unwrap();
+        drop(connection);
+
+        assert_eq!(
+            PersistentAuthority::open(&database).err(),
+            Some(AuthorityError::Storage)
+        );
         std::fs::remove_dir_all(directory).unwrap();
     }
 

--- a/native/chatmux-core/src/watcher.rs
+++ b/native/chatmux-core/src/watcher.rs
@@ -7,7 +7,7 @@ use std::sync::mpsc::{self, RecvTimeoutError, TrySendError};
 use std::thread;
 use std::time::Duration;
 
-use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::{Config, ErrorKind, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 
 const READY_FRAME: &[u8] = b"{\"protocolVersion\":1,\"kind\":\"ready\"}\n";
 const WATCH_ERROR: &[u8] = b"chatmux-core: watcher failed\n";
@@ -127,18 +127,24 @@ fn wait_for_stdin_eof() -> bool {
 /// `MAX_WATCH_DIR_DEPTH`. With `emit_existing`, transcripts already present
 /// are reported as synthetic add frames: a directory created moments before
 /// its watch lands may already contain the session file the event was for.
-/// Vanished directories are not failures; only stdout write errors are fatal.
-fn watch_directory_tree(
-    watcher: &mut RecommendedWatcher,
+/// Vanished directories are not failures; watch-install and stdout errors are.
+fn watch_directory_tree<W: Watcher>(
+    watcher: &mut W,
     stdout: &mut impl Write,
     roots: &[PathBuf],
     dir: &Path,
     depth: usize,
     emit_existing: bool,
 ) -> bool {
-    let _ = watcher.watch(dir, RecursiveMode::NonRecursive);
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return true;
+    match watcher.watch(dir, RecursiveMode::NonRecursive) {
+        Ok(()) => {}
+        Err(error) if is_vanished_directory_error(&error) => return true,
+        Err(_) => return false,
+    }
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return true,
+        Err(_) => return false,
     };
     for entry in entries.flatten() {
         let Ok(file_type) = entry.file_type() else {
@@ -168,11 +174,19 @@ fn watch_directory_tree(
     true
 }
 
+fn is_vanished_directory_error(error: &notify::Error) -> bool {
+    match &error.kind {
+        ErrorKind::PathNotFound => true,
+        ErrorKind::Io(error) => error.kind() == io::ErrorKind::NotFound,
+        _ => false,
+    }
+}
+
 /// Extends the watch set when a directory appears inside a root at an
 /// observable depth, whether freshly created or moved in.
-fn watch_created_directories(
+fn watch_created_directories<W: Watcher>(
     stdout: &mut impl Write,
-    watcher: &mut RecommendedWatcher,
+    watcher: &mut W,
     roots: &[PathBuf],
     event: &Event,
 ) -> bool {
@@ -326,9 +340,82 @@ fn fail() -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{OutputEvent, directory_depth, frame_for_path, frame_for_resolved_path};
+    use super::{
+        OutputEvent, directory_depth, frame_for_path, frame_for_resolved_path, watch_directory_tree,
+    };
+    use notify::{Config, EventHandler, RecursiveMode, Watcher, WatcherKind};
     use std::fs;
     use std::path::{Path, PathBuf};
+    struct FailingWatcher {
+        error: Option<notify::Error>,
+    }
+
+    impl Watcher for FailingWatcher {
+        fn new<F: EventHandler>(_event_handler: F, _config: Config) -> notify::Result<Self> {
+            Ok(Self { error: None })
+        }
+
+        fn watch(&mut self, _path: &Path, _recursive_mode: RecursiveMode) -> notify::Result<()> {
+            Err(self
+                .error
+                .take()
+                .unwrap_or_else(|| notify::Error::generic("unexpected watch")))
+        }
+
+        fn unwatch(&mut self, _path: &Path) -> notify::Result<()> {
+            Ok(())
+        }
+
+        fn kind() -> WatcherKind {
+            WatcherKind::NullWatcher
+        }
+    }
+
+    #[test]
+    fn propagates_non_vanished_watch_install_failures() {
+        let directory = std::env::temp_dir().join(format!(
+            "chatmux-core-watch-error-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        ));
+        fs::create_dir(&directory).unwrap();
+        let mut watcher = FailingWatcher {
+            error: Some(notify::Error::generic("watch limit reached")),
+        };
+        let mut output = Vec::new();
+
+        assert!(!watch_directory_tree(
+            &mut watcher,
+            &mut output,
+            std::slice::from_ref(&directory),
+            &directory,
+            0,
+            false,
+        ));
+
+        fs::remove_dir_all(directory).unwrap();
+    }
+
+    #[test]
+    fn ignores_vanished_directory_watch_install_failures() {
+        let directory = PathBuf::from("/nonexistent/chatmux-core-watch-test");
+        let mut watcher = FailingWatcher {
+            error: Some(notify::Error::path_not_found()),
+        };
+        let mut output = Vec::new();
+
+        assert!(watch_directory_tree(
+            &mut watcher,
+            &mut output,
+            std::slice::from_ref(&directory),
+            &directory,
+            0,
+            false,
+        ));
+    }
 
     #[test]
     fn directory_depth_is_relative_to_the_closest_containing_root() {


### PR DESCRIPTION
## Problem\n- Startup reconciliation left leases acquired while jobs were queued, permanently blocking future workers.\n- Nested watcher installation failures were discarded, allowing partial watch trees to announce readiness.\n- Persisted event index corruption could panic during idempotent event append.\n\n## Fix\n- Clear leases for every nonterminal job during reconciliation while preserving active-job interruption.\n- Propagate non-vanished watch-install and directory-read failures; retain benign handling for disappeared directories.\n- Validate persisted event indexes at open and use checked event lookup defensively.\n\n## Tests\n- 
running 19 tests
test jobs::tests::clears_queued_leases_during_reconciliation ... ok
test jobs::tests::enforces_leases_and_state_transitions ... ok
test jobs::tests::appends_events_idempotently_and_replays_in_order ... ok
test jobs::tests::reconciles_owned_active_jobs_as_interrupted ... ok
test tests::maps_normal_exit_codes ... ok
test tests::maps_unix_signals_and_unknown_statuses_deterministically ... ok
test tests::parses_opaque_program_and_arguments ... ok
test tests::parses_opaque_pty_program_and_arguments ... ok
test tests::parses_version_only ... ok
test tests::parses_existing_absolute_watch_roots_only ... ok
test tests::rejects_malformed_invocations ... ok
test watcher::tests::directory_depth_is_relative_to_the_closest_containing_root ... ok
test watcher::tests::ignores_vanished_directory_watch_install_failures ... ok
test watcher::tests::propagates_non_vanished_watch_install_failures ... ok
test watcher::tests::frames_only_supported_canonical_paths_inside_roots ... ok
test watcher::tests::rejects_frames_larger_than_the_protocol_limit ... ok
test jobs::tests::rejects_unknown_future_schema_versions ... ok
test jobs::tests::rejects_persisted_event_sequence_indexes_that_do_not_match_events ... ok
test jobs::tests::persists_state_and_reconciles_active_jobs_on_reopen ... ok

test result: ok. 19 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s\n- \n- 