### PR TITLE
fix(stream): defer stale state until resync

### DIFF
--- a/server/modules/websocket/services/discovery-stream.service.ts
+++ b/server/modules/websocket/services/discovery-stream.service.ts
@@ -33,6 +33,7 @@ type Subscriber = {
   queuedBytes: number;
   slowSince: number | null;
   resyncs: number[];
+  awaitingResync: boolean;
 };
 
 function selected(snapshot: DiscoverySnapshot, lanes: readonly DiscoveryLane[]): DiscoverySnapshot {
@@ -78,7 +79,7 @@ export function createDiscoveryStream(collector: DiscoveryCollector, now = Date.
       unchangedTicks += 1;
       if (unchangedTicks % HEARTBEAT_CADENCE === 0) {
         for (const subscriber of subscribers.values()) {
-          if (subscriber.queue.length === 0) {
+          if (!subscriber.awaitingResync && subscriber.queue.length === 0) {
             enqueue(subscriber, { kind: 'discovery.heartbeat', epoch: snapshot.epoch, revision: snapshot.revision, takenAtMs: snapshot.takenAtMs });
           }
         }
@@ -109,6 +110,7 @@ export function createDiscoveryStream(collector: DiscoveryCollector, now = Date.
   function enqueue(subscriber: Subscriber, payload: unknown): void {
     const frame = JSON.stringify(payload);
     if (subscriber.queue.length >= MAX_QUEUED_MESSAGES || subscriber.queuedBytes + Buffer.byteLength(frame) > MAX_QUEUED_BYTES) {
+      subscriber.awaitingResync = true;
       subscriber.queue = [JSON.stringify({ kind: 'discovery.resync_required', epoch: collector.currentSnapshot().epoch, reason: 'queue_overflow' })];
       subscriber.queuedBytes = Buffer.byteLength(subscriber.queue[0]!);
     } else {
@@ -118,6 +120,10 @@ export function createDiscoveryStream(collector: DiscoveryCollector, now = Date.
     flush(subscriber);
   }
   function enqueueDelta(subscriber: Subscriber, delta: Delta): void {
+    if (subscriber.awaitingResync) {
+      flush(subscriber);
+      return;
+    }
     if (delta.revision <= subscriber.baselineRevision) return;
     const changes = delta.changes.filter((change) => {
       const lane = change.op === 'added' ? change.row.lane : change.op === 'updated' ? change.patch.lane : undefined;
@@ -128,6 +134,7 @@ export function createDiscoveryStream(collector: DiscoveryCollector, now = Date.
   function snapshot(subscriber: Subscriber): void {
     const current = collector.currentSnapshot();
     subscriber.baselineRevision = current.revision;
+    subscriber.awaitingResync = false;
     enqueue(subscriber, { kind: 'discovery.snapshot', ...selected(current, subscriber.lanes) });
   }
   function subscribe(ws: WebSocket, data: AnyRecord): void {
@@ -143,6 +150,7 @@ export function createDiscoveryStream(collector: DiscoveryCollector, now = Date.
       queuedBytes: 0,
       slowSince: null,
       resyncs: [],
+      awaitingResync: false,
     };
     subscribers.set(ws, subscriber);
     const known = data.known as AnyRecord | null | undefined;

--- a/server/modules/websocket/tests/discovery-stream.service.test.ts
+++ b/server/modules/websocket/tests/discovery-stream.service.test.ts
@@ -124,6 +124,37 @@ test('bounded queue emits resync without oversized payload and closes only susta
   clock = SLOW_CLIENT_MS; source.emit(snapshot(102)); assert.equal(ws.closeCode, 1013);
   stream.dispose();
 });
+
+test('queue overflow suppresses stale deltas until the client resyncs', () => {
+  const source = collector();
+  const stream = createDiscoveryStream(source.instance);
+  const ws = new FakeWebSocket();
+  ws.bufferedAmount = MAX_BUFFERED_AMOUNT + 1;
+  subscribe(stream, ws);
+
+  for (let revision = 2; revision <= MAX_QUEUED_MESSAGES + 3; revision += 1) {
+    source.emit(snapshot(revision));
+  }
+
+  ws.bufferedAmount = 0;
+  source.emit(snapshot(MAX_QUEUED_MESSAGES + 4));
+  source.emit(snapshot(MAX_QUEUED_MESSAGES + 5));
+  assert.deepEqual(frames(ws).map((event) => event.kind), ['discovery.resync_required']);
+
+  stream.handle(ws as never, { type: 'discovery.resync', reason: 'queue_overflow' });
+  assert.deepEqual(frames(ws).map((event) => event.kind), [
+    'discovery.resync_required',
+    'discovery.snapshot',
+  ]);
+
+  source.emit(snapshot(MAX_QUEUED_MESSAGES + 6));
+  assert.deepEqual(frames(ws).map((event) => event.kind), [
+    'discovery.resync_required',
+    'discovery.snapshot',
+    'discovery.delta',
+  ]);
+  stream.dispose();
+});
 test('exact-known subscriptions receive one heartbeat, unchanged ticks heartbeat every cadence, and resync is rate-limited', () => {
   let clock = 0;
   const source = collector();

--- a/src/components/shell/hooks/useShellConnection.ts
+++ b/src/components/shell/hooks/useShellConnection.ts
@@ -183,6 +183,14 @@ export function useShellConnection({
         return;
       }
 
+      // Socket events cannot satisfy browser user-activation requirements, so
+      // render auth URLs in the terminal instead of attempting a popup.
+      if (message.type === 'auth_url' && typeof message.url === 'string' && message.url) {
+        terminalRef.current?.write(`\r\n[Authentication required] Open this URL in your browser:\r\n${message.url}\r\n`);
+        onOutputRef?.current?.();
+        return;
+      }
+
       if (message.type === 'replay_start') {
         // 'resume' continues the existing screen; 'redraw' means the server is
         // about to repaint from scratch (fresh PTY, legacy path, or a replay

--- a/src/components/shell/shellProtocol.test.ts
+++ b/src/components/shell/shellProtocol.test.ts
@@ -160,6 +160,22 @@ test('protocol outdated errors remain terminal after socket close and suppress a
   assert.match(connection, /protocolOutdatedRef\.current \|\|/);
   assert.match(connection, /connectToShell\(\{ automatic: true \}\)/);
 });
+
+test('auth_url messages surface the provider login URL in the terminal', () => {
+  const connection = readFileSync(new URL('./hooks/useShellConnection.ts', import.meta.url), 'utf8');
+  const types = readFileSync(new URL('./types/types.ts', import.meta.url), 'utf8');
+  const authUrlHandler = connection.slice(
+    connection.indexOf("message.type === 'auth_url'"),
+    connection.indexOf("message.type === 'replay_start'"),
+  );
+
+  assert.match(types, /\{ type: 'auth_url'; url\?: string; autoOpen\?: boolean \}/);
+  assert.match(authUrlHandler, /terminalRef\.current\?\.write/);
+  assert.match(authUrlHandler, /Authentication required/);
+  assert.match(authUrlHandler, /message\.url/);
+  assert.match(authUrlHandler, /onOutputRef\?\.current\?\.\(\)/);
+  assert.equal(authUrlHandler.includes('window.open'), false);
+});
 test('init carries the acknowledged output seq only when one exists', () => {
   const withSeq = buildShellInitMessage({ ...baseInit, attachTarget: null, lastSeq: 42 });
   assert.equal((withSeq as { lastSeq?: number }).lastSeq, 42);

--- a/src/components/shell/types/types.ts
+++ b/src/components/shell/types/types.ts
@@ -58,7 +58,7 @@ export type ShellOutgoingMessage = ShellInitMessage | ShellResizeMessage | Shell
 export type ShellIncomingMessage =
   | { type: 'output'; data: string; seq?: number }
   | { type: 'replay_start'; mode?: 'resume' | 'redraw' }
-  | { type: 'auth_url'; url?: string }
+  | { type: 'auth_url'; url?: string; autoOpen?: boolean }
   | { type: 'url_open'; url?: string }
   | { type: 'error'; code?: string; reloadRequired?: boolean; message?: string }
   | { type: string; [key: string]: unknown };

--- a/src/stores/useSessionStore.test.ts
+++ b/src/stores/useSessionStore.test.ts
@@ -181,7 +181,7 @@ test('refresh preserves the message window expanded by pagination', async () => 
   }
 });
 
-test('background refresh cannot invalidate an explicit pagination request', async () => {
+test('refresh queues a reconcile after an explicit pagination request settles', async () => {
   const originalFetch = globalThis.fetch;
   const pending: PendingRequest[] = [];
   globalThis.fetch = ((url: string) => new Promise<Response>((resolve) => {
@@ -203,6 +203,7 @@ test('background refresh cannot invalidate an explicit pagination request', asyn
 
     const page = store.fetchMore('session', { limit: 2 });
     const refresh = store.refreshFromServer('session');
+    const duplicateRefresh = store.refreshFromServer('session');
     assert.equal(pending.length, 1, 'refresh reuses the pending slot instead of issuing a competing request');
 
     pending.shift()!.resolve(response({
@@ -213,21 +214,38 @@ test('background refresh cannot invalidate an explicit pagination request', asyn
       total: 4,
       hasMore: false,
     }));
-    const [pagedSlot, refreshedSlot] = await Promise.all([page, refresh]);
-
-    assert.equal(refreshedSlot, pagedSlot);
+    const pagedSlot = await page;
     assert.deepEqual(
       pagedSlot.serverMessages.map(message => message.id),
       ['old-1', 'old-2', 'new-1', 'new-2'],
     );
-    assert.equal(pagedSlot.hasMore, false);
-    assert.equal(pagedSlot.offset, 4);
+    assert.equal(pending.length, 1, 'multiple refreshes coalesce into one deferred reconcile');
+    pending.shift()!.resolve(response({
+      messages: [
+        { id: 'old-1', sessionId: 'session', timestamp: '2026-01-01T00:00:00Z', kind: 'text', provider: 'claude' },
+        { id: 'old-2', sessionId: 'session', timestamp: '2026-01-01T00:01:00Z', kind: 'text', provider: 'claude' },
+        { id: 'new-1', sessionId: 'session', timestamp: '2026-01-01T00:02:00Z', kind: 'text', provider: 'claude' },
+        { id: 'new-2', sessionId: 'session', timestamp: '2026-01-01T00:03:00Z', kind: 'text', provider: 'claude' },
+        { id: 'latest', sessionId: 'session', timestamp: '2026-01-01T00:04:00Z', kind: 'text', provider: 'claude' },
+      ],
+      total: 5,
+      hasMore: false,
+    }));
+    const [refreshedSlot, duplicateRefreshedSlot] = await Promise.all([refresh, duplicateRefresh]);
+    assert.equal(duplicateRefreshedSlot, pagedSlot);
+    assert.deepEqual(
+      refreshedSlot.serverMessages.map(message => message.id),
+      ['old-1', 'old-2', 'new-1', 'new-2', 'latest'],
+    );
+    assert.equal(refreshedSlot.total, 5);
+    assert.equal(refreshedSlot.hasMore, false);
+    assert.equal(refreshedSlot.offset, 5);
   } finally {
     globalThis.fetch = originalFetch;
   }
 });
 
-test('background refresh cannot invalidate a load-all request', async () => {
+test('refresh queues a reconcile after a load-all request settles', async () => {
   const originalFetch = globalThis.fetch;
   const pending: PendingRequest[] = [];
   globalThis.fetch = ((url: string) => new Promise<Response>((resolve) => {
@@ -258,11 +276,21 @@ test('background refresh cannot invalidate a load-all request', async () => {
       total: 2,
       hasMore: false,
     }));
-    const [fullSlot, refreshedSlot] = await Promise.all([loadAll, refresh]);
+    const fullSlot = await loadAll;
+    assert.equal(pending.length, 1, 'the deferred reconcile starts after the full-history request');
+    pending.shift()!.resolve(response({
+      messages: [
+        { id: 'old', sessionId: 'session', timestamp: '2026-01-01T00:00:00Z', kind: 'text', provider: 'claude' },
+        { id: 'new', sessionId: 'session', timestamp: '2026-01-01T00:01:00Z', kind: 'text', provider: 'claude' },
+      ],
+      total: 2,
+      hasMore: false,
+    }));
+    const refreshedSlot = await refresh;
 
     assert.equal(refreshedSlot, fullSlot);
-    assert.deepEqual(fullSlot.serverMessages.map(message => message.id), ['old', 'new']);
-    assert.equal(fullSlot.hasMore, false);
+    assert.deepEqual(refreshedSlot.serverMessages.map(message => message.id), ['old', 'new']);
+    assert.equal(refreshedSlot.hasMore, false);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/src/stores/useSessionStore.ts
+++ b/src/stores/useSessionStore.ts
@@ -110,6 +110,8 @@ export interface SessionSlot {
   _fetchMoreTicket: number | null;
   /** @internal Number of server requests still using this slot. */
   _pendingRequests: number;
+  /** @internal Reconcile requested while another server request was active. */
+  _reconcilePending: boolean;
   /** @internal Request currently allowed to settle `loading`. */
   _loadingTicket: number | null;
   status: SessionStatus;
@@ -138,6 +140,7 @@ function createEmptySlot(): SessionSlot {
     _fetchSeq: 0,
     _fetchMoreTicket: null,
     _pendingRequests: 0,
+    _reconcilePending: false,
     _loadingTicket: null,
   };
 }
@@ -520,6 +523,11 @@ function dedupeMessagesById(messages: NormalizedMessage[]): NormalizedMessage[] 
 export function useSessionStore() {
   const storeRef = useRef(new Map<string, SessionSlot>());
   const activeSessionIdRef = useRef<string | null>(null);
+  const refreshFromServerRef = useRef<((sessionId: string) => Promise<SessionSlot>) | null>(null);
+  const queuedRefreshesRef = useRef(new Map<string, {
+    promise: Promise<SessionSlot>;
+    resolve: (slot: SessionSlot) => void;
+  }>());
   // Bump to force re-render — only when the active session's data changes.
   // Session ids are stable for the whole conversation lifetime (the backend
   // allocates them before the first send), so slots are keyed directly with
@@ -578,6 +586,21 @@ export function useSessionStore() {
     touchSlot(sessionId, slot);
     return slot;
   }, [touchSlot]);
+
+  const runQueuedRefresh = useCallback((sessionId: string, slot: SessionSlot) => {
+    if (!slot._reconcilePending || slot._pendingRequests !== 0) {
+      return;
+    }
+    const queued = queuedRefreshesRef.current.get(sessionId);
+    if (!queued || !refreshFromServerRef.current) {
+      return;
+    }
+    slot._reconcilePending = false;
+    void refreshFromServerRef.current(sessionId).then((refreshedSlot) => {
+      queued.resolve(refreshedSlot);
+      queuedRefreshesRef.current.delete(sessionId);
+    });
+  }, []);
 
   const has = useCallback((sessionId: string) => {
     return storeRef.current.has(sessionId);
@@ -660,9 +683,10 @@ export function useSessionStore() {
       if (slot._loadingTicket === fetchTicket) {
         slot._loadingTicket = null;
       }
+      runQueuedRefresh(sessionId, slot);
       trimInactiveSlots();
     }
-  }, [beginRequest, notify, trimInactiveSlots]);
+  }, [beginRequest, notify, runQueuedRefresh, trimInactiveSlots]);
 
   /**
    * Load older (paginated) messages and prepend to serverMessages.
@@ -744,9 +768,10 @@ export function useSessionStore() {
       if (slot._loadingTicket === fetchTicket) {
         slot._loadingTicket = null;
       }
+      runQueuedRefresh(sessionId, slot);
       trimInactiveSlots();
     }
-  }, [notify, touchSlot, trimInactiveSlots]);
+  }, [notify, runQueuedRefresh, touchSlot, trimInactiveSlots]);
 
   /**
    * Append a realtime (WebSocket) message to the correct session slot.
@@ -810,8 +835,18 @@ export function useSessionStore() {
     // slot was successfully expanded.
     const pendingSlot = storeRef.current.get(sessionId);
     if (pendingSlot && pendingSlot._pendingRequests > 0) {
+      pendingSlot._reconcilePending = true;
       touchSlot(sessionId, pendingSlot);
-      return pendingSlot;
+      const queued = queuedRefreshesRef.current.get(sessionId);
+      if (queued) {
+        return queued.promise;
+      }
+      let resolve!: (slot: SessionSlot) => void;
+      const promise = new Promise<SessionSlot>((nextResolve) => {
+        resolve = nextResolve;
+      });
+      queuedRefreshesRef.current.set(sessionId, { promise, resolve });
+      return promise;
     }
 
     const slot = beginRequest(sessionId);
@@ -871,9 +906,12 @@ export function useSessionStore() {
       if (slot._loadingTicket === fetchTicket) {
         slot._loadingTicket = null;
       }
+      runQueuedRefresh(sessionId, slot);
       trimInactiveSlots();
     }
-  }, [beginRequest, notify, touchSlot, trimInactiveSlots]);
+  }, [beginRequest, notify, runQueuedRefresh, touchSlot, trimInactiveSlots]);
+
+  refreshFromServerRef.current = refreshFromServer;
 
   /**
    * Update session status.


### PR DESCRIPTION
## Problem
- Discovery queue overflow left stale deltas behind `discovery.resync_required`, causing repeated client resync requests and rate-limit disconnects.
- Shell `auth_url` frames were silently ignored.
- Completion reconciliation requested during another transcript request was dropped.

## Fix
- Suppress discovery deltas and heartbeats while awaiting resubscribe/resync, then resume after the snapshot.
- Render provider authentication URLs in the terminal; socket messages are not browser user gestures, so no popup is attempted.
- Coalesce pending refresh triggers and run one reconcile after the active request settles.

## Tests
- `TSX_TSCONFIG_PATH=server/tsconfig.json node --import tsx --test server/modules/websocket/tests/discovery-stream.service.test.ts`
- `TSX_TSCONFIG_PATH=tsconfig.json node --import tsx --test src/components/shell/shellProtocol.test.ts src/stores/useSessionStore.test.ts`