### PR TITLE
docs(release): declare the full schema-compatible rollback window

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,7 +150,7 @@ ChatMux uses trunk-based development: `main` plus short-lived branches. There is
 
 Cutting a release (maintainers):
 
-1. On up-to-date `main`, add the compatibility declaration for the new version to `packaging/release/update-compatibility.json` and commit it as `chore(release): declare X.Y.Z database rollback compatibility`.
+1. On up-to-date `main`, add the compatibility declaration for the new version to `packaging/release/update-compatibility.json` and commit it as `chore(release): declare X.Y.Z database rollback compatibility`. When the database schema is unchanged, carry forward **every** prior version sharing that schema in `rollbackCompatibleFrom` (the release workflow proves each declared entry); reset the list to only the immediately preceding version when a release actually migrates the schema. A single-entry declaration on an unchanged schema strands any install more than one release behind in `manual_required` (#49).
 2. Bump the version (`npm version X.Y.Z --no-git-tag-version`), prepend the `CHANGELOG.md` section, and commit as `chore(release): vX.Y.Z`.
 3. Push `main` and dispatch the **Release ChatMux Server** workflow (`gh workflow run "Release ChatMux Server" --ref main`). The workflow verifies, builds, proves rollback compatibility, and publishes the GitHub Release with the tag.
 


### PR DESCRIPTION
Documents the fix policy for #49: when the schema is unchanged, carry forward every prior schema-compatible version in `rollbackCompatibleFrom` (each entry is proven by the release workflow's rollback-compatibility job); reset only on an actual migration.

Context: this host's 1.8.11 install failed the one-click update to 1.8.13 with `manual_required` — `Release metadata does not permit rollback to current database version` — despite `git diff v1.8.0..main` over the schema/migrations files being empty. The declaration convention, not the schema, was the blocker. The wider declaration itself lands with the next release's step-1 commit per this updated policy.