### PR TITLE
fix(test): wait for the second interrupt instead of sleeping

### DIFF
--- a/server/modules/providers/tests/support/tmux-e2e-harness.ts
+++ b/server/modules/providers/tests/support/tmux-e2e-harness.ts
@@ -32,7 +32,8 @@ export type FakeTmuxAgent = {
   events: () => Promise<FakeAgentEvent[]>;
   waitUntilReady: () => Promise<void>;
   waitForInput: (value: string) => Promise<void>;
-  waitForInterrupt: () => Promise<void>;
+  /** Resolves once at least `count` interrupts have been recorded. */
+  waitForInterrupt: (count?: number) => Promise<void>;
   waitForTurnStarted: () => Promise<void>;
   waitForTurnInterrupted: () => Promise<void>;
 };
@@ -325,9 +326,9 @@ export async function createTmuxE2EHarness(): Promise<TmuxE2EHarness> {
         async () => (await events()).some((event) => event.type === 'input' && event.value === value),
         `${sessionName} input ${JSON.stringify(value)}`,
       ),
-      waitForInterrupt: () => waitFor(
-        async () => (await events()).some((event) => event.type === 'interrupt'),
-        `${sessionName} SIGINT`,
+      waitForInterrupt: (count = 1) => waitFor(
+        async () => (await events()).filter((event) => event.type === 'interrupt').length >= count,
+        `${sessionName} SIGINT x${count}`,
       ),
       waitForTurnStarted: () => waitFor(
         async () => (await events()).some((event) => event.type === 'turn_started'),
@@ -430,9 +431,9 @@ export async function createTmuxE2EHarness(): Promise<TmuxE2EHarness> {
           async () => (await events()).some((event) => event.type === 'input' && event.value === value),
           `${sessionName} input ${JSON.stringify(value)}`,
         ),
-        waitForInterrupt: () => waitFor(
-          async () => (await events()).some((event) => event.type === 'interrupt'),
-          `${sessionName} SIGINT`,
+        waitForInterrupt: (count = 1) => waitFor(
+          async () => (await events()).filter((event) => event.type === 'interrupt').length >= count,
+          `${sessionName} SIGINT x${count}`,
         ),
         waitForTurnStarted: () => waitFor(
           async () => (await events()).some((event) => event.type === 'turn_started'),

--- a/server/modules/providers/tests/tmux-runtime.e2e.test.ts
+++ b/server/modules/providers/tests/tmux-runtime.e2e.test.ts
@@ -386,7 +386,9 @@ test('real tmux interrupt cancels a running verified fake-agent turn and repeats
   );
 
   await sendTmuxProcessAction(target, 'interrupt');
-  await delay(100);
+  // Wait for the second interrupt to be recorded instead of sleeping: a fixed
+  // delay made this assertion fail on slower CI runners (observed on Node 24).
+  await agent.waitForInterrupt(2);
   assert.equal(
     (await agent.events()).filter((event) => event.type === 'interrupt').length,
     2,


### PR DESCRIPTION
## Problem
`real tmux interrupt cancels a running verified fake-agent turn and repeats on the same generation` slept a fixed 100ms after sending the second interrupt, then asserted that exactly two interrupts had been recorded.

That is a timing race, and it fired for real: PR #37 failed on **Node 24** while **Node 22 passed on the same commit**, and a plain rerun went green. The change under test was unrelated to interrupt handling.

```
✖ real tmux interrupt … (126ms)
  AssertionError: same-generation interrupts are intentional repeatable user gestures
  1 !== 2
```

## Fix
`waitForInterrupt` takes an expected count and polls to the harness deadline, so the test waits on the exact event it asserts instead of guessing how long tmux needs.

The `assert.equal(..., 2)` stays, so an extra interrupt is still a failure — the wait only removes the "too early" failure mode.

## Note
The `delay(1_100)` above it is left alone on purpose: it backs a *negative* assertion (no `turn_completed` may appear), and there is no event to wait for when asserting absence.

## Verification
File run three times consecutively, 10/10 passing each time.