### PR TITLE
fix(chat): render Oh My Pi todo snapshots

### DIFF
--- a/src/components/chat/tools/ToolRenderer.tsx
+++ b/src/components/chat/tools/ToolRenderer.tsx
@@ -40,7 +40,7 @@ function getToolCategory(toolName: string): string {
   if (['Edit', 'Write', 'ApplyPatch'].includes(toolName)) return 'edit';
   if (['Grep', 'Glob'].includes(toolName)) return 'search';
   if (toolName === 'Bash') return 'bash';
-  if (['TodoWrite', 'TodoRead'].includes(toolName)) return 'todo';
+  if (['TodoWrite', 'TodoRead', 'todo'].includes(toolName)) return 'todo';
   if (['TaskCreate', 'TaskUpdate', 'TaskList', 'TaskGet'].includes(toolName)) return 'task';
   if (toolName === 'Task') return 'agent';
   if (toolName === 'exit_plan_mode' || toolName === 'ExitPlanMode') return 'plan';
@@ -223,7 +223,8 @@ export const ToolRenderer: React.FC<ToolRendererProps> = memo(({
     const contentProps = displayConfig.getContentProps?.(parsedData, {
       selectedProject,
       createDiff,
-      onFileOpen
+      onFileOpen,
+      toolResult,
     }) || {};
 
     let contentComponent: React.ReactNode = null;

--- a/src/components/chat/tools/configs/toolConfigs.test.tsx
+++ b/src/components/chat/tools/configs/toolConfigs.test.tsx
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import ToolGroupContainer from '../../view/subcomponents/ToolGroupContainer';
+import type { ChatMessage } from '../../types/types';
+import type { ToolGroupItem } from '../../utils/toolGrouping';
+import { ToolRenderer } from '../ToolRenderer';
+
+import { parseOmpTodoResult } from './toolConfigs';
+
+const RESULT_CONTENT = `Remaining items (2):
+  - Implement parser [in_progress] (Implementation)
+  - Ship fix [pending] (Verification)
+Overall: 1/3 done, 2 open.
+Active phase 1/2 "Implementation" (1/2).
+ Implementation:
+    - [X] Reproduce missing todo list
+    - [ ] Implement parser (in progress)
+ Verification:
+    - [ ] Ship fix`;
+
+const toolResult = {
+  content: RESULT_CONTENT,
+  isError: false,
+};
+
+function todoMessage(id: string, content = RESULT_CONTENT): ChatMessage {
+  return {
+    type: 'assistant',
+    timestamp: '2026-08-02T12:00:00.000Z',
+    isToolUse: true,
+    toolName: 'todo',
+    toolId: id,
+    toolInput: { op: 'done', task: 'Reproduce missing todo list' },
+    toolResult: { content, isError: false },
+  };
+}
+
+test('parseOmpTodoResult reads the phase checklist without duplicating its summary', () => {
+  assert.deepEqual(parseOmpTodoResult(toolResult), [
+    { content: 'Reproduce missing todo list', status: 'completed' },
+    { content: 'Implement parser', status: 'in_progress' },
+    { content: 'Ship fix', status: 'pending' },
+  ]);
+});
+
+test('lowercase OMP todo renders its result as a todo list', () => {
+  const html = renderToStaticMarkup(createElement(ToolRenderer, {
+    toolName: 'todo',
+    toolId: 'todo-1',
+    toolInput: { op: 'done', task: 'Reproduce missing todo list' },
+    toolResult,
+    mode: 'input',
+  }));
+
+  assert.match(html, /Todo list/);
+  assert.match(html, /Reproduce missing todo list/);
+  assert.match(html, /Implement parser/);
+  assert.match(html, /Ship fix/);
+  assert.doesNotMatch(html, /Parameters/);
+});
+
+test('consecutive OMP todo snapshots are expanded by default', () => {
+  const group: ToolGroupItem = {
+    _isGroup: true,
+    toolName: 'todo',
+    timestamp: '2026-08-02T12:00:00.000Z',
+    messages: [todoMessage('todo-1'), todoMessage('todo-2')],
+  };
+
+  const html = renderToStaticMarkup(createElement(ToolGroupContainer, {
+    group,
+    prevMessage: null,
+    createDiff: () => [],
+    getMessageKey: (message) => String(message.toolId),
+    provider: 'omp',
+  }));
+
+  assert.match(html, /Todo list/);
+  assert.match(html, /x2/);
+  assert.match(html, /Reproduce missing todo list/);
+  assert.match(html, /aria-expanded="true"/);
+});

--- a/src/components/chat/tools/configs/toolConfigs.ts
+++ b/src/components/chat/tools/configs/toolConfigs.ts
@@ -41,6 +41,51 @@ export interface ToolDisplayConfig {
   };
 }
 
+export type ParsedTodoItem = {
+  content: string;
+  status: 'completed' | 'in_progress' | 'pending';
+};
+
+/**
+ * OMP's lowercase `todo` tool returns the authoritative list as formatted
+ * text in toolResult.content (unlike Claude TodoWrite, whose input owns a
+ * structured `todos` array). Prefer the indented phase checklist to avoid
+ * duplicating the shorter "Remaining items" summary at the top.
+ */
+export function parseOmpTodoResult(result: unknown): ParsedTodoItem[] {
+  const content = result
+    && typeof result === 'object'
+    && 'content' in result
+    ? result.content
+    : null;
+  if (typeof content !== 'string' || !content.trim()) return [];
+
+  const lines = content.split(/\r?\n/);
+  const parseLines = (minimumIndent: number): ParsedTodoItem[] => {
+    const items: ParsedTodoItem[] = [];
+    const seen = new Set<string>();
+    for (const line of lines) {
+      const match = /^(\s*)- \[([xX ])\]\s+(.+?)\s*$/.exec(line);
+      if (!match || match[1].length < minimumIndent) continue;
+      const raw = match[3].trim();
+      const inProgress = /\s+\(in progress\)$/i.test(raw);
+      const item = raw.replace(/\s+\(in progress\)$/i, '').trim();
+      if (!item || seen.has(item)) continue;
+      seen.add(item);
+      items.push({
+        content: item,
+        status: match[2].toLowerCase() === 'x'
+          ? 'completed'
+          : inProgress ? 'in_progress' : 'pending',
+      });
+    }
+    return items;
+  };
+
+  const phaseItems = parseLines(4);
+  return phaseItems.length > 0 ? phaseItems : parseLines(1);
+}
+
 export const TOOL_CONFIGS: Record<string, ToolDisplayConfig> = {
   // ============================================================================
   // COMMAND TOOLS
@@ -230,6 +275,7 @@ export const TOOL_CONFIGS: Record<string, ToolDisplayConfig> = {
     }
   },
 
+
   // ============================================================================
   // TODO TOOLS
   // ============================================================================
@@ -249,6 +295,31 @@ export const TOOL_CONFIGS: Record<string, ToolDisplayConfig> = {
       contentType: 'success-message',
       getMessage: () => 'Todo list updated'
     }
+  },
+
+  // Oh My Pi exposes the current list in the result text of its lowercase
+  // `todo` tool. Keep this snapshot visible instead of falling back to a raw
+  // Parameters card.
+  todo: {
+    input: {
+      type: 'collapsible',
+      icon: 'todo',
+      label: 'Todo list',
+      title: 'Todo list',
+      defaultOpen: true,
+      contentType: 'todo-list',
+      getContentProps: (_input, helpers) => ({
+        todos: parseOmpTodoResult(helpers?.toolResult),
+        isResult: true,
+      }),
+      colorScheme: {
+        border: 'border-violet-400 dark:border-violet-500',
+        icon: 'text-violet-600 dark:text-violet-400',
+      },
+    },
+    result: {
+      hidden: true,
+    },
   },
 
   TodoRead: {

--- a/src/components/chat/view/subcomponents/ToolGroupContainer.tsx
+++ b/src/components/chat/view/subcomponents/ToolGroupContainer.tsx
@@ -76,7 +76,7 @@ export default function ToolGroupContainer({
   pendingAskToolId = null,
   onAskChoiceSelect,
 }: ToolGroupContainerProps) {
-  const [isExpanded, setIsExpanded] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(group.toolName === 'todo');
   const config = getToolConfig(group.toolName).input;
   const label = config.label || group.toolName;
   const borderClass = config.colorScheme?.border || 'border-border';


### PR DESCRIPTION
## Summary
- recognize the lowercase Oh My Pi `todo` tool instead of rendering a generic Parameters card
- parse the authoritative checklist from `toolResult.content` into the existing Todo UI
- expand OMP todo cards and consecutive todo groups by default

## Verification
- `TSX_TSCONFIG_PATH=tsconfig.json node --import tsx --test src/components/chat/tools/configs/toolConfigs.test.tsx`
- `npm run typecheck`
- targeted ESLint on all changed files
- browser smoke: actual Vite `ToolRenderer` showed the expanded 3-item checklist