### PR TITLE
fix(release): invoke CLI from runtime wrapper

### DIFF
--- a/scripts/chatmux-runtime.mjs
+++ b/scripts/chatmux-runtime.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 function loadManagedEnvironment(configPath) {
   if (!configPath) return;
@@ -26,13 +28,32 @@ function loadManagedEnvironment(configPath) {
   }
 }
 
-loadManagedEnvironment(process.env.CHATMUX_ENV_FILE);
+export async function runChatmuxRuntime({
+  platform = process.platform,
+  arch = process.arch,
+  nodeVersion = process.versions.node,
+  cliArgs = process.argv.slice(2),
+  configPath = process.env.CHATMUX_ENV_FILE,
+  importCli = () => import('../dist-server/server/cli.js'),
+} = {}) {
+  loadManagedEnvironment(configPath);
 
-if (process.platform !== 'linux' || process.arch !== 'x64' || process.versions.node.split('.')[0] !== '22') {
-  console.error(
-    `ChatMux server requires Linux x64 with Node.js 22; received ${process.platform} ${process.arch} Node.js ${process.versions.node}.`,
-  );
-  process.exit(1);
+  if (platform !== 'linux' || arch !== 'x64' || nodeVersion.split('.')[0] !== '22') {
+    throw new Error(
+      `ChatMux server requires Linux x64 with Node.js 22; received ${platform} ${arch} Node.js ${nodeVersion}.`,
+    );
+  }
+
+  const cli = await importCli();
+  if (typeof cli.runChatmuxCli !== 'function') {
+    throw new Error('ChatMux CLI entrypoint is unavailable.');
+  }
+  await cli.runChatmuxCli(cliArgs);
 }
 
-await import('../dist-server/server/cli.js');
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  runChatmuxRuntime().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/scripts/chatmux-runtime.test.mjs
+++ b/scripts/chatmux-runtime.test.mjs
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { runChatmuxRuntime } from './chatmux-runtime.mjs';
+
+test('release runtime invokes the exported CLI with its original arguments', async () => {
+  const calls = [];
+
+  await runChatmuxRuntime({
+    platform: 'linux',
+    arch: 'x64',
+    nodeVersion: '22.23.1',
+    cliArgs: ['start', '--port=39001'],
+    configPath: null,
+    importCli: async () => ({
+      runChatmuxCli: async (args) => {
+        calls.push(args);
+      },
+    }),
+  });
+
+  assert.deepEqual(calls, [['start', '--port=39001']]);
+});
+
+test('release runtime rejects an artifact CLI without an invokable entrypoint', async () => {
+  await assert.rejects(
+    runChatmuxRuntime({
+      platform: 'linux',
+      arch: 'x64',
+      nodeVersion: '22.23.1',
+      configPath: null,
+      importCli: async () => ({}),
+    }),
+    /CLI entrypoint is unavailable/,
+  );
+});
+
+test('release runtime enforces the pinned platform before loading the CLI', async () => {
+  let imported = false;
+
+  await assert.rejects(
+    runChatmuxRuntime({
+      platform: 'linux',
+      arch: 'x64',
+      nodeVersion: '24.18.0',
+      configPath: null,
+      importCli: async () => {
+        imported = true;
+        return { runChatmuxCli: async () => {} };
+      },
+    }),
+    /requires Linux x64 with Node.js 22/,
+  );
+  assert.equal(imported, false);
+});

--- a/server/cli.js
+++ b/server/cli.js
@@ -701,9 +701,9 @@ export function buildInstallArgs(options, remainingArgs = []) {
 }
 
 
-// Main CLI handler
-async function main() {
-    const args = process.argv.slice(2);
+// Main CLI handler. Exported so the release runtime wrapper can invoke the
+// CLI after enforcing its pinned platform and Node.js contract.
+export async function runChatmuxCli(args = process.argv.slice(2)) {
     const { command, options, remainingArgs } = parseArgs(args);
 
     // Apply CLI options to environment variables
@@ -762,7 +762,7 @@ async function main() {
 
 // Run the CLI
 if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
-    main().catch(error => {
+    runChatmuxCli().catch(error => {
         console.error('\n❌ Error:', error.message);
         process.exit(1);
     });


### PR DESCRIPTION
## Problem
The v1.8.0 release artifact built successfully, but downstream smoke and rollback jobs could not reach health. The wrapper imported `cli.js`; `cli.js` correctly skipped its direct-entry block because `process.argv[1]` remained the wrapper path, so the process exited without starting ChatMux.

## Fix
- export the CLI dispatcher with explicit argv support
- have the pinned runtime wrapper invoke that dispatcher after platform validation
- add behavioral regressions for argument forwarding, missing entrypoint failure, and platform enforcement

## Verification
- runtime + CLI tests: 5/5 pass
- client/server typecheck pass
- targeted ESLint passes
- failed release evidence: build smoke passed before packaging; extracted wrapper exited 0 without opening its health port