### PR TITLE
fix(notifications): preserve completion delivery correctness

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -731,7 +731,7 @@ async function startServer() {
             // Server-side so web push works with every tab closed.
             // Shared kill switch: CHATMUX_LIVE_NOTIFY=0.
             const ensureSharedDiscovery = async () => {
-                await discoveryCollector.ensureFresh(2_000);
+                await discoveryCollector.ensureFresh(2_000, true);
                 return discoveryCollector.currentDetailed();
             };
             startLiveTurnMonitor(2_000, async () => {

--- a/server/modules/database/migrations.ts
+++ b/server/modules/database/migrations.ts
@@ -605,6 +605,14 @@ const MIGRATIONS: Migration[] = [
       db.exec('DROP TABLE IF EXISTS user_credentials');
     },
   },
+  {
+    version: 16,
+    migrate: (db) => {
+      if (!tableExists(db, 'completion_notification_outbox')) return;
+      db.exec(`CREATE INDEX IF NOT EXISTS idx_completion_notification_outbox_decision_key
+        ON completion_notification_outbox(decision_key, user_id, id)`);
+    },
+  },
 ];
 
 export const runMigrations = (db: Database) => {

--- a/server/modules/database/repositories/completion-notification-outbox.ts
+++ b/server/modules/database/repositories/completion-notification-outbox.ts
@@ -298,6 +298,16 @@ export class CompletionNotificationOutboxRepository {
   acknowledge(deliveryId: number, claimToken: string, now: number): boolean {
     return this.finishClaim(deliveryId, claimToken, `state = 'acknowledged', acknowledged_at = ?, error_class = NULL`, [now]);
   }
+
+  /** A sent push whose acknowledgement could not be persisted must never be reclaimed. */
+  sentUnacknowledged(deliveryId: number, claimToken: string): boolean {
+    return this.finishClaim(
+      deliveryId,
+      claimToken,
+      `state = 'permanent_failed', error_class = 'sent_unacknowledged'`,
+      [],
+    );
+  }
   /**
    * Call immediately before transport. A paused policy wins the token CAS and
    * does not consume an attempt; only a permitted transport increments it.

--- a/server/modules/database/schema.ts
+++ b/server/modules/database/schema.ts
@@ -245,6 +245,8 @@ CREATE INDEX IF NOT EXISTS idx_completion_notification_watch_mutations_target
     ON completion_notification_watch_mutations(target_id);
 CREATE INDEX IF NOT EXISTS idx_completion_notification_outbox_user_created
     ON completion_notification_outbox(user_id, created_at, id);
+CREATE INDEX IF NOT EXISTS idx_completion_notification_outbox_decision_key
+    ON completion_notification_outbox(decision_key, user_id, id);
 CREATE INDEX IF NOT EXISTS idx_completion_notification_deliveries_due
     ON completion_notification_deliveries(state, next_due_at, id);
 CREATE INDEX IF NOT EXISTS idx_completion_notification_deliveries_subscription

--- a/server/modules/database/tests/completion-notification-lifecycle.integration.test.ts
+++ b/server/modules/database/tests/completion-notification-lifecycle.integration.test.ts
@@ -307,6 +307,16 @@ function detailedSession() {
   };
 }
 
+test('resolver does not expose a previously promoted app target after its mapping disappears', async () => {
+  await withIsolatedDatabase(() => {
+    sessionsDb.createSession('resolver-session', 'claude', '/workspace/resolver', undefined, undefined, undefined, process.execPath);
+    assert.equal(resolveCompletionTargetsFromDetailedScan(detailedSession(), 1)[0]?.target.kind, 'app');
+
+    sessionsDb.deleteSessionById('resolver-session');
+    assert.deepEqual(resolveCompletionTargetsFromDetailedScan(detailedSession(), 1), []);
+  });
+});
+
 test('resolver contains pre- and post-promotion identity conflicts without exposing identity keys', async () => {
   await withIsolatedDatabase(() => {
     sessionsDb.createSession('resolver-session', 'claude', '/workspace/resolver', undefined, undefined, undefined, process.execPath);

--- a/server/modules/database/tests/completion-notifications.integration.test.ts
+++ b/server/modules/database/tests/completion-notifications.integration.test.ts
@@ -95,7 +95,7 @@ const appDecision = (userId: number, targetIdentityKey: string, sessionId = 'ses
 test('v13 clamps legacy liveStop and direct valid JSON writes while completion policy remains all-off', () => {
   withDatabase((db) => {
     assert.deepEqual(all<{ version: number }>(db, 'SELECT version FROM schema_migrations ORDER BY version').map((row) => row.version),
-      Array.from({ length: 15 }, (_, index) => index + 1));
+      Array.from({ length: 16 }, (_, index) => index + 1));
     addUser(db, 1);
     assert.deepEqual(get<Row>(db, 'SELECT desired_web_push, consent_configured, enforcement_enabled FROM completion_notification_policy WHERE user_id = 1'),
       { desired_web_push: 0, consent_configured: 0, enforcement_enabled: 1 });
@@ -444,6 +444,30 @@ test('terminal decisions fan out owners once and enforce delivery claims, pause,
     assert.equal(outbox.endpointGone(retry.id, retry.claimToken), true);
     assert.equal(get<Row>(db, "SELECT * FROM push_subscriptions WHERE endpoint = 'https://push/shared'"), undefined);
     assert.equal(outbox.getDeliveryState(retry.id), 'endpoint_removed');
+  });
+});
+
+test('a sent-but-unacknowledged delivery is terminal and cannot be reclaimed', () => {
+  withDatabase((db) => {
+    addUser(db, 1);
+    addSubscription(db, 1);
+    enablePush(db, 1);
+    db.prepare(`INSERT INTO completion_notification_outbox
+      (decision_id, decision_key, user_id, event_code, target_alias_snapshot, payload_json, notification_tag)
+      VALUES ('sent-decision', 'sent-key', 1, 'reply_ready', 'target', '{}', 'tag')`).run();
+    const outboxId = get<{ id: number }>(db,
+      "SELECT id FROM completion_notification_outbox WHERE decision_id = 'sent-decision'")!.id;
+    db.prepare(`INSERT INTO completion_notification_deliveries
+      (outbox_id, subscription_id, subscription_id_at_creation, endpoint_owner_id, endpoint_snapshot, next_due_at)
+      VALUES (?, 1, 1, 1, 'https://push/1', 0)`).run(outboxId);
+    const outbox = new CompletionNotificationOutboxRepository(db);
+    const claim = outbox.claimDue(0, 1, 10)[0]!;
+    assert.equal(outbox.prepareSend(claim.id, claim.claimToken), true);
+    assert.equal(outbox.sentUnacknowledged(claim.id, claim.claimToken), true);
+    assert.deepEqual(get<{ state: string; error_class: string }>(db,
+      'SELECT state, error_class FROM completion_notification_deliveries WHERE id = ?', claim.id),
+    { state: 'permanent_failed', error_class: 'sent_unacknowledged' });
+    assert.deepEqual(outbox.claimDue(10_000, 1, 10), []);
   });
 });
 test('duplicate panes observing the same conversation and terminal evidence create one notification', () => {

--- a/server/modules/database/tests/migrations-integrity.test.ts
+++ b/server/modules/database/tests/migrations-integrity.test.ts
@@ -242,7 +242,7 @@ const fxFixtures: Array<{ id: string; seed: (db: Database.Database) => void; ver
       runMigrations(db);
     },
     verify: (db) => {
-      assert.deepEqual(migrationVersions(db), Array.from({ length: 15 }, (_, index) => index + 1));
+      assert.deepEqual(migrationVersions(db), Array.from({ length: 16 }, (_, index) => index + 1));
       assert.equal(
         get<Row>(db, "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'api_keys'"),
         undefined,
@@ -252,6 +252,10 @@ const fxFixtures: Array<{ id: string; seed: (db: Database.Database) => void; ver
         undefined,
       );
       assert.ok(get<Row>(db, "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_sessions_provider_session_id'"));
+      assert.match(
+        get<{ sql: string }>(db, "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_completion_notification_outbox_decision_key'")!.sql,
+        /ON completion_notification_outbox\s*\(decision_key, user_id, id\)/,
+      );
       assert.deepEqual(
         all<TableInfoRow>(
           db,
@@ -465,13 +469,31 @@ test('replays a complete pre-journal database without changing data, schema, or 
 
     runMigrations(db);
     assert.deepEqual(snapshot(), beforeReplay);
-    assert.deepEqual(migrationVersions(db), Array.from({ length: 15 }, (_, index) => index + 1));
+    assert.deepEqual(migrationVersions(db), Array.from({ length: 16 }, (_, index) => index + 1));
 
     const afterReplay = snapshot();
     runMigrations(db);
     assert.deepEqual(snapshot(), afterReplay);
-    assert.deepEqual(migrationVersions(db), Array.from({ length: 15 }, (_, index) => index + 1));
+    assert.deepEqual(migrationVersions(db), Array.from({ length: 16 }, (_, index) => index + 1));
     assertForeignKeysValid(db);
+
+  } finally {
+    db.close();
+  }
+});
+test('migration 16 adds the decision-key-leading outbox index to existing databases', () => {
+  const db = createLegacyDatabase();
+  try {
+    runMigrations(db);
+    db.exec(`DROP INDEX idx_completion_notification_outbox_decision_key;
+      DELETE FROM schema_migrations WHERE version = 16`);
+
+    runMigrations(db);
+    assert.match(
+      get<{ sql: string }>(db,
+        "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_completion_notification_outbox_decision_key'")!.sql,
+      /ON completion_notification_outbox\s*\(decision_key, user_id, id\)/,
+    );
   } finally {
     db.close();
   }

--- a/server/modules/notifications/services/completion-outbox-dispatcher.service.ts
+++ b/server/modules/notifications/services/completion-outbox-dispatcher.service.ts
@@ -6,7 +6,7 @@ import {
 
 type ClaimedCompletionDelivery = ReturnType<typeof completionNotificationOutboxDb.claimDue>[number];
 type CompletionOutboxStore = Pick<typeof completionNotificationOutboxDb,
-  'claimDue' | 'prepareSend' | 'acknowledge' | 'endpointGone' | 'permanentFailure' | 'retry'>;
+  'claimDue' | 'prepareSend' | 'acknowledge' | 'sentUnacknowledged' | 'endpointGone' | 'permanentFailure' | 'retry'>;
 type PushSender = (subscription: { endpoint: string; keys: { p256dh: string; auth: string } }, payload: string) => Promise<void>;
 const require = createRequire(import.meta.url);
 const webPush = require('web-push') as { sendNotification: PushSender };
@@ -99,8 +99,9 @@ export function createCompletionOutboxDispatcher({
         acknowledgementError = error;
       }
     }
-    // Transport already succeeded. Retry acknowledgement only within this
-    // bounded drain; never re-send this delivery after an acknowledgement fault.
+    // The push has reached its provider. Persist a terminal outcome rather
+    // than leaving an expired claim eligible for a second send.
+    outbox.sentUnacknowledged(delivery.id, delivery.claimToken);
     if (acknowledgementError !== undefined) {
       logError('[Completion Outbox] Acknowledgement error:', acknowledgementError);
     }

--- a/server/modules/notifications/services/completion-target-resolver.service.ts
+++ b/server/modules/notifications/services/completion-target-resolver.service.ts
@@ -158,6 +158,9 @@ function resolveExternalCompletionTarget(
   );
   const generationId = generationTargetId(generationIdentityKey);
 
+  // A prior promotion makes createTarget resolve this generation through its
+  // former app target. When that app mapping is now absent, never expose it.
+  if (mappingState === 'none' && generationTarget.kind !== 'external_generation') return null;
   if (mappingState === 'none') {
     return {
       generationTargetId: generationId,

--- a/server/modules/notifications/services/event-driven-monitor-loop.service.ts
+++ b/server/modules/notifications/services/event-driven-monitor-loop.service.ts
@@ -51,6 +51,11 @@ export function startEventDrivenMonitorLoop<Event>({
     void drain();
   };
 
+  const requestFallbackTick = (): void => {
+    if (running) return;
+    requestTick();
+  };
+
   const unsubscribe = subscribe((event) => {
     if (stopped || !accepts(event)) return;
     if (!eventBurstActive) {
@@ -66,7 +71,7 @@ export function startEventDrivenMonitorLoop<Event>({
     quietTimer.unref?.();
   });
 
-  const fallbackTimer = setInterval(requestTick, fallbackMs);
+  const fallbackTimer = setInterval(requestFallbackTick, fallbackMs);
   fallbackTimer.unref?.();
   requestTick();
 

--- a/server/modules/notifications/services/external-turn-monitor.service.ts
+++ b/server/modules/notifications/services/external-turn-monitor.service.ts
@@ -288,6 +288,9 @@ export function createExternalTurnMonitor(deps: MonitorDeps) {
           ...(session ? diagnosticContext(session) : {}),
         });
       }
+      for (const identityKey of readBackoff.keys()) {
+        if (!sessionsByIdentity.has(identityKey)) readBackoff.delete(identityKey);
+      }
       const completeObservations: Array<{ generationTargetId: number; paneEvidenceKey: string }> = [];
       const currentPaneRoster = new Set<string>();
       const replacementGenerationIdsByPane = new Map<string, Set<number>>();

--- a/server/modules/notifications/services/live-turn-monitor.service.ts
+++ b/server/modules/notifications/services/live-turn-monitor.service.ts
@@ -250,6 +250,10 @@ export function createLiveTurnMonitor(deps: MonitorDeps) {
       for (const id of cursors.keys()) {
         if (!seen.has(id)) cursors.delete(id);
       }
+      for (const key of diagnosticLastReported.keys()) {
+        const sessionId = key.slice(key.indexOf('\0') + 1);
+        if (sessionId && !seen.has(sessionId)) diagnosticLastReported.delete(key);
+      }
     } catch {
       emitDiagnostic('tick_unavailable');
     } finally {

--- a/server/modules/notifications/tests/completion-outbox-dispatcher.test.ts
+++ b/server/modules/notifications/tests/completion-outbox-dispatcher.test.ts
@@ -31,6 +31,7 @@ function store(batches: ReturnType<typeof delivery>[][]) {
     claimDue: () => batches.shift() ?? [],
     prepareSend: (id: number, token: string) => { calls.push(['prepare', id, token]); return true; },
     acknowledge: (id: number, token: string, now: number) => { calls.push(['ack', id, token, now]); return true; },
+    sentUnacknowledged: (id: number, token: string) => { calls.push(['sent-unacknowledged', id, token]); return true; },
     endpointGone: (id: number, token: string, now: number) => { calls.push(['gone', id, token, now]); return true; },
     permanentFailure: (id: number, token: string, errorClass: string) => { calls.push(['permanent', id, token, errorClass]); return true; },
     retry: (id: number, token: string, due: number, errorClass: string) => { calls.push(['retry', id, token, due, errorClass]); return true; },
@@ -161,6 +162,7 @@ test('dispatcher preserves a terminal acknowledgement conflict without resending
   assert.equal(outbox.calls.filter(([name]) => name === 'ack').length, 3);
   assert.equal(outbox.calls.filter(([name]) => name === 'retry').length, 0);
   assert.equal(errors.length, 1);
+  assert.equal(outbox.calls.filter(([name]) => name === 'sent-unacknowledged').length, 1);
 });
 
 test('dispatcher acknowledges a send that resolves while stop is waiting', async () => {

--- a/server/modules/notifications/tests/event-driven-monitor-loop.test.ts
+++ b/server/modules/notifications/tests/event-driven-monitor-loop.test.ts
@@ -70,6 +70,26 @@ test('an event during a slow tick queues one non-overlapping follow-up', async (
   stop();
 });
 
+test('fallback intervals do not queue catch-up ticks behind a slow monitor tick', async () => {
+  let release!: () => void;
+  let ticks = 0;
+  const stop = startEventDrivenMonitorLoop({
+    tick: async () => {
+      ticks += 1;
+      if (ticks === 1) await new Promise<void>((resolve) => { release = resolve; });
+    },
+    subscribe: () => () => {},
+    accepts: () => true,
+    fallbackMs: 50,
+  });
+  await wait(70);
+  assert.equal(ticks, 1);
+  release();
+  await wait(5);
+  assert.equal(ticks, 1);
+  stop();
+});
+
 test('the fallback catches a missed event without constant polling', async () => {
   let ticks = 0;
   const stop = startEventDrivenMonitorLoop({

--- a/server/modules/notifications/tests/external-turn-monitor.test.ts
+++ b/server/modules/notifications/tests/external-turn-monitor.test.ts
@@ -243,3 +243,16 @@ test('read backoff resets when a provider binding changes', async () => {
   current = session({ providerSessionId: 'late' }); await monitor.tick();
   assert.equal(calls, 3, 'binding change clears the pending backoff');
 });
+
+test('removing an external generation clears its read backoff', async () => {
+  const h = harness();
+  h.setAnswer({ status: 'unavailable', activity: 'unknown', reasonCode: 'transcript_read_unavailable', appSession: null, transcriptEnded: false });
+  await h.monitor.tick();
+  assert.equal(h.monitor.stats().read_unavailable, 1);
+
+  h.setSessions([]);
+  await h.monitor.tick();
+  h.setSessions([session()]);
+  await h.monitor.tick();
+  assert.equal(h.monitor.stats().read_unavailable, 2);
+});

--- a/server/modules/notifications/tests/live-turn-monitor.test.ts
+++ b/server/modules/notifications/tests/live-turn-monitor.test.ts
@@ -66,6 +66,32 @@ test('disappearance and manual interruption silently retire cursors without a fi
   assert.equal(h.notices.length, 0); assert.equal(h.monitor.cursorCount(), 0);
 });
 
+test('retiring a session clears its per-session diagnostic throttle', async () => {
+  let present = true;
+  const diagnostics: Array<{ code: string; count: number }> = [];
+  const monitor = createLiveTurnMonitor({
+    getUserId: () => 1,
+    getDetailed: async () => ({
+      ok: true,
+      sessions: present ? [{ id: 's1', tmuxName: 'pane', claim: 'lineage' as const }] : [],
+      transcriptPaths: present ? new Map([['s1', '/tmp/s1']]) : new Map<string, string>(),
+    }),
+    statSize: async () => { throw new Error('unavailable'); },
+    notify: async () => {},
+    diagnostic: (event) => { diagnostics.push(event); },
+  });
+
+  await monitor.tick();
+  present = false;
+  await monitor.tick();
+  present = true;
+  await monitor.tick();
+  assert.deepEqual(diagnostics.map(({ code, count }) => ({ code, count })), [
+    { code: 'transcript_unavailable', count: 1 },
+    { code: 'transcript_unavailable', count: 2 },
+  ]);
+});
+
 test('omits cwd, idle, and transcript-pathless rows', async () => {
   const h = harness();
   h.rows([{ id: 'cwd', tmuxName: 'pane', claim: 'cwd' }, { id: 'idle-gjc:1', tmuxName: 'pane', claim: 'lineage' }, { id: 'no-path', tmuxName: 'pane', claim: 'lineage' }]);

--- a/server/modules/providers/services/discovery-collector.service.ts
+++ b/server/modules/providers/services/discovery-collector.service.ts
@@ -103,7 +103,7 @@ export type DiscoveryCollector = {
   setActive(active: boolean): void;
   forceRefresh(): void;
   tick(): Promise<void>;
-  ensureFresh(maxAgeMs: number): Promise<void>;
+  ensureFresh(maxAgeMs: number, forceFull?: boolean): Promise<void>;
   currentSnapshot(): DiscoverySnapshot;
   currentDetailed(): DiscoveryDetailedSnapshot;
   onSnapshot(listener: (snapshot: DiscoverySnapshot) => void): () => void;
@@ -395,7 +395,10 @@ export function createDiscoveryCollector(options: DiscoveryCollectorOptions = {}
   function runTick(forceFull: boolean): Promise<void> {
     if (disposed) return Promise.resolve();
     if (currentTick) {
-      if (forceFull && !currentTickSatisfiesFullScan) fullRefreshPending = true;
+      if (forceFull && !currentTickSatisfiesFullScan) {
+        fullRefreshPending = true;
+        return currentTick.then(() => runTick(true));
+      }
       return currentTick;
     }
     currentTickSatisfiesFullScan = forceFull
@@ -514,12 +517,12 @@ export function createDiscoveryCollector(options: DiscoveryCollectorOptions = {}
       }, FORCE_REFRESH_DEBOUNCE_MS);
     },
     tick: () => runTick(true),
-    async ensureFresh(maxAgeMs) {
+    async ensureFresh(maxAgeMs, forceFull = false) {
       const ageMs = detailed.takenAtMs === null
         ? Number.POSITIVE_INFINITY
         : Math.max(0, now() - detailed.takenAtMs);
-      if (ageMs <= Math.max(0, maxAgeMs)) return;
-      await runTick(false);
+      if (!forceFull && ageMs <= Math.max(0, maxAgeMs)) return;
+      await runTick(forceFull);
     },
     currentSnapshot: () => snapshot,
     currentDetailed: () => detailed,

--- a/server/modules/providers/tests/discovery-collector.service.test.ts
+++ b/server/modules/providers/tests/discovery-collector.service.test.ts
@@ -260,6 +260,52 @@ test('collector shares one fresh detailed scan with UI and notification consumer
   assert.equal(externalScans, 2);
 });
 
+test('a forced freshness check performs full discovery despite an unchanged host fingerprint', async () => {
+  let now = 1_000;
+  let externalScans = 0;
+  let holdProbe = false;
+  let releaseProbe = () => {};
+  let probeStarted = () => {};
+  let waitForProbe = new Promise<void>((resolve) => { probeStarted = resolve; });
+  const collector = createDiscoveryCollector({
+    now: () => now,
+    scanExternal: async () => {
+      externalScans += 1;
+      return { ok: true, sessions: [external] };
+    },
+    scanLive: async () => ({ ok: true, sessions: [] }),
+    scanHost: async () => {
+      if (holdProbe) {
+        probeStarted();
+        await new Promise<void>((resolve) => { releaseProbe = resolve; });
+      }
+      return {
+        ok: true,
+        capturedAtMs: now,
+        panes: [{ name: external.tmuxName, tmux, pid: external.agentPid, command: 'ssh' }],
+      };
+    },
+    isProcessAlive: async () => true,
+  });
+
+  await collector.tick();
+  now += 1;
+  await collector.ensureFresh(0);
+  assert.equal(externalScans, 2);
+  now += 1;
+  await collector.ensureFresh(2_000, true);
+  assert.equal(externalScans, 3);
+
+  holdProbe = true;
+  now += 1;
+  const nonForcedTick = collector.ensureFresh(0);
+  await waitForProbe;
+  const forcedTick = collector.ensureFresh(2_000, true);
+  releaseProbe();
+  await Promise.all([nonForcedTick, forcedTick]);
+  assert.equal(externalScans, 4, 'a forced caller waits for a full tick after an in-flight probe');
+});
+
 test('stable one-second host probes skip full discovery until panes change or stale rows need confirmation', async () => {
   let now = 1_000;
   let externalScans = 0;


### PR DESCRIPTION
## Problem\nPost-v1.7.0 review findings left completion notification fallbacks stale, allowed stale promoted targets, queued fallback scans behind slow ticks, and could reclaim a successfully sent but unacknowledged delivery. The outbox replay path also lacked a decision-key-leading index, while monitor diagnostic/backoff maps retained vanished identities.\n\n## Fix\n- Force and await a full discovery collector scan for missed-event notification fallbacks, including when a probe is already in flight.\n- Reject formerly promoted app targets when their external generation has no current mapping.\n- Skip fallback catch-up while a monitor tick runs.\n- Terminalize sent-but-unacknowledged deliveries so expired leases cannot resend them.\n- Add migration 16 and schema index for outbox decision-key replay lookups.\n- Prune vanished live diagnostic and external read-backoff identities.\n\n## Tests\n`TSX_TSCONFIG_PATH=server/tsconfig.json node --import tsx --test server/modules/providers/tests/discovery-collector.service.test.ts server/modules/notifications/tests/event-driven-monitor-loop.test.ts server/modules/notifications/tests/completion-outbox-dispatcher.test.ts server/modules/notifications/tests/live-turn-monitor.test.ts server/modules/notifications/tests/external-turn-monitor.test.ts server/modules/database/tests/completion-notification-lifecycle.integration.test.ts server/modules/database/tests/completion-notifications.integration.test.ts server/modules/database/tests/migrations-integrity.test.ts`\n\nPasses: 107 tests.