### PR TITLE
fix(gjc): restore Bun launcher session detection

### DIFF
--- a/server/modules/providers/services/live-sessions.service.ts
+++ b/server/modules/providers/services/live-sessions.service.ts
@@ -95,7 +95,8 @@ export function isGjcCommandLine(cmdline: string): boolean {
   const argv = cmdline.includes('\0')
     ? cmdline.split('\0').filter(Boolean)
     : cmdline.trim().split(/\s+/).filter(Boolean);
-  return argv.some((token) => basename(token) === 'gjc') || cmdline.includes('@chatmux-code/coding-agent');
+  return argv.some((token) => basename(token) === 'gjc')
+    || cmdline.includes('@gajae-code/coding-agent');
 }
 
 /** Roots gjc writes transcripts under; a live transcript sits in one of them. */
@@ -124,7 +125,8 @@ export function isGjcProcessArgs(args: string): boolean {
     return true;
   }
   if ((head === 'bun' || head === 'node') && tokens.length > 1) {
-    return basename(tokens[1]) === 'gjc' || tokens[1].includes('@chatmux-code/coding-agent');
+    return basename(tokens[1]) === 'gjc'
+      || tokens[1].includes('@gajae-code/coding-agent');
   }
   return false;
 }

--- a/server/modules/providers/tests/live-sessions.service.test.ts
+++ b/server/modules/providers/tests/live-sessions.service.test.ts
@@ -795,7 +795,7 @@ test('findIdleGjcTmuxSessions: a stray "gjc" token deeper in argv never qualifie
 test('isGjcProcessArgs: argv-anchored — native, bun/node entry, package path; rejects lookalikes', () => {
   assert.equal(isGjcProcessArgs('/usr/local/bin/gjc --resume 019f'), true);
   assert.equal(isGjcProcessArgs('/home/u/.bun/bin/bun /home/u/.bun/bin/gjc'), true);
-  assert.equal(isGjcProcessArgs('/usr/bin/node /opt/node_modules/@chatmux-code/coding-agent/bin/gjc.js'), true);
+  assert.equal(isGjcProcessArgs('/usr/bin/node /opt/node_modules/@gajae-code/coding-agent/bin/gjc.js'), true);
   assert.equal(isGjcProcessArgs('man gjc'), false);
   assert.equal(isGjcProcessArgs('vi /tmp/notes/gjc'), false);
   assert.equal(isGjcProcessArgs('/usr/bin/node /srv/devserver/index.js'), false);
@@ -1274,7 +1274,7 @@ test('isGjcCommandLine matches gjc as a native binary AND under bun/node interpr
   // bun launcher — real-world case where comm reads "bun" (the regression this fixes)
   assert.equal(isGjcCommandLine(cmdline('/home/u/.bun/bin/bun', '/home/u/.bun/bin/gjc', '--resume', '019f6f27')), true);
   // node launching the packaged entry (basename is gjc.js — matched via the package path)
-  assert.equal(isGjcCommandLine(cmdline('/usr/bin/node', '/opt/node_modules/@chatmux-code/coding-agent/bin/gjc.js', 'start')), true);
+  assert.equal(isGjcCommandLine(cmdline('/usr/bin/node', '/opt/node_modules/@gajae-code/coding-agent/bin/gjc.js', 'start')), true);
   // NOT gjc: the app server and its native watcher must never be mistaken for a session holder
   assert.equal(isGjcCommandLine(cmdline('/usr/bin/node', '/home/u/.chatmux/current/scripts/chatmux-runtime.mjs', 'start')), false);
   assert.equal(isGjcCommandLine(cmdline('/home/u/.chatmux/current/dist-native/chatmux-core', 'watch', '--root', '/home/u/.gjc/agent/sessions')), false);

--- a/server/modules/providers/tests/support/tmux-e2e-harness.ts
+++ b/server/modules/providers/tests/support/tmux-e2e-harness.ts
@@ -207,7 +207,7 @@ export async function createTmuxE2EHarness(): Promise<TmuxE2EHarness> {
   const npmPackageDirectory = path.join(
     workspace,
     'node_modules',
-    '@chatmux-code',
+    '@gajae-code',
     'coding-agent',
   );
   const npmGjcPath = path.join(npmPackageDirectory, 'gjc');


### PR DESCRIPTION
## What changed
- restore the published `@gajae-code/coding-agent` marker used by Bun/Node GJC launchers
- cover both idle-pane and transcript-backed process detection

## Evidence
- current launcher resolves to `@gajae-code/coding-agent/bin/gjc.js`
- commit `4a88a12` changed the detector to the nonexistent `@chatmux-code/coding-agent` marker during the ChatMux rebrand
- changed-line privacy scan found no usernames, machine paths, credentials, tokens, or secrets

## Verification
- `TSX_TSCONFIG_PATH=server/tsconfig.json npx tsx --test server/modules/providers/tests/live-sessions.service.test.ts` (63 passed)
- typecheck, Rust fmt/clippy/tests, lint, identity check, and production build passed
- full local `npm test` currently reports 7 unrelated frontend loader/import failures; PR CI is authoritative for clean Node 22/24 runners