### PR TITLE
fix(ci): repair lint and typecheck breakage from the fix wave

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1,6 +1,5 @@
 import { readdir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 

--- a/server/modules/providers/services/sessions-watcher.service.ts
+++ b/server/modules/providers/services/sessions-watcher.service.ts
@@ -538,7 +538,8 @@ function startWatcherFallbackPass(): void {
   const controller = new AbortController();
   watcherFallbackAbortController = controller;
   const { signal } = controller;
-  const task = (async () => {
+  let task: Promise<void> | null = null;
+  task = (async () => {
     try {
       for (const { provider } of PROVIDER_WATCH_PATHS) {
         if (!fallbackPassIsActive(generation, signal)) return;

--- a/server/modules/providers/tests/discovery-collector.service.test.ts
+++ b/server/modules/providers/tests/discovery-collector.service.test.ts
@@ -266,7 +266,7 @@ test('a forced freshness check performs full discovery despite an unchanged host
   let holdProbe = false;
   let releaseProbe = () => {};
   let probeStarted = () => {};
-  let waitForProbe = new Promise<void>((resolve) => { probeStarted = resolve; });
+  const waitForProbe = new Promise<void>((resolve) => { probeStarted = resolve; });
   const collector = createDiscoveryCollector({
     now: () => now,
     scanExternal: async () => {


### PR DESCRIPTION
PRs #22/#23/#24 were merged while their CI was red (no branch protection gates merges; my merge script failed to check). Three mechanical breakages landed on main:

- `scripts/run-tests.mjs`: empty line inside an import group (import-x/order) — from #22
- `server/modules/providers/tests/discovery-collector.service.test.ts:269`: `let` never reassigned (prefer-const) — from #23
- `server/modules/providers/services/sessions-watcher.service.ts:563`: TS2454 — the async IIFE's `finally` reads `task` which TS cannot prove assigned if the body settles synchronously; declared as `let task: Promise<void> | null = null` before assignment — from #24

Verified locally: full `npm run lint` and both typecheck projects clean; sessions-watcher + discovery-collector tests pass.