### PR TITLE
fix(relay): enable verified Claude multi-select answers

### DIFF
--- a/server/modules/providers/services/tmux-interactive-prompt.service.ts
+++ b/server/modules/providers/services/tmux-interactive-prompt.service.ts
@@ -720,18 +720,6 @@ async function answerMultiSelect(
   choices: number[],
   run?: TmuxRunner,
 ): Promise<void> {
-  if (prompt.responder === 'claude-question') {
-    // The Enter-as-toggle assumption below is corroborated for GJC (explicit
-    // "Done selecting" row) and OMP ("Space/Enter toggle" hint), but there is
-    // no evidence for Claude's multi-select keybindings; if Enter submits
-    // instead of toggling, the first key would commit an incomplete
-    // selection into the user's pane. Detection/rendering still work —
-    // answering stays terminal-side until the real key sequence is verified.
-    throw new AppError('This CLI does not support multiple selections.', {
-      code: 'TMUX_INTERACTIVE_CHOICE_UNSUPPORTED',
-      statusCode: 400,
-    });
-  }
   if (choices.length === 0) {
     throw new AppError('Select at least one option.', {
       code: 'TMUX_INTERACTIVE_CHOICE_INVALID',
@@ -753,6 +741,10 @@ async function answerMultiSelect(
     keys.push(...navigationKeys(prompt.options.length - cursor), 'Enter');
   } else if (prompt.responder === 'omp-question') {
     keys.push('Tab', 'Enter');
+  } else if (prompt.responder === 'claude-question') {
+    // Verified against Claude Code 2.1.220: Enter toggles the focused option,
+    // Right opens the Submit tab, and Enter confirms the reviewed answers.
+    keys.push('Right', 'Enter');
   } else {
     throw new AppError('This CLI does not support multiple selections.', {
       code: 'TMUX_INTERACTIVE_CHOICE_UNSUPPORTED',

--- a/server/modules/providers/tests/tmux-interactive-prompt.service.test.ts
+++ b/server/modules/providers/tests/tmux-interactive-prompt.service.test.ts
@@ -338,7 +338,7 @@ test('answers are rejected as stale when a same-shaped prompt with a different b
   assert.equal(calls.some((args) => args.includes('send-keys')), false);
 });
 
-test('Claude multi-select answers are rejected without injecting keys until the toggle sequence is verified', async () => {
+test('Claude multi-select answers reconcile checked options and submit through the review tab', async () => {
   const screen = `
 ☐ Checks
 
@@ -374,9 +374,9 @@ Enter to select · ↑/↓ to navigate · Esc to cancel
     null,
   );
 
-  await assert.rejects(
-    answerTmuxInteractivePrompt(target, prompt.id, [1, 3], run),
-    (error: { code?: string }) => error.code === 'TMUX_INTERACTIVE_CHOICE_UNSUPPORTED',
+  await answerTmuxInteractivePrompt(target, prompt.id, [1, 3], run);
+  assert.deepEqual(
+    calls.filter((args) => args.includes('send-keys')).map((args) => args.at(-1)),
+    ['Enter', 'Down', 'Enter', 'Down', 'Enter', 'Right', 'Enter'],
   );
-  assert.equal(calls.some((args) => args.includes('send-keys')), false);
 });


### PR DESCRIPTION
Closes #14

## Summary
- remove the temporary Claude multi-select response guard
- reconcile checked options with Enter, then open Claude's Submit tab with Right and confirm with Enter
- replace the guard regression with the exact verified key sequence

## Live verification
Claude Code 2.1.220 in a real tmux pane:
- Enter toggled Red and Green independently
- Right opened Review your answers showing Red, Green
- Enter submitted and Claude received Red, Green

## Automated verification
- targeted tmux interactive prompt tests: 10/10 pass
- client and server typecheck pass
- targeted ESLint passes