### PR TITLE
fix(infra): harden release and server defaults

### DIFF
--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -4,14 +4,16 @@ on:
   release:
     types: [published]
 
+
+permissions:
+  contents: read
+
 jobs:
   github-releases-to-discord:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
       - name: Github Releases To Discord
-        uses: SethCohen/github-releases-to-discord@v1.19.0
+        uses: SethCohen/github-releases-to-discord@b96a33520f8ad5e6dcdecee6f1212bdf88b16550 # v1.19.0
         with:
           webhook_url: ${{ secrets.DISCORD_WEBHOOK_URL }}
           color: "2105893"

--- a/docs/SELF-HOST.md
+++ b/docs/SELF-HOST.md
@@ -12,7 +12,9 @@ registry, container image, desktop delivery, or an unverified source build.
 ## Supported target and filesystem layout
 
 The first supported artifact target is Linux on x86_64 with glibc 2.35 or
-newer and a Node.js 22 runtime. It is a server artifact only.
+newer. The bootstrap installer self-provisions Node.js 22.22.2; manual runtime
+operation requires Node.js 22.22.2 or newer within the 22.x line. It is a server
+artifact only.
 
 | Path | Purpose |
 |---|---|
@@ -31,8 +33,7 @@ Before the first deployment, confirm the host contract:
 test "$(uname -s)" = Linux
 test "$(uname -m)" = x86_64
 getconf GNU_LIBC_VERSION    # requires glibc 2.35 or newer
-node --version              # requires v22
-```
+node --version              # manual runtime requires v22.22.2 or newer
 
 Use the release-install procedure in [INSTALL.md](INSTALL.md) to verify the
 checksum, unpack a versioned release, install `chatmux.service`, and activate
@@ -96,9 +97,12 @@ the ordinary mobile update experience.
 ## Managed-root safety
 
 `~/.chatmux` is a security boundary. It must be a real directory owned by the
-installing user with mode `0700`; the installer and updater refuse a symlink,
-non-directory, wrong owner, unsafe mode, or identity replacement before network,
-database, service, or link effects. Do not “fix” this through the mobile UI.
+installing user with mode `0700`; the installer and detached update worker refuse
+a symlink, non-directory, wrong owner, unsafe mode, or identity replacement
+before their network, database, service, or link effects. The update router first
+records update state, creates its state directory, and discovers releases before
+the worker applies this managed-root check. Do not “fix” this through the mobile
+UI.
 An operator must stop, inspect the path and ownership, remove or relocate an
 unexpected symlink only after confirming its target is safe, then recreate or
 repair the managed root as the intended user with `0700` before manual recovery.

--- a/scripts/build-rust-core.mjs
+++ b/scripts/build-rust-core.mjs
@@ -29,7 +29,7 @@ function runCargo(commandArgs) {
       output += chunk;
     });
     child.once('error', reject);
-    child.once('exit', (code) => {
+    child.once('close', (code) => {
       if (code !== 0) {
         reject(new Error(`cargo exited with code ${code}`));
         return;

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,29 +1,29 @@
 import { readdir } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
 const TEST_FILE_PATTERN = /\.(?:test|spec)\.(?:js|ts|tsx)$/;
-const SKIPPED_DIRECTORIES = new Set(['dist', 'dist-server', 'node_modules', 'release']);
+const SKIPPED_DIRECTORIES = new Set(['dist', 'dist-server', 'node_modules']);
 
-const [nodeMajor, nodeMinor, nodePatch] = process.versions.node.split('.').map(Number);
-const meetsMinimumNodeVersion =
-  (nodeMajor === 22 && (nodeMinor > 22 || (nodeMinor === 22 && nodePatch >= 2))) ||
-  (nodeMajor === 24 && (nodeMinor > 15 || (nodeMinor === 15 && nodePatch >= 0)));
-
-if (!meetsMinimumNodeVersion) {
-  console.error(
-    `[test] Node 22.22.2+ (22.x) or 24.15.0+ (24.x) is required; current runtime is Node ${process.versions.node}.`,
-  );
-  process.exit(1);
+function meetsMinimumNodeVersion() {
+  const [nodeMajor, nodeMinor, nodePatch] = process.versions.node.split('.').map(Number);
+  return (nodeMajor === 22 && (nodeMinor > 22 || (nodeMinor === 22 && nodePatch >= 2))) ||
+    (nodeMajor === 24 && (nodeMinor > 15 || (nodeMinor === 15 && nodePatch >= 0)));
 }
 
-async function collectTests(root) {
+function shouldSkipDirectory(root, entryName) {
+  return SKIPPED_DIRECTORIES.has(entryName) || (entryName === 'release' && root !== 'scripts');
+}
+
+export async function collectTests(root) {
   const files = [];
 
   async function visit(directory) {
     const entries = await readdir(directory, { withFileTypes: true });
     for (const entry of entries) {
-      if (entry.isDirectory() && SKIPPED_DIRECTORIES.has(entry.name)) continue;
+      if (entry.isDirectory() && shouldSkipDirectory(root, entry.name)) continue;
       const entryPath = path.join(directory, entry.name);
       if (entry.isDirectory()) {
         await visit(entryPath);
@@ -37,7 +37,7 @@ async function collectTests(root) {
   return files.sort();
 }
 
-function runTests(label, files, { tsconfig } = {}) {
+export function runTests(label, files, { tsconfig } = {}) {
   if (files.length === 0) {
     throw new Error(`[test] ${label}: no test files were discovered.`);
   }
@@ -56,10 +56,32 @@ function runTests(label, files, { tsconfig } = {}) {
   if (result.status !== 0) process.exit(result.status ?? 1);
 }
 
-const [serverTests, clientTests] = await Promise.all([
-  collectTests('server'),
-  collectTests('src'),
-]);
+export async function discoverTests() {
+  const [serverTests, scriptTests, clientTests] = await Promise.all([
+    collectTests('server'),
+    collectTests('scripts'),
+    collectTests('src'),
+  ]);
 
-runTests('server', serverTests, { tsconfig: 'server/tsconfig.json' });
-runTests('client', clientTests, { tsconfig: 'tsconfig.json' });
+  return {
+    serverTests: [...serverTests, ...scriptTests].sort(),
+    clientTests,
+  };
+}
+
+async function main() {
+  if (!meetsMinimumNodeVersion()) {
+    console.error(
+      `[test] Node 22.22.2+ (22.x) or 24.15.0+ (24.x) is required; current runtime is Node ${process.versions.node}.`,
+    );
+    process.exit(1);
+  }
+
+  const { serverTests, clientTests } = await discoverTests();
+  runTests('server', serverTests, { tsconfig: 'server/tsconfig.json' });
+  runTests('client', clientTests, { tsconfig: 'tsconfig.json' });
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  await main();
+}

--- a/scripts/run-tests.test.mjs
+++ b/scripts/run-tests.test.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import test from 'node:test';
+
+import { discoverTests } from './run-tests.mjs';
+
+test('server-side discovery includes release verification tests in scripts', async () => {
+  const { serverTests } = await discoverTests();
+  assert.ok(serverTests.includes(path.join('scripts', 'release', 'verify-db-rollback-compatibility.test.ts')));
+});

--- a/server/cli.js
+++ b/server/cli.js
@@ -19,6 +19,8 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { fileURLToPath } from 'url';
+
 
 import { findAppRoot, getModuleDir } from './utils/runtime-paths.js';
 
@@ -642,24 +644,38 @@ async function runAccess(args) {
 }
 
 // Parse CLI arguments
-function parseArgs(args) {
+export function parseArgs(args) {
     const parsed = { command: 'start', options: {} };
+    const commands = new Set(['start', 'sandbox', 'install', 'access', 'browser-mcp-cleanup', 'status', 'info']);
+
+    const readOptionValue = (option, index) => {
+        const value = args[index + 1];
+        if (!value || value.startsWith('-') || commands.has(value)) {
+            throw new Error(`${option} requires a value`);
+        }
+        return value;
+    };
 
     for (let i = 0; i < args.length; i++) {
         const arg = args[i];
 
         if (arg === '--port' || arg === '-p') {
-            parsed.options.serverPort = args[++i];
+            parsed.options.serverPort = readOptionValue(arg, i);
+            i += 1;
         } else if (arg.startsWith('--port=')) {
-            parsed.options.serverPort = arg.split('=')[1];
+            parsed.options.serverPort = arg.slice('--port='.length);
         } else if (arg === '--host') {
-            parsed.options.host = args[++i];
+            parsed.options.host = readOptionValue(arg, i);
+            i += 1;
         } else if (arg.startsWith('--host=')) {
-            parsed.options.host = arg.split('=')[1];
+            parsed.options.host = arg.slice('--host='.length);
         } else if (arg === '--database-path') {
-            parsed.options.databasePath = args[++i];
+            parsed.options.databasePath = readOptionValue(arg, i);
+            i += 1;
         } else if (arg.startsWith('--database-path=')) {
-            parsed.options.databasePath = arg.split('=')[1];
+            parsed.options.databasePath = arg.slice('--database-path='.length);
+        } else if (arg === '--yes' || arg === '-y') {
+            parsed.options.yes = true;
         } else if (arg === '--help' || arg === '-h') {
             parsed.command = 'help';
         } else if (arg === '--version' || arg === '-v') {
@@ -675,6 +691,15 @@ function parseArgs(args) {
 
     return parsed;
 }
+
+export function buildInstallArgs(options, remainingArgs = []) {
+    return [
+        ...(options.yes ? ['--yes'] : []),
+        ...(options.serverPort ? [`--port=${options.serverPort}`] : []),
+        ...remainingArgs,
+    ];
+}
+
 
 // Main CLI handler
 async function main() {
@@ -692,6 +717,8 @@ async function main() {
         process.env.HOST = options.host;
     }
 
+    const installArgs = buildInstallArgs(options, remainingArgs);
+
     switch (command) {
         case 'start':
             await startServer();
@@ -700,7 +727,7 @@ async function main() {
             await sandboxCommand(remainingArgs || []);
             break;
         case 'install':
-            await runInstall(remainingArgs || []);
+            await runInstall(installArgs);
             break;
         case 'access':
             await runAccess(remainingArgs || []);
@@ -734,7 +761,9 @@ async function main() {
 }
 
 // Run the CLI
-main().catch(error => {
-    console.error('\n❌ Error:', error.message);
-    process.exit(1);
-});
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+    main().catch(error => {
+        console.error('\n❌ Error:', error.message);
+        process.exit(1);
+    });
+}

--- a/server/cli.test.js
+++ b/server/cli.test.js
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { buildInstallArgs, parseArgs } from './cli.js';
+
+test('global install options before the command are retained', () => {
+  const parsed = parseArgs(['--port', '8080', '--host', '127.0.0.1', '--yes', 'install']);
+  assert.deepEqual(
+    parsed,
+    {
+      command: 'install',
+      options: { serverPort: '8080', host: '127.0.0.1', yes: true },
+      remainingArgs: [],
+    },
+  );
+  assert.deepEqual(buildInstallArgs(parsed.options, parsed.remainingArgs), ['--yes', '--port=8080']);
+});
+
+test('options requiring values reject a following command', () => {
+  assert.throws(() => parseArgs(['--port', 'install']), /--port requires a value/);
+});

--- a/server/index.js
+++ b/server/index.js
@@ -214,6 +214,13 @@ app.use(compression({
         return compression.filter(req, res);
     },
 }));
+// Credential endpoints are public and never need the large upload payload budget.
+app.use('/api/auth', express.json({
+    limit: '64kb',
+    type: (req) => (req.headers['content-type'] || '').includes('json')
+}));
+app.use('/api/auth', express.urlencoded({ limit: '64kb', extended: true }));
+
 app.use(express.json({
     limit: '50mb',
     type: (req) => {

--- a/server/modules/database/connection.ts
+++ b/server/modules/database/connection.ts
@@ -41,8 +41,18 @@ function resolveDatabasePath(): string {
 function ensureDatabaseDirectory(dbPath: string): void {
   const dir = path.dirname(dbPath);
   if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
     console.log('Created database directory:', dir);
+  }
+}
+
+function secureDatabaseFiles(dbPath: string): void {
+  for (const filePath of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+    try {
+      if (fs.existsSync(filePath)) fs.chmodSync(filePath, 0o600);
+    } catch {
+      // chmod is not supported consistently on Windows filesystems.
+    }
   }
 }
 
@@ -70,6 +80,7 @@ export function getConnection(): Database.Database {
   ensureDatabaseDirectory(dbPath);
 
   instance = new Database(dbPath);
+  secureDatabaseFiles(dbPath);
 
   // app_config must exist immediately — the auth middleware reads
   // the JWT secret at module-load time, before initializeDatabase() runs.

--- a/server/modules/database/tests/connection-permissions.test.ts
+++ b/server/modules/database/tests/connection-permissions.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { closeConnection, getConnection } from '@/modules/database/connection.js';
+
+test('database connection creates private storage', async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'chatmux-db-permissions-'));
+  const databasePath = path.join(root, 'private', 'auth.db');
+  const previousDatabasePath = process.env.DATABASE_PATH;
+  process.env.DATABASE_PATH = databasePath;
+  closeConnection();
+  t.after(async () => {
+    closeConnection();
+    if (previousDatabasePath === undefined) delete process.env.DATABASE_PATH;
+    else process.env.DATABASE_PATH = previousDatabasePath;
+    await rm(root, { recursive: true, force: true });
+  });
+
+  getConnection();
+
+  assert.equal(fs.statSync(path.dirname(databasePath)).mode & 0o777, 0o700);
+  assert.equal(fs.statSync(databasePath).mode & 0o777, 0o600);
+});

--- a/server/routes/auth-limiter.test.js
+++ b/server/routes/auth-limiter.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import express from 'express';
+
+const databaseDirectory = await mkdtemp(path.join(os.tmpdir(), 'chatmux-auth-limiter-'));
+const previousDatabasePath = process.env.DATABASE_PATH;
+const previousAuthMode = process.env.CHATMUX_AUTH;
+process.env.DATABASE_PATH = path.join(databaseDirectory, 'auth.db');
+process.env.CHATMUX_AUTH = 'password';
+const [{ default: authRoutes }, database] = await Promise.all([
+  import('./auth.js'),
+  import('../modules/database/index.js'),
+]);
+const { closeConnection, initializeDatabase } = database;
+await initializeDatabase();
+
+test('login blocks an IP and username after ten failed attempts', async (t) => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/auth', authRoutes);
+  const server = createServer(app);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address();
+  const login = () => fetch(`http://127.0.0.1:${port}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: 'unknown-user', password: 'wrong-password' }),
+  });
+
+  t.after(async () => {
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    closeConnection();
+    if (previousDatabasePath === undefined) delete process.env.DATABASE_PATH;
+    else process.env.DATABASE_PATH = previousDatabasePath;
+    if (previousAuthMode === undefined) delete process.env.CHATMUX_AUTH;
+    else process.env.CHATMUX_AUTH = previousAuthMode;
+    await rm(databaseDirectory, { recursive: true, force: true });
+  });
+
+  for (let attempt = 0; attempt < 10; attempt += 1) {
+    assert.equal((await login()).status, 401);
+  }
+
+  const blocked = await login();
+  assert.equal(blocked.status, 429);
+  assert.match(blocked.headers.get('retry-after') ?? '', /^\d+$/);
+});

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -22,6 +22,42 @@ import {
 const router = express.Router();
 const db = getConnection();
 
+const LOGIN_FAILURE_LIMIT = 10;
+const LOGIN_FAILURE_WINDOW_MS = 15 * 60 * 1000;
+const loginFailures = new Map();
+
+function loginFailureKey(req, username) {
+  return `${req.ip}\u0000${username}`;
+}
+
+function getLoginRetryAfterSeconds(key) {
+  const attempt = loginFailures.get(key);
+  if (!attempt) return 0;
+
+  const remainingMs = attempt.resetAt - Date.now();
+  if (remainingMs <= 0) {
+    loginFailures.delete(key);
+    return 0;
+  }
+
+  return attempt.count >= LOGIN_FAILURE_LIMIT ? Math.ceil(remainingMs / 1000) : 0;
+}
+
+function recordLoginFailure(key) {
+  const now = Date.now();
+  const attempt = loginFailures.get(key);
+  if (!attempt || attempt.resetAt <= now) {
+    loginFailures.set(key, { count: 1, resetAt: now + LOGIN_FAILURE_WINDOW_MS });
+    return;
+  }
+
+  attempt.count += 1;
+}
+
+function clearLoginFailures(key) {
+  loginFailures.delete(key);
+}
+
 const clearAuthCookie = (req, res) => {
   const { maxAge, ...options } = getAuthCookieOptions(req);
   res.clearCookie(AUTH_COOKIE_NAME, options);
@@ -133,19 +169,30 @@ router.post('/login', rejectWhenPasswordless, async (req, res) => {
     if (!username || !password) {
       return res.status(400).json({ error: 'Username and password are required' });
     }
+
+    const failureKey = loginFailureKey(req, username);
+    const retryAfterSeconds = getLoginRetryAfterSeconds(failureKey);
+    if (retryAfterSeconds > 0) {
+      res.set('Retry-After', String(retryAfterSeconds));
+      return res.status(429).json({ error: 'Too many failed login attempts. Try again later.' });
+    }
     
     // Get user from database
     const user = userDb.getUserByUsername(username);
     if (!user) {
+      recordLoginFailure(failureKey);
       return res.status(401).json({ error: 'Invalid username or password' });
     }
     
     // Verify password
     const isValidPassword = await bcrypt.compare(password, user.password_hash);
     if (!isValidPassword) {
+      recordLoginFailure(failureKey);
       return res.status(401).json({ error: 'Invalid username or password' });
     }
     
+    clearLoginFailures(failureKey);
+
     // Generate token
     const token = generateToken(user);
     


### PR DESCRIPTION
## Problem
Post-v1.7.0 review findings left release workflow privileges and action references mutable, sensitive SQLite storage permissive, public auth parsing overly large, login unthrottled, CLI global flags lossy, scripts tests undiscovered, Cargo output racy, and self-hosting guidance inaccurate.

## Fix
- Pin the Discord notifier action to the resolved v1.19.0 commit, grant read-only contents permission, and remove checkout because the notifier action only declares webhook/release inputs and does not require repository files.
- Create new database directories as 0700 and secure the database plus existing WAL/SHM sidecars as 0600, tolerating unsupported chmod filesystems.
- Apply 64kb JSON/urlencoded parsing to public `/api/auth` before authenticated-route 50mb parsers.
- Limit each username+IP to 10 failed logins per 15 minutes with a Retry-After 429 response. The existing six-character password floor is intentionally unchanged; no named constant exists.
- Preserve pre-command `--port`, `--host`, and `--yes`/`-y`; forward global install port/confirmation options and reject a command used as an option value.
- Include `scripts/` tests, including release verification tests, in server-side discovery while retaining generated/dependency skips.
- Wait for Cargo child `close` before parsing piped stdout.
- Correct managed-root ordering and Node runtime requirements in SELF-HOST.md.

## Tests
- `TSX_TSCONFIG_PATH=server/tsconfig.json node --import tsx --test server/routes/auth-limiter.test.js`
- `TSX_TSCONFIG_PATH=server/tsconfig.json node --import tsx --test server/modules/database/tests/connection-permissions.test.ts`
- `TSX_TSCONFIG_PATH=server/tsconfig.json node --import tsx --test server/cli.test.js`
- `node --test scripts/run-tests.test.mjs`
- `TSX_TSCONFIG_PATH=server/tsconfig.json node --import tsx --test scripts/release/verify-db-rollback-compatibility.test.ts`
- `node --check server/index.js && node --check server/routes/auth.js && node --check server/cli.js && node --check scripts/run-tests.mjs && node --check scripts/build-rust-core.mjs`