### PR TITLE
fix(installer): make managed root check locale independent

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,7 @@ verify_checksum() {
   [ "$actual" = "$expected" ] || fail "checksum verification failed for $(basename "$payload")"
 }
 read_managed_root_metadata() {
-  metadata=$(stat -c '%F|%u|%d|%i|%a' -- "$INSTALL_ROOT") || fail "could not inspect managed root"
+  metadata=$(LC_ALL=C stat -c '%F|%u|%d|%i|%a' -- "$INSTALL_ROOT") || fail "could not inspect managed root"
   old_ifs=$IFS
   IFS='|'
   read root_type root_uid root_device root_inode root_mode <<EOF


### PR DESCRIPTION
## Summary
- force the installer's `stat` metadata query to use the C locale
- prevent failures when `%F` is localized, such as `디렉터리` under Korean locales

## Verification
- `sh -n install.sh`
- verified the installer fixture with `LANG=ko_KR.UTF-8`

Fixes the one-line installer error:
`[chatmux] ERROR: managed root must be an ordinary directory`