### PR TITLE
fix(installer): use shell directory checks for managed root

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -62,14 +62,15 @@ verify_checksum() {
   [ "$actual" = "$expected" ] || fail "checksum verification failed for $(basename "$payload")"
 }
 read_managed_root_metadata() {
-  metadata=$(LC_ALL=C stat -c '%F|%u|%d|%i|%a' -- "$INSTALL_ROOT") || fail "could not inspect managed root"
+  [ -d "$INSTALL_ROOT" ] && [ ! -L "$INSTALL_ROOT" ] ||
+    fail "managed root must be an ordinary directory"
+  metadata=$(stat -c '%u|%d|%i|%a' -- "$INSTALL_ROOT") || fail "could not inspect managed root"
   old_ifs=$IFS
   IFS='|'
-  read root_type root_uid root_device root_inode root_mode <<EOF
+  read root_uid root_device root_inode root_mode <<EOF
 $metadata
 EOF
   IFS=$old_ifs
-  [ "$root_type" = directory ] || fail "managed root must be an ordinary directory"
   [ "$root_uid" = "$(id -u)" ] || fail "managed root must be owned by the effective user"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,10 @@ EOF
 }
 
 ensure_managed_root() {
+  while [ "$INSTALL_ROOT" != / ] && [ "${INSTALL_ROOT%/}" != "$INSTALL_ROOT" ]; do
+    INSTALL_ROOT=${INSTALL_ROOT%/}
+  done
+
   if [ -e "$INSTALL_ROOT" ] || [ -L "$INSTALL_ROOT" ]; then
     read_managed_root_metadata
   else

--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,9 @@ EOF
 }
 
 ensure_managed_root() {
+  # Strip trailing slashes BEFORE any symlink test. `[ ! -L "$link/" ]` is true
+  # because a trailing slash makes the kernel resolve the link, so reordering
+  # this loop after read_managed_root_metadata silently reopens a symlink escape.
   while [ "$INSTALL_ROOT" != / ] && [ "${INSTALL_ROOT%/}" != "$INSTALL_ROOT" ]; do
     INSTALL_ROOT=${INSTALL_ROOT%/}
   done

--- a/install.sh
+++ b/install.sh
@@ -75,11 +75,15 @@ EOF
 }
 
 ensure_managed_root() {
-  # Strip trailing slashes BEFORE any symlink test. `[ ! -L "$link/" ]` is true
-  # because a trailing slash makes the kernel resolve the link, so reordering
-  # this loop after read_managed_root_metadata silently reopens a symlink escape.
-  while [ "$INSTALL_ROOT" != / ] && [ "${INSTALL_ROOT%/}" != "$INSTALL_ROOT" ]; do
-    INSTALL_ROOT=${INSTALL_ROOT%/}
+  # Strip trailing path terminators BEFORE any symlink test. Both `link/` and
+  # `link/.` make the kernel resolve the link, so `test -L` cannot see it.
+  while :; do
+    case "$INSTALL_ROOT" in
+      / | /.) INSTALL_ROOT=/; break ;;
+      */) INSTALL_ROOT=${INSTALL_ROOT%/} ;;
+      */.) INSTALL_ROOT=${INSTALL_ROOT%/.} ;;
+      *) break ;;
+    esac
   done
 
   if [ -e "$INSTALL_ROOT" ] || [ -L "$INSTALL_ROOT" ]; then

--- a/server/install-bootstrap.test.ts
+++ b/server/install-bootstrap.test.ts
@@ -110,13 +110,20 @@ test('one-line bootstrap tightens an existing owner-managed root and rejects uns
 
   for (const [name, setup, expected] of [
     ['symlink', async (target: string) => fs.symlink(path.join(root, 'missing'), target), /ordinary directory/],
+    ['symlink-trailing-slash', async (target: string) => {
+      await fs.mkdir(`${target}-target`);
+      await fs.symlink(`${target}-target`, target);
+    }, /ordinary directory/],
     ['non-directory', async (target: string) => fs.writeFile(target, 'not a directory'), /ordinary directory/],
   ] as const) {
     const unsafeRoot = path.join(root, name);
     await setup(unsafeRoot);
     const result = spawnSync('bash', [installerPath, '--local'], {
       encoding: 'utf8',
-      env: { ...commonEnv, CHATMUX_INSTALL_ROOT: unsafeRoot },
+      env: {
+        ...commonEnv,
+        CHATMUX_INSTALL_ROOT: name === 'symlink-trailing-slash' ? `${unsafeRoot}/` : unsafeRoot,
+      },
     });
     assert.notEqual(result.status, 0, name);
     assert.match(result.stderr, expected);

--- a/server/install-bootstrap.test.ts
+++ b/server/install-bootstrap.test.ts
@@ -108,13 +108,17 @@ test('one-line bootstrap tightens an existing owner-managed root and rejects uns
   assert.equal(migrated.status, 0, migrated.stderr);
   assert.equal((await fs.stat(managedRoot)).mode & 0o777, 0o700);
 
-  for (const [name, setup, expected] of [
-    ['symlink', async (target: string) => fs.symlink(path.join(root, 'missing'), target), /ordinary directory/],
+  for (const [name, setup, suffix, expected] of [
+    ['symlink', async (target: string) => fs.symlink(path.join(root, 'missing'), target), '', /ordinary directory/],
     ['symlink-trailing-slash', async (target: string) => {
       await fs.mkdir(`${target}-target`);
       await fs.symlink(`${target}-target`, target);
-    }, /ordinary directory/],
-    ['non-directory', async (target: string) => fs.writeFile(target, 'not a directory'), /ordinary directory/],
+    }, '/', /ordinary directory/],
+    ['symlink-trailing-dot', async (target: string) => {
+      await fs.mkdir(`${target}-target`);
+      await fs.symlink(`${target}-target`, target);
+    }, '/.', /ordinary directory/],
+    ['non-directory', async (target: string) => fs.writeFile(target, 'not a directory'), '', /ordinary directory/],
   ] as const) {
     const unsafeRoot = path.join(root, name);
     await setup(unsafeRoot);
@@ -122,7 +126,7 @@ test('one-line bootstrap tightens an existing owner-managed root and rejects uns
       encoding: 'utf8',
       env: {
         ...commonEnv,
-        CHATMUX_INSTALL_ROOT: name === 'symlink-trailing-slash' ? `${unsafeRoot}/` : unsafeRoot,
+        CHATMUX_INSTALL_ROOT: `${unsafeRoot}${suffix}`,
       },
     });
     assert.notEqual(result.status, 0, name);


### PR DESCRIPTION
## What changed
- validate the managed root with `-d` and `! -L` instead of parsing localized `stat %F` output
- retain `stat` only for locale-independent ownership, device, inode, and mode metadata

This avoids requiring `LC_ALL=C` while preserving symlink rejection and replacement detection.

## Tests
- `node --test --import tsx server/install-bootstrap.test.ts`
