### PR TITLE
fix(providers): harden watcher and transcript lifecycle

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -415,10 +415,20 @@ app.get('/api/projects/:projectId/sessions/:sessionId/token-usage', authenticate
 
         // Handle Codex sessions
         if (provider === 'codex') {
+            if (!sessionRow.provider_session_id || !sessionRow.jsonl_path) {
+                return res.status(404).json({ error: 'Codex transcript not found', sessionId: safeSessionId });
+            }
+
             const history = await sessionsService.fetchHistory(safeSessionId, {
                 limit: 0,
                 offset: 0,
             });
+            if (history.sourceStatus === 'missing') {
+                return res.status(404).json({ error: 'Codex transcript not found', sessionId: safeSessionId });
+            }
+            if (history.sourceStatus === 'unreadable') {
+                return res.status(500).json({ error: 'Failed to read Codex transcript', sessionId: safeSessionId });
+            }
             const tokenUsage = history.tokenUsage && typeof history.tokenUsage === 'object'
                 ? history.tokenUsage
                 : {};

--- a/server/modules/providers/list/codex/codex-sessions.provider.ts
+++ b/server/modules/providers/list/codex/codex-sessions.provider.ts
@@ -21,6 +21,7 @@ type CodexHistoryResult =
       messages?: NormalizedMessage[];
       total?: number;
       hasMore?: boolean;
+      sourceStatus?: 'available' | 'missing' | 'unreadable';
       offset?: number;
       limit?: number | null;
       tokenUsage?: unknown;
@@ -102,6 +103,8 @@ function extractCodexTextContent(content: unknown): string {
 type CodexHistoryAccumulator = {
   messages: AnyRecord[];
   tokenUsage: AnyRecord | null;
+  retainedBytes: number;
+  malformed: boolean;
 };
 
 type CodexHistoryCacheEntry = {
@@ -113,6 +116,8 @@ type CodexHistoryCacheEntry = {
   modifiedAtMs: number;
   messages: NormalizedMessage[];
   tokenUsage: AnyRecord | null;
+  malformed: boolean;
+  retainedBytes: number;
   toolResults: Map<string, NormalizedMessage>;
   toolUses: Map<string, NormalizedMessage[]>;
   sortTimestamps: WeakMap<NormalizedMessage, number>;
@@ -124,6 +129,7 @@ type CodexHistoryNormalizer = (
 ) => NormalizedMessage[];
 
 const CODEX_HISTORY_CACHE_MAX_ENTRIES = 4;
+const CODEX_HISTORY_CACHE_MAX_RETAINED_BYTES = 8 * 1024 * 1024;
 const codexHistoryCache = new Map<string, CodexHistoryCacheEntry>();
 const codexHistoryRefreshes = new Map<string, Promise<CodexHistoryCacheEntry>>();
 
@@ -283,7 +289,8 @@ function parseCodexHistoryLine(line: string, accumulator: CodexHistoryAccumulato
       });
     }
   } catch {
-    // Skip malformed lines.
+    accumulator.malformed = true;
+    // Skip malformed lines so history can still render valid records.
   }
 }
 
@@ -377,6 +384,8 @@ async function refreshCodexHistoryCache(
       modifiedAtMs: metadata.mtimeMs,
       messages: [],
       tokenUsage: null,
+      retainedBytes: 0,
+      malformed: false,
       toolResults: new Map(),
       toolUses: new Map(),
       sortTimestamps: new WeakMap(),
@@ -387,6 +396,8 @@ async function refreshCodexHistoryCache(
     const appended: CodexHistoryAccumulator = {
       messages: [],
       tokenUsage: entry.tokenUsage,
+      retainedBytes: 0,
+      malformed: entry.malformed,
     };
     let tail = entry.tail;
     const fileStream = fsSync.createReadStream(sessionFilePath, {
@@ -398,6 +409,7 @@ async function refreshCodexHistoryCache(
       const lines = `${tail}${chunk}`.split(/\r?\n/);
       tail = lines.pop() ?? '';
       for (const line of lines) {
+        appended.retainedBytes += Buffer.byteLength(line);
         parseCodexHistoryLine(line, appended);
         if (appended.messages.length > 0) {
           appendNormalizedCodexHistory(entry, appended.messages, sessionId, normalize);
@@ -409,10 +421,16 @@ async function refreshCodexHistoryCache(
     entry.tokenUsage = appended.tokenUsage;
     entry.tail = tail;
     entry.offset = metadata.size;
+    entry.retainedBytes += appended.retainedBytes;
+    entry.malformed = appended.malformed;
     entry.modifiedAtMs = metadata.mtimeMs;
   }
 
-  touchCodexHistoryCache(sessionId, entry);
+  if (entry.retainedBytes + Buffer.byteLength(entry.tail) <= CODEX_HISTORY_CACHE_MAX_RETAINED_BYTES) {
+    touchCodexHistoryCache(sessionId, entry);
+  } else {
+    codexHistoryCache.delete(sessionId);
+  }
   return entry;
 }
 
@@ -444,11 +462,12 @@ async function getCodexSessionMessages(
 
     if (!sessionFilePath) {
       console.warn(`Codex session file not found for session ${sessionId}`);
-      return { messages: [], total: 0, hasMore: false };
+      return { messages: [], total: 0, hasMore: false, sourceStatus: 'missing' };
     }
 
-    const { messages, tokenUsage } = await loadCodexHistory(sessionId, sessionFilePath, normalize);
+    const { messages, tokenUsage, malformed } = await loadCodexHistory(sessionId, sessionFilePath, normalize);
     const total = messages.length;
+    const sourceStatus = malformed ? 'unreadable' : 'available';
 
     if (limit !== null) {
       const startIndex = Math.max(0, total - offset - limit);
@@ -463,13 +482,22 @@ async function getCodexSessionMessages(
         offset,
         limit,
         tokenUsage,
+        sourceStatus,
       };
     }
 
-    return { messages, tokenUsage };
+    return { messages, tokenUsage, sourceStatus };
   } catch (error) {
     console.error(`Error reading Codex session messages for ${sessionId}:`, error);
-    return { messages: [], total: 0, hasMore: false };
+    const code = error && typeof error === 'object' && 'code' in error
+      ? error.code
+      : undefined;
+    return {
+      messages: [],
+      total: 0,
+      hasMore: false,
+      sourceStatus: code === 'ENOENT' ? 'missing' : 'unreadable',
+    };
   }
 }
 
@@ -759,11 +787,19 @@ export class CodexSessionsProvider implements IProviderSessions {
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       console.warn(`[CodexProvider] Failed to load session ${sessionId}:`, message);
-      return { messages: [], total: 0, hasMore: false, offset: 0, limit: null };
+      return {
+        messages: [],
+        total: 0,
+        hasMore: false,
+        offset: 0,
+        limit: null,
+        sourceStatus: 'unreadable',
+      };
     }
 
     const normalized = Array.isArray(result) ? result : (result.messages || []);
     const tokenUsage = Array.isArray(result) ? undefined : result.tokenUsage;
+    const sourceStatus = Array.isArray(result) ? 'available' : result.sourceStatus;
 
     let total = 0;
     for (const msg of normalized) {
@@ -782,6 +818,7 @@ export class CodexSessionsProvider implements IProviderSessions {
       offset: normalizedOffset,
       limit: normalizedLimit,
       tokenUsage,
+      sourceStatus,
     };
   }
 }

--- a/server/modules/providers/services/external-cli-sessions.service.ts
+++ b/server/modules/providers/services/external-cli-sessions.service.ts
@@ -515,6 +515,12 @@ export function isCodexRuntimeProcess(
     && !proc.args?.includes(' app-server')
     && !proc.args?.includes('code-mode');
 }
+
+export function isClaudeRuntimeProcess(
+  proc: Pick<ProcessTreeEntry, 'comm' | 'args'>,
+): boolean {
+  return processCliKind(proc) === 'claude';
+}
 /**
  * Foreground-aware process classification. A GJC descendant excludes the tmux
  * session from this lane. Other agents must own the pane foreground (or carry
@@ -934,7 +940,8 @@ async function inferClaudeSessionIds(args: {
     const targetKey = tmuxPaneIdentityKey(pane.tmux);
     if (!claudeTargets.has(targetKey) || !pane.cwd) continue;
     for (const pid of descendants(pane.pid, children)) {
-      if (procByPid.get(pid)?.comm !== 'claude') continue;
+      const proc = procByPid.get(pid);
+      if (!proc || !isClaudeRuntimeProcess(proc)) continue;
       const byPid = candidates.get(targetKey) ?? new Map<number, string>();
       byPid.set(pid, pane.cwd);
       candidates.set(targetKey, byPid);

--- a/server/modules/providers/services/sessions-watcher.service.ts
+++ b/server/modules/providers/services/sessions-watcher.service.ts
@@ -88,7 +88,9 @@ let pendingWatcherFlushTimer: ReturnType<typeof setTimeout> | null = null;
 let watcherRefreshInFlight = false;
 let watcherRescheduleAfterRefresh = false;
 let watcherFallbackTimer: ReturnType<typeof setInterval> | null = null;
-let watcherFallbackInFlight = false;
+let watcherFallbackTask: Promise<void> | null = null;
+let watcherFallbackAbortController: AbortController | null = null;
+let watcherFallbackGeneration = 0;
 type PendingFileUpdate = {
   eventType: WatcherEventType;
   filePath: string;
@@ -523,6 +525,50 @@ function startGjcSessionWatcher(reconcileAfterStart = false): Promise<void> {
   return trackedTask;
 }
 
+function fallbackPassIsActive(generation: number, signal: AbortSignal): boolean {
+  return !signal.aborted
+    && !sessionWatchersClosing
+    && generation === watcherFallbackGeneration;
+}
+
+function startWatcherFallbackPass(): void {
+  if (watcherFallbackTask) return;
+
+  const generation = watcherFallbackGeneration;
+  const controller = new AbortController();
+  watcherFallbackAbortController = controller;
+  const { signal } = controller;
+  const task = (async () => {
+    try {
+      for (const { provider } of PROVIDER_WATCH_PATHS) {
+        if (!fallbackPassIsActive(generation, signal)) return;
+        try {
+          const reconciliation = await sessionSynchronizerService.reconcileProvider(provider, signal);
+          if (!fallbackPassIsActive(generation, signal)) return;
+          for (const sessionId of reconciliation.sessionIds) {
+            if (!fallbackPassIsActive(generation, signal)) return;
+            markTranscriptChanged(
+              provider,
+              providerSessionIdForIndexed(provider, sessionId),
+            );
+            queuePendingWatcherUpdate('change', provider, sessionId);
+          }
+        } catch {
+          if (!fallbackPassIsActive(generation, signal)) return;
+          // Native watcher events remain primary; the next bounded fallback
+          // pass retries a missed or temporarily unreadable provider root.
+        }
+      }
+    } finally {
+      if (watcherFallbackTask === task) {
+        watcherFallbackTask = null;
+        watcherFallbackAbortController = null;
+      }
+    }
+  })();
+  watcherFallbackTask = task;
+}
+
 /**
  * Starts provider filesystem watchers and performs initial DB synchronization.
  */
@@ -576,31 +622,7 @@ export async function initializeSessionsWatcher(): Promise<void> {
   }
 
   if (!watcherFallbackTimer) {
-    watcherFallbackTimer = setInterval(() => {
-      if (watcherFallbackInFlight) return;
-      watcherFallbackInFlight = true;
-      void (async () => {
-        try {
-          for (const { provider } of PROVIDER_WATCH_PATHS) {
-            try {
-              const reconciliation = await sessionSynchronizerService.reconcileProvider(provider);
-              for (const sessionId of reconciliation.sessionIds) {
-                markTranscriptChanged(
-                  provider,
-                  providerSessionIdForIndexed(provider, sessionId),
-                );
-                queuePendingWatcherUpdate('change', provider, sessionId);
-              }
-            } catch {
-              // Native watcher events remain primary; the next bounded fallback
-              // pass retries a missed or temporarily unreadable provider root.
-            }
-          }
-        } finally {
-          watcherFallbackInFlight = false;
-        }
-      })();
-    }, WATCHER_FALLBACK_RECONCILE_MS);
+    watcherFallbackTimer = setInterval(startWatcherFallbackPass, WATCHER_FALLBACK_RECONCILE_MS);
     watcherFallbackTimer.unref?.();
   }
 }
@@ -610,6 +632,7 @@ export async function initializeSessionsWatcher(): Promise<void> {
  */
 export async function closeSessionsWatcher(): Promise<void> {
   sessionWatchersClosing = true;
+  watcherFallbackGeneration += 1;
   gjcWatcherGeneration += 1;
   clearGjcWatcherRestartTimer();
   clearPendingWatcherFlushTimer();
@@ -621,6 +644,8 @@ export async function closeSessionsWatcher(): Promise<void> {
     clearInterval(watcherFallbackTimer);
     watcherFallbackTimer = null;
   }
+  watcherFallbackAbortController?.abort();
+  const fallbackTask = watcherFallbackTask;
   for (const controller of gjcWatcherStartAbortControllers) {
     controller.abort();
   }
@@ -648,6 +673,9 @@ export async function closeSessionsWatcher(): Promise<void> {
     ...startTasks.map((task) => task.catch(() => {
       console.error('Failed to stop GJC native session watcher startup.');
     })),
+    fallbackTask?.catch(() => {
+      console.error('Failed to stop session watcher fallback reconciliation.');
+    }),
   ]);
   watchers.length = 0;
   gjcWatcherRestartDelayMs = 1_000;
@@ -655,5 +683,6 @@ export async function closeSessionsWatcher(): Promise<void> {
   pendingWatcherUpdateStartedAt = null;
   watcherRefreshInFlight = false;
   watcherRescheduleAfterRefresh = false;
-  watcherFallbackInFlight = false;
+  watcherFallbackTask = null;
+  watcherFallbackAbortController = null;
 }

--- a/server/modules/providers/services/tmux-output-activity-monitor.service.ts
+++ b/server/modules/providers/services/tmux-output-activity-monitor.service.ts
@@ -139,7 +139,7 @@ export function createTmuxControlObserver(
     '-S', session.socketPath,
     'attach-session',
     '-r',
-    '-f', 'active-pane',
+    '-f', 'active-pane,ignore-size',
     '-t', session.sessionId,
   ], {
     stdio: ['pipe', 'pipe', 'pipe'],

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
-import { appendFile, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { appendFile, mkdir, mkdtemp, rm, stat, utimes, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -315,6 +315,105 @@ test('Codex history incrementally appends complete JSONL records', { concurrency
         content: '/workspace',
         isError: false,
       });
+    });
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex history drops rollouts that exceed the retained cache bound', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-history-cache-bound-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+
+  try {
+    const sessionId = 'codex-cache-bound-history';
+    const transcriptPath = await writeCodexTranscript(tempRoot, sessionId, workspacePath);
+    const firstContent = `first-${'x'.repeat(8 * 1024 * 1024)}`;
+    const replacementContent = `next-${'x'.repeat(8 * 1024 * 1024)}`;
+    await appendFile(transcriptPath, `${JSON.stringify({
+      type: 'event_msg',
+      payload: { type: 'user_message', message: firstContent },
+    })}\n`, 'utf8');
+
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createSession(
+        sessionId,
+        'codex',
+        workspacePath,
+        undefined,
+        undefined,
+        undefined,
+        transcriptPath,
+      );
+      const provider = new CodexSessionsProvider();
+      assert.equal((await provider.fetchHistory(sessionId)).messages[0]?.content, firstContent);
+
+      const beforeReplacement = await stat(transcriptPath);
+      const replacement = [
+        JSON.stringify({ type: 'session_meta', payload: { id: sessionId, cwd: workspacePath } }),
+        JSON.stringify({
+          type: 'event_msg',
+          payload: { type: 'user_message', message: replacementContent },
+        }),
+        '',
+      ].join('\n');
+      await writeFile(transcriptPath, replacement, 'utf8');
+      await utimes(transcriptPath, beforeReplacement.atime, beforeReplacement.mtime);
+
+      assert.equal((await provider.fetchHistory(sessionId)).messages[0]?.content, replacementContent);
+    });
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex history reports a missing transcript source', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-history-missing-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+
+  try {
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createSession(
+        'codex-missing-history',
+        'codex',
+        workspacePath,
+        undefined,
+        undefined,
+        undefined,
+        path.join(tempRoot, 'missing.jsonl'),
+      );
+
+      const history = await new CodexSessionsProvider().fetchHistory('codex-missing-history');
+      assert.equal(history.sourceStatus, 'missing');
+    });
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
+test('Codex history reports malformed transcript sources as unreadable', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-history-malformed-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  const transcriptPath = path.join(tempRoot, 'malformed.jsonl');
+  await mkdir(workspacePath, { recursive: true });
+  await writeFile(transcriptPath, '{not-json}\n', 'utf8');
+
+  try {
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createSession(
+        'codex-malformed-history',
+        'codex',
+        workspacePath,
+        undefined,
+        undefined,
+        undefined,
+        transcriptPath,
+      );
+
+      const history = await new CodexSessionsProvider().fetchHistory('codex-malformed-history');
+      assert.equal(history.sourceStatus, 'unreadable');
     });
   } finally {
     await rm(tempRoot, { recursive: true, force: true });

--- a/server/modules/providers/tests/external-cli-sessions.service.test.ts
+++ b/server/modules/providers/tests/external-cli-sessions.service.test.ts
@@ -16,6 +16,7 @@ import {
   extractExternalResumeSessionId,
   extractContainedTranscriptSessionId,
   isCodexRuntimeProcess,
+  isClaudeRuntimeProcess,
   normalizeExternalPaneOutput,
   parseClaudeRuntimeSession,
   parseExternalPanes,
@@ -176,6 +177,17 @@ test('Codex process selection accepts the npm wrapper and native child pair', ()
   }), true);
   assert.equal(selectPrimaryCodexProcessPid([89009, 89076]), 89009);
   assert.equal(selectPrimaryCodexProcessPid([]), null);
+});
+
+test('Claude receipt inference recognizes argv-wrapped Claude runtimes', () => {
+  assert.equal(isClaudeRuntimeProcess({
+    comm: 'node',
+    args: 'node /opt/homebrew/bin/claude --resume session-id',
+  }), true);
+  assert.equal(isClaudeRuntimeProcess({
+    comm: 'node',
+    args: 'node /opt/homebrew/bin/codex',
+  }), false);
 });
 
 test('external CLI resolution excludes app-local npm shims', async () => {

--- a/server/modules/providers/tests/tmux-output-activity-monitor.service.test.ts
+++ b/server/modules/providers/tests/tmux-output-activity-monitor.service.test.ts
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
 import type {
@@ -7,6 +10,7 @@ import type {
 } from '@/modules/providers/services/discovery-collector.service.js';
 import { getCachedTmuxInteractiveActivity } from '@/modules/providers/services/tmux-interactive-prompt.service.js';
 import {
+  createTmuxControlObserver,
   createTmuxOutputActivityMonitor,
   tmuxControlOutputPaneId,
   tmuxObserverIsSafe,
@@ -200,9 +204,9 @@ function fakeCollector(initial: DiscoverySnapshot) {
   };
 }
 
-async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+async function waitFor(predicate: () => boolean | Promise<boolean>, timeoutMs = 1_000): Promise<void> {
   const started = Date.now();
-  while (!predicate()) {
+  while (!(await predicate())) {
     if (Date.now() - started > timeoutMs) throw new Error('condition timed out');
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
@@ -230,6 +234,51 @@ test('parses normal and extended tmux control-mode output bells', () => {
   assert.equal(tmuxControlOutputPaneId('%extended-output %31 25 : hello'), '%31');
   assert.equal(tmuxControlOutputPaneId('%session-changed $1 demo'), null);
   assert.equal(tmuxControlOutputPaneId('ordinary terminal output'), null);
+});
+
+test('control-mode observers exclude their client from tmux size calculation', { concurrency: false }, async () => {
+  const tempDirectory = await mkdtemp(path.join(os.tmpdir(), 'tmux-observer-'));
+  const executable = path.join(tempDirectory, 'tmux');
+  const argsFile = path.join(tempDirectory, 'args');
+  const originalPath = process.env.PATH;
+  const originalArgsFile = process.env.TMUX_ARGS_FILE;
+
+  try {
+    await writeFile(executable, '#!/bin/sh\nprintf "%s\\n" "$@" > "$TMUX_ARGS_FILE"\n', { mode: 0o755 });
+    process.env.PATH = `${tempDirectory}:${originalPath ?? ''}`;
+    process.env.TMUX_ARGS_FILE = argsFile;
+    createTmuxControlObserver(
+      { socketPath: '/tmp/tmux-test.sock', sessionId: '$42' },
+      () => undefined,
+      () => undefined,
+    );
+
+    await waitFor(async () => {
+      try {
+        return (await readFile(argsFile, 'utf8')).length > 0;
+      } catch {
+        return false;
+      }
+    });
+    const args = (await readFile(argsFile, 'utf8')).trim().split('\n');
+    assert.deepEqual(args, [
+      '-C',
+      '-S',
+      '/tmp/tmux-test.sock',
+      'attach-session',
+      '-r',
+      '-f',
+      'active-pane,ignore-size',
+      '-t',
+      '$42',
+    ]);
+  } finally {
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    if (originalArgsFile === undefined) delete process.env.TMUX_ARGS_FILE;
+    else process.env.TMUX_ARGS_FILE = originalArgsFile;
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
 });
 
 test('keeps GJC, Codex, OMP, and Claude INPUT states without an open chat', async () => {

--- a/server/shared/types.ts
+++ b/server/shared/types.ts
@@ -310,6 +310,7 @@ export type FetchHistoryResult = {
   offset: number;
   limit: number | null;
   tokenUsage?: unknown;
+  sourceStatus?: 'available' | 'missing' | 'unreadable';
 };
 
 // ---------------------------


### PR DESCRIPTION
## Problem
- Fallback reconciliation could broadcast after watcher shutdown.
- Codex history caching retained complete long rollouts, while missing or unreadable sources appeared as zero usage.
- Read-only tmux control clients influenced pane sizing.
- Claude receipt inference ignored argv-wrapped runtime processes.

## Fix
- Track, abort, generation-gate, and await fallback reconciliation during watcher shutdown.
- Bound retained Codex cache data to 8 MiB per rollout and expose missing/unreadable transcript source state; the token-usage route now returns 404 for missing sources and 500 for unreadable sources.
- Attach tmux control observers with `active-pane,ignore-size`.
- Reuse `processCliKind` for Claude receipt candidates.

## Tests
`TSX_TSCONFIG_PATH=server/tsconfig.json node --import tsx --test server/modules/providers/tests/codex-sessions.test.ts server/modules/providers/tests/tmux-output-activity-monitor.service.test.ts server/modules/providers/tests/external-cli-sessions.service.test.ts`

Passed: 75 tests.