### PR TITLE
fix(codex): 새 transcript 형식의 사용자 메시지 복원

### DIFF
--- a/server/modules/providers/list/codex/codex-sessions.provider.ts
+++ b/server/modules/providers/list/codex/codex-sessions.provider.ts
@@ -39,6 +39,36 @@ function isVisibleCodexUserMessage(payload: AnyRecord | null | undefined): boole
   return typeof payload.message === 'string' && payload.message.trim().length > 0;
 }
 
+function isSyntheticCodexUserContext(content: string): boolean {
+  const trimmed = content.trim();
+  return (
+    (trimmed.startsWith('# AGENTS.md instructions for ')
+      && trimmed.includes('<INSTRUCTIONS>')
+      && trimmed.includes('</INSTRUCTIONS>'))
+    || (trimmed.startsWith('<environment_context>')
+      && trimmed.endsWith('</environment_context>'))
+  );
+}
+
+function extractCodexResponseUserImages(
+  content: unknown,
+): Array<{ path?: string; data?: string }> | undefined {
+  if (!Array.isArray(content)) return undefined;
+
+  const attachments: Array<{ path?: string; data?: string }> = [];
+  for (const item of content) {
+    if (!item || typeof item !== 'object') continue;
+    const record = item as AnyRecord;
+    if (record.type !== 'input_image' || typeof record.image_url !== 'string') continue;
+    if (record.image_url.startsWith('data:')) {
+      attachments.push({ data: record.image_url });
+    } else if (record.image_url.trim()) {
+      attachments.push(...toImageAttachments([record.image_url]));
+    }
+  }
+  return attachments.length > 0 ? attachments : undefined;
+}
+
 /**
  * Reads the image attachments Codex records on `user_message` events.
  * Turns sent with `local_image` input items land in `local_images` as file
@@ -120,6 +150,7 @@ type CodexHistoryCacheEntry = {
   normalizedBytes: number;
   toolResults: Map<string, NormalizedMessage>;
   toolUses: Map<string, NormalizedMessage[]>;
+  userSources: WeakMap<NormalizedMessage, 'event_msg' | 'response_item'>;
   sortTimestamps: WeakMap<NormalizedMessage, number>;
 };
 
@@ -165,6 +196,7 @@ function parseCodexHistoryLine(line: string, accumulator: CodexHistoryAccumulato
     if (entry.type === 'event_msg' && isVisibleCodexUserMessage(entry.payload as AnyRecord)) {
       accumulator.messages.push({
         type: 'user',
+        codexUserSource: 'event_msg',
         timestamp: entry.timestamp,
         message: {
           role: 'user',
@@ -172,6 +204,28 @@ function parseCodexHistoryLine(line: string, accumulator: CodexHistoryAccumulato
         },
         images: extractCodexUserImages(entry.payload as AnyRecord),
       });
+    }
+
+    if (
+      entry.type === 'response_item'
+      && entry.payload?.type === 'message'
+      && entry.payload.role === 'user'
+    ) {
+      const textContent = extractCodexTextContent(entry.payload.content);
+      const images = extractCodexResponseUserImages(entry.payload.content);
+      if ((textContent.trim() || images) && !isSyntheticCodexUserContext(textContent)) {
+        accumulator.messages.push({
+          type: 'user',
+          codexUserSource: 'response_item',
+          uuid: entry.payload.id,
+          timestamp: entry.timestamp,
+          message: {
+            role: 'user',
+            content: textContent,
+          },
+          images,
+        });
+      }
     }
 
     if (
@@ -386,8 +440,47 @@ function appendNormalizedCodexHistory(
     const rawTimestamp = new Date(raw.timestamp || 0).getTime();
     const sortTimestamp = Number.isFinite(rawTimestamp) ? rawTimestamp : 0;
     for (const message of normalize(raw, sessionId)) {
-      entry.normalizedBytes += estimateCodexMessageBytes(message);
       entry.sortTimestamps.set(message, sortTimestamp);
+
+      if (message.kind === 'text' && message.role === 'user') {
+        let duplicateIndex = -1;
+        for (let index = entry.messages.length - 1; index >= 0; index -= 1) {
+          const previous = entry.messages[index];
+          const previousTimestamp = codexMessageTimestamp(previous, entry.sortTimestamps);
+          if (sortTimestamp - previousTimestamp > 100) break;
+          if (
+            previous.kind === 'text'
+            && previous.role === 'user'
+            && previous.content === message.content
+            && Math.abs(sortTimestamp - previousTimestamp) <= 10
+          ) {
+            duplicateIndex = index;
+            break;
+          }
+        }
+
+        if (duplicateIndex >= 0) {
+          const previous = entry.messages[duplicateIndex];
+          const previousSource = entry.userSources.get(previous);
+          const nextSource = raw.codexUserSource;
+          // Older Codex versions write the same prompt twice: first as a
+          // response_item and then as event_msg. Prefer event_msg because it
+          // carries compact local image paths instead of inline base64 data.
+          if (previousSource === 'response_item' && nextSource === 'event_msg') {
+            entry.normalizedBytes -= estimateCodexMessageBytes(previous);
+            entry.messages[duplicateIndex] = message;
+            entry.userSources.set(message, 'event_msg');
+            entry.normalizedBytes += estimateCodexMessageBytes(message);
+          }
+          continue;
+        }
+
+        if (raw.codexUserSource === 'event_msg' || raw.codexUserSource === 'response_item') {
+          entry.userSources.set(message, raw.codexUserSource);
+        }
+      }
+
+      entry.normalizedBytes += estimateCodexMessageBytes(message);
 
       if (message.kind === 'tool_result' && message.toolId) {
         entry.toolResults.set(message.toolId, message);
@@ -470,6 +563,7 @@ async function refreshCodexHistoryCache(
       malformed: false,
       toolResults: new Map(),
       toolUses: new Map(),
+      userSources: new WeakMap(),
       sortTimestamps: new WeakMap(),
     };
   }

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -336,6 +336,102 @@ test('Codex history incrementally appends complete JSONL records', { concurrency
   }
 });
 
+test('Codex history reads response-item-only user prompts without exposing injected context', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-history-response-user-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+
+  try {
+    const sessionId = 'codex-response-user-history';
+    const transcriptPath = await writeCodexTranscript(tempRoot, sessionId, workspacePath);
+    const pairedImagePath = path.join(workspacePath, 'paired.png');
+    await appendFile(transcriptPath, [
+      JSON.stringify({
+        type: 'response_item',
+        timestamp: '2026-08-14T00:00:00.000Z',
+        payload: {
+          type: 'message',
+          id: 'synthetic-context',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: '# AGENTS.md instructions for /workspace\n\n<INSTRUCTIONS>\ninternal\n</INSTRUCTIONS>' },
+            { type: 'input_text', text: '<environment_context>\ninternal\n</environment_context>' },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'response_item',
+        timestamp: '2026-08-14T00:00:01.000Z',
+        payload: {
+          type: 'message',
+          id: 'response-user-only',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'Visible new-format prompt' },
+            { type: 'input_image', image_url: 'data:image/png;base64,QUJD' },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'response_item',
+        timestamp: '2026-08-14T00:00:02.000Z',
+        payload: {
+          type: 'message',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Visible answer' }],
+        },
+      }),
+      // Older Codex versions persist both forms for one prompt. The later
+      // event record must replace, not duplicate, the response item.
+      JSON.stringify({
+        type: 'response_item',
+        timestamp: '2026-08-14T00:00:03.000Z',
+        payload: {
+          type: 'message',
+          id: 'paired-response-user',
+          role: 'user',
+          content: [
+            { type: 'input_text', text: 'One paired prompt' },
+            { type: 'input_image', image_url: 'data:image/png;base64,REVG' },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'event_msg',
+        timestamp: '2026-08-14T00:00:03.000Z',
+        payload: {
+          type: 'user_message',
+          message: 'One paired prompt',
+          local_images: [pairedImagePath],
+        },
+      }),
+      '',
+    ].join('\n'), 'utf8');
+
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createSession(
+        sessionId,
+        'codex',
+        workspacePath,
+        undefined,
+        undefined,
+        undefined,
+        transcriptPath,
+      );
+
+      const history = await new CodexSessionsProvider().fetchHistory(sessionId);
+      assert.deepEqual(
+        history.messages.map((message) => message.content),
+        ['Visible new-format prompt', 'Visible answer', 'One paired prompt'],
+      );
+      assert.deepEqual(history.messages[0]?.images, [{ data: 'data:image/png;base64,QUJD' }]);
+      assert.deepEqual(history.messages[2]?.images, [{ path: pairedImagePath }]);
+    });
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test('Codex history detects same-size rewrites beyond the former raw cache bound', { concurrency: false }, async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-history-cache-bound-'));
   const workspacePath = path.join(tempRoot, 'workspace');


### PR DESCRIPTION
## 문제

최신 Codex transcript에서는 사용자가 보낸 메시지가 기존의 `event_msg:user_message` 없이 `response_item`의 `role: user` 형식으로만 기록될 수 있습니다. 이 경우 ChatMux가 어시스턴트 답변은 표시하지만 사용자 메시지 말풍선은 누락했습니다.

## 변경 사항

- `response_item` 형식의 사용자 메시지를 transcript에 포함합니다.
- Codex가 내부적으로 주입하는 `AGENTS.md instructions` 및 `environment_context`는 채팅에서 제외합니다.
- `input_image` 첨부도 사용자 메시지에서 복원합니다.
- 구버전 transcript처럼 동일 메시지가 `response_item`과 `event_msg` 양쪽에 기록된 경우 중복을 제거합니다.
- 두 형식이 함께 있으면 base64 이미지보다 가벼운 로컬 이미지 경로를 가진 `event_msg`를 우선합니다.

## 검증

- Codex provider 테스트: 15/15 통과
- Rust core 테스트: 19/19 통과
- TypeScript typecheck, lint, identity check, production build 통과
- 실제 누락 세션: 사용자 메시지 5개 복원, 내부 주입 메시지 0개 노출 확인
- 기존 이중 기록 세션: 사용자 메시지 272개가 중복 없이 유지됨을 확인
- 전체 테스트: 929개 통과. 로컬 HOME의 실제 skills 데이터가 fixture에 섞이는 기존 환경 의존 테스트 2개만 실패했으며 이번 변경 파일과는 무관합니다. GitHub CI의 격리 환경에서도 최종 확인하겠습니다.