### PR TITLE
fix(installer): normalize a trailing slash or dot before the managed-root check

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -74,6 +74,19 @@ EOF
 }
 
 ensure_managed_root() {
+  # `stat` and the test builtins resolve a trailing "/" or "/." through a symlink, so a
+  # managed root given as "link/" or "link/." is inspected as the link TARGET and slips
+  # past the ordinary-directory check below. Normalize before any inspection; reordering
+  # this loop after read_managed_root_metadata silently reopens the symlink escape.
+  while [ "$INSTALL_ROOT" != / ]; do
+    case $INSTALL_ROOT in
+      */.) INSTALL_ROOT=${INSTALL_ROOT%/.} ;;
+      */) INSTALL_ROOT=${INSTALL_ROOT%/} ;;
+      *) break ;;
+    esac
+    [ -n "$INSTALL_ROOT" ] || INSTALL_ROOT=/
+  done
+
   if [ -e "$INSTALL_ROOT" ] || [ -L "$INSTALL_ROOT" ]; then
     read_managed_root_metadata
   else

--- a/server/install-bootstrap.test.ts
+++ b/server/install-bootstrap.test.ts
@@ -108,15 +108,23 @@ test('one-line bootstrap tightens an existing owner-managed root and rejects uns
   assert.equal(migrated.status, 0, migrated.stderr);
   assert.equal((await fs.stat(managedRoot)).mode & 0o777, 0o700);
 
-  for (const [name, setup, expected] of [
-    ['symlink', async (target: string) => fs.symlink(path.join(root, 'missing'), target), /ordinary directory/],
-    ['non-directory', async (target: string) => fs.writeFile(target, 'not a directory'), /ordinary directory/],
+  // A trailing "/" or "/." makes the kernel resolve a symlink, so the suffixed cases
+  // fail closed only while ensure_managed_root normalizes the root before inspecting it.
+  const symlinkToDirectory = async (target: string): Promise<void> => {
+    await fs.mkdir(`${target}-target`);
+    await fs.symlink(`${target}-target`, target);
+  };
+  for (const [name, setup, expected, suffix] of [
+    ['symlink', async (target: string) => fs.symlink(path.join(root, 'missing'), target), /ordinary directory/, ''],
+    ['non-directory', async (target: string) => fs.writeFile(target, 'not a directory'), /ordinary directory/, ''],
+    ['symlink-trailing-slash', symlinkToDirectory, /ordinary directory/, '/'],
+    ['symlink-trailing-dot', symlinkToDirectory, /ordinary directory/, '/.'],
   ] as const) {
     const unsafeRoot = path.join(root, name);
     await setup(unsafeRoot);
     const result = spawnSync('bash', [installerPath, '--local'], {
       encoding: 'utf8',
-      env: { ...commonEnv, CHATMUX_INSTALL_ROOT: unsafeRoot },
+      env: { ...commonEnv, CHATMUX_INSTALL_ROOT: `${unsafeRoot}${suffix}` },
     });
     assert.notEqual(result.status, 0, name);
     assert.match(result.stderr, expected);


### PR DESCRIPTION
Supersedes #35.

## What changed
`ensure_managed_root` strips a trailing `/` or `/.` from `INSTALL_ROOT` before anything inspects it.

## Why
The kernel resolves a symlink when the path ends in `/` or `/.`, so the ordinary-directory check ran against the link **target**:

```
link    -> rejected
link/   -> ACCEPTED   <-- bypass
link/.  -> ACCEPTED   <-- bypass
```

Severity is low on its own: `CHATMUX_INSTALL_ROOT` is user-supplied, and the owner check, the 0700 enforcement, and the dev/inode replacement detection all still apply. But rejecting a symlinked root is the stated purpose of that check, so it should hold for every spelling of the path.

## Relationship to #35
#35 fixes only the trailing-`/` half and rewrites the check from `LC_ALL=C stat %F` to `-d` plus `! -L`. That rewrite is not needed — #33 already made the check locale-independent — and it splits one atomic `stat` into a separate type test and metadata read. This change keeps the existing single `stat` and closes both spellings, so #35 is being closed in favour of it.

`link/..` still resolves through the link. That points at the target's *parent*, a different object rather than a disguised one, and full normalization would need `cd -P`, which would rewrite the root whenever `$HOME` itself is a symlink. Left alone deliberately.

## Tests
- `symlink-trailing-slash` and `symlink-trailing-dot` added to the unsafe-root table in `server/install-bootstrap.test.ts`
- removing the normalization loop makes that test fail, so the cases are not vacuous
- `sh -n install.sh`, `bash -n install.sh` clean
- `npm run typecheck`, `npm run lint`, `npm run check:identity`, `npm test` (server 907, client 262) all green