### PR TITLE
fix(ui): use Oh My OpenAgent product name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="docs/assets/readme-hero.svg" alt="ChatMux — every coding agent, one command deck: Codex, Claude, Gajae Code, Cursor, OpenCode, Oh My Pi, and omo sessions multiplexed into one self-hosted interface" width="900">
+  <img src="docs/assets/readme-hero.svg" alt="ChatMux — every coding agent, one command deck: Codex, Claude, Gajae Code, Cursor, OpenCode, Oh My Pi, and Oh My OpenAgent sessions multiplexed into one self-hosted interface" width="900">
 </p>
 
 <p align="center"><sub><b>English</b> · <a href="docs/readme/README.ko.md">한국어</a> · <a href="docs/readme/README.ja.md">日本語</a> · <a href="docs/readme/README.zh-CN.md">简体中文</a></sub></p>
 
-<p align="center">One interface for Claude Code, Codex, Cursor, OpenCode, Gajae Code, Oh My Pi, and omo —<br>the agents already running in your tmux.</p>
+<p align="center">One interface for Claude Code, Codex, Cursor, OpenCode, Gajae Code, Oh My Pi, and Oh My OpenAgent —<br>the agents already running in your tmux.</p>
 
 <p align="center">
   <a href="https://github.com/devswha/chatmux/releases"><img src="https://img.shields.io/github/v/release/devswha/chatmux?display_name=tag&label=release&style=flat-square&color=6366f1" alt="GitHub release"></a>
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/runtime-tmux-ff6b4a?style=flat-square" alt="tmux runtime">
 </p>
 
-You run coding agents — Gajae Code, Claude Code, Codex, Cursor CLI, OpenCode, Oh My Pi, omo — inside tmux, like always. ChatMux finds them by itself and shows every session in one browser page, from your desktop or your phone.
+You run coding agents — Gajae Code, Claude Code, Codex, Cursor CLI, OpenCode, Oh My Pi, Oh My OpenAgent — inside tmux, like always. ChatMux finds them by itself and shows every session in one browser page, from your desktop or your phone.
 
 - **Zero registration:** Agents already running in tmux just appear in the sidebar. Nothing to wrap, wire, or restart.
 - **Multi-provider:** Every provider in a single drag-sortable list, with `RUN`, `READY`, and `ERROR` badges for live state.
@@ -86,7 +86,7 @@ Turn on Tailscale on the phone, scan the QR code from the install output, and us
 | **Cursor CLI** | Yes | After its history is indexed | Prompts and `/` skills | Yes |
 | **OpenCode** | Yes | After its history is indexed | Prompts and `/` skills | Yes |
 | **Oh My Pi** | Yes | After its history is indexed | Prompts and `/skill:` skills | Yes |
-| **omo** | Yes | After its history is indexed | Prompts and `/skill:` skills | Yes |
+| **Oh My OpenAgent** (`omo`) | Yes | After its history is indexed | Prompts and `/skill:` skills | Yes |
 | **SSH tmux** | Yes | No — terminal only | Terminal keystrokes | No |
 | **Local shell** | Yes | No — terminal only | Terminal keystrokes | No |
 

--- a/docs/readme/README.ja.md
+++ b/docs/readme/README.ja.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="../assets/readme-hero.svg" alt="ChatMux — あらゆるコーディングエージェントをひとつのコマンドデッキに: Codex、Claude、Gajae Code、Cursor、OpenCode、Oh My Pi、omo のセッションをひとつのセルフホスト型インターフェースへ多重化" width="900">
+  <img src="../assets/readme-hero.svg" alt="ChatMux — あらゆるコーディングエージェントをひとつのコマンドデッキに: Codex、Claude、Gajae Code、Cursor、OpenCode、Oh My Pi、Oh My OpenAgent のセッションをひとつのセルフホスト型インターフェースへ多重化" width="900">
 </p>
 
 <p align="center"><sub><a href="../../README.md">English</a> · <a href="README.ko.md">한국어</a> · <b>日本語</b> · <a href="README.zh-CN.md">简体中文</a></sub></p>
 
-<p align="center">Claude Code、Codex、Cursor、OpenCode、Gajae Code、Oh My Pi、omo のためのひとつのインターフェース —<br>tmux ですでに動いているエージェントをまとめて管理できます。</p>
+<p align="center">Claude Code、Codex、Cursor、OpenCode、Gajae Code、Oh My Pi、Oh My OpenAgent のためのひとつのインターフェース —<br>tmux ですでに動いているエージェントをまとめて管理できます。</p>
 
 <p align="center">
   <a href="https://github.com/devswha/chatmux/releases"><img src="https://img.shields.io/github/v/release/devswha/chatmux?display_name=tag&label=release&style=flat-square&color=6366f1" alt="GitHub リリース"></a>
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/runtime-tmux-ff6b4a?style=flat-square" alt="tmux ランタイム">
 </p>
 
-コーディングエージェント — Gajae Code、Claude Code、Codex、Cursor CLI、OpenCode、Oh My Pi、omo — は、これまでどおり tmux の中で動かします。ChatMux が自動で見つけ出し、デスクトップからでもスマホからでも、すべてのセッションをブラウザの 1 ページに表示します。
+コーディングエージェント — Gajae Code、Claude Code、Codex、Cursor CLI、OpenCode、Oh My Pi、Oh My OpenAgent — は、これまでどおり tmux の中で動かします。ChatMux が自動で見つけ出し、デスクトップからでもスマホからでも、すべてのセッションをブラウザの 1 ページに表示します。
 
 - **登録不要:** tmux ですでに動いているエージェントがサイドバーにそのまま現れます。ラップも配線も再起動も不要です。
 - **マルチプロバイダー:** すべてのプロバイダーを、ドラッグで並べ替えられるひとつのリストにまとめ、ライブ状態を `RUN`、`READY`、`ERROR` バッジで表示します。
@@ -86,7 +86,7 @@ Linux x86_64 (glibc 2.35+)、tmux、ユーザーレベルの systemd、`curl`/`t
 | **Cursor CLI** | はい | 履歴のインデックス後 | プロンプトと `/` スキル | はい |
 | **OpenCode** | はい | 履歴のインデックス後 | プロンプトと `/` スキル | はい |
 | **Oh My Pi** | はい | 履歴のインデックス後 | プロンプトと `/skill:` スキル | はい |
-| **omo** | はい | 履歴のインデックス後 | プロンプトと `/skill:` スキル | はい |
+| **Oh My OpenAgent** (`omo`) | はい | 履歴のインデックス後 | プロンプトと `/skill:` スキル | はい |
 | **SSH tmux** | はい | いいえ — ターミナルのみ | ターミナルのキー入力 | いいえ |
 | **Local shell** | はい | いいえ — ターミナルのみ | ターミナルのキー入力 | いいえ |
 

--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="../assets/readme-hero.svg" alt="ChatMux — 모든 코딩 에이전트를 하나의 커맨드 데크로: Codex, Claude, Gajae Code, Cursor, OpenCode, Oh My Pi, omo 세션을 하나의 셀프호스트 인터페이스로 멀티플렉싱" width="900">
+  <img src="../assets/readme-hero.svg" alt="ChatMux — 모든 코딩 에이전트를 하나의 커맨드 데크로: Codex, Claude, Gajae Code, Cursor, OpenCode, Oh My Pi, Oh My OpenAgent 세션을 하나의 셀프호스트 인터페이스로 멀티플렉싱" width="900">
 </p>
 
 <p align="center"><sub><a href="../../README.md">English</a> · <b>한국어</b> · <a href="README.ja.md">日本語</a> · <a href="README.zh-CN.md">简体中文</a></sub></p>
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/runtime-tmux-ff6b4a?style=flat-square" alt="tmux 런타임">
 </p>
 
-Gajae Code, Claude Code, Codex, Cursor CLI, OpenCode, Oh My Pi, omo 같은 코딩 에이전트를 늘 하던 대로 tmux 안에서 실행하세요. ChatMux가 알아서 찾아 데스크톱이나 휴대폰에서 모든 세션을 하나의 브라우저 페이지에 보여줍니다.
+Gajae Code, Claude Code, Codex, Cursor CLI, OpenCode, Oh My Pi, Oh My OpenAgent 같은 코딩 에이전트를 늘 하던 대로 tmux 안에서 실행하세요. ChatMux가 알아서 찾아 데스크톱이나 휴대폰에서 모든 세션을 하나의 브라우저 페이지에 보여줍니다.
 
 - **등록 절차 없음:** tmux에서 이미 실행 중인 에이전트가 사이드바에 바로 나타납니다. 감싸거나 연결하거나 재시작할 것이 없습니다.
 - **멀티 프로바이더:** 모든 프로바이더가 드래그로 정렬할 수 있는 하나의 목록에 모이고, `RUN`, `READY`, `ERROR` 배지로 실시간 상태를 보여줍니다.
@@ -86,7 +86,7 @@ Linux x86_64(glibc 2.35+)와 tmux, 사용자 레벨 systemd, `curl`/`tar`/`sha25
 | **Cursor CLI** | 예 | 히스토리 인덱싱 후 | 프롬프트와 `/` 스킬 | 예 |
 | **OpenCode** | 예 | 히스토리 인덱싱 후 | 프롬프트와 `/` 스킬 | 예 |
 | **Oh My Pi** | 예 | 히스토리 인덱싱 후 | 프롬프트와 `/skill:` 스킬 | 예 |
-| **omo** | 예 | 히스토리 인덱싱 후 | 프롬프트와 `/skill:` 스킬 | 예 |
+| **Oh My OpenAgent** (`omo`) | 예 | 히스토리 인덱싱 후 | 프롬프트와 `/skill:` 스킬 | 예 |
 | **SSH tmux** | 예 | 아니오 — 터미널 전용 | 터미널 키 입력 | 아니오 |
 | **Local shell** | 예 | 아니오 — 터미널 전용 | 터미널 키 입력 | 아니오 |
 

--- a/docs/readme/README.zh-CN.md
+++ b/docs/readme/README.zh-CN.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="../assets/readme-hero.svg" alt="ChatMux — 所有编码代理，一个指挥台：Codex、Claude、Gajae Code、Cursor、OpenCode、Oh My Pi 和 omo 会话多路复用到一个自托管界面" width="900">
+  <img src="../assets/readme-hero.svg" alt="ChatMux — 所有编码代理，一个指挥台：Codex、Claude、Gajae Code、Cursor、OpenCode、Oh My Pi 和 Oh My OpenAgent 会话多路复用到一个自托管界面" width="900">
 </p>
 
 <p align="center"><sub><a href="../../README.md">English</a> · <a href="README.ko.md">한국어</a> · <a href="README.ja.md">日本語</a> · <b>简体中文</b></sub></p>
 
-<p align="center">One interface for Claude Code, Codex, Cursor, OpenCode, Gajae Code, Oh My Pi, and omo —<br>the agents already running in your tmux.</p>
+<p align="center">One interface for Claude Code, Codex, Cursor, OpenCode, Gajae Code, Oh My Pi, and Oh My OpenAgent —<br>the agents already running in your tmux.</p>
 
 <p align="center">
   <a href="https://github.com/devswha/chatmux/releases"><img src="https://img.shields.io/github/v/release/devswha/chatmux?display_name=tag&label=release&style=flat-square&color=6366f1" alt="GitHub 发布"></a>
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/runtime-tmux-ff6b4a?style=flat-square" alt="tmux 运行时">
 </p>
 
-你照常在 tmux 中运行编码代理 — Gajae Code、Claude Code、Codex、Cursor CLI、OpenCode、Oh My Pi、omo。ChatMux 会自动发现它们，并把所有会话显示在一个浏览器页面中，无论你使用桌面还是手机。
+你照常在 tmux 中运行编码代理 — Gajae Code、Claude Code、Codex、Cursor CLI、OpenCode、Oh My Pi、Oh My OpenAgent。ChatMux 会自动发现它们，并把所有会话显示在一个浏览器页面中，无论你使用桌面还是手机。
 
 - **无需注册：** 已在 tmux 中运行的代理会直接出现在侧边栏。不用包装、接线或重启。
 - **多提供方：** 所有提供方都在一个可拖拽排序的列表中，实时显示 `RUN`、`READY` 和 `ERROR` 徽章。
@@ -86,7 +86,7 @@ curl -fsSL https://github.com/devswha/chatmux/releases/latest/download/install.s
 | **Cursor CLI** | 是 | 历史索引后 | 提示词与 `/` 技能 | 是 |
 | **OpenCode** | 是 | 历史索引后 | 提示词与 `/` 技能 | 是 |
 | **Oh My Pi** | 是 | 历史索引后 | 提示词与 `/skill:` 技能 | 是 |
-| **omo** | 是 | 历史索引后 | 提示词与 `/skill:` 技能 | 是 |
+| **Oh My OpenAgent** (`omo`) | 是 | 历史索引后 | 提示词与 `/skill:` 技能 | 是 |
 | **SSH tmux** | 是 | 否 — 仅终端 | 终端按键 | 否 |
 | **Local shell** | 是 | 否 — 仅终端 | 终端按键 | 否 |
 

--- a/server/modules/notifications/services/external-turn-monitor.service.ts
+++ b/server/modules/notifications/services/external-turn-monitor.service.ts
@@ -179,7 +179,7 @@ function completionPayload(
     codex: 'Codex',
     opencode: 'OpenCode',
     omp: 'Oh My Pi',
-    omo: 'omo',
+    omo: 'Oh My OpenAgent',
   } as Record<string, string>)[session.kind] ?? 'Assistant';
   return {
     title,

--- a/server/modules/notifications/services/notification-orchestrator.service.js
+++ b/server/modules/notifications/services/notification-orchestrator.service.js
@@ -26,6 +26,7 @@ const PROVIDER_LABELS = {
   codex: 'Codex',
   opencode: 'OpenCode',
   omp: 'Oh My Pi',
+  omo: 'Oh My OpenAgent',
   gjc: 'GJC',
   system: 'System'
 };

--- a/server/modules/providers/README.md
+++ b/server/modules/providers/README.md
@@ -40,6 +40,8 @@ Current provider ids accepted by the registry and `parseProvider` are:
 - `omp`
 - `omo`
 
+Here, `omo` is the CLI/provider id for **Oh My OpenAgent**.
+
 Those ids are mirrored in backend unions and frontend provider constants. If
 adding a new provider, update every place that hardcodes this list.
 
@@ -347,5 +349,3 @@ alongside the implementation.
 - Forgetting that Claude plugin skills are discovered differently from normal
   user/project skill folders.
 - Assuming one provider's MCP config file format works for the others.
-
-

--- a/server/modules/providers/list/gjc/gjc-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/gjc/gjc-session-synchronizer.provider.ts
@@ -90,7 +90,7 @@ export const PI_AGENT_ROOT_DIRS: Record<PiTranscriptProvider, string> = {
 const PI_UNTITLED_SESSION_TITLES: Record<PiTranscriptProvider, string> = {
   gjc: 'Untitled gjc Session',
   omp: 'Untitled Oh My Pi Session',
-  omo: 'Untitled omo Session',
+  omo: 'Untitled Oh My OpenAgent Session',
 };
 
 export class GjcSessionSynchronizer implements IProviderSessionSynchronizer {

--- a/server/modules/providers/list/omo/omo-auth.provider.ts
+++ b/server/modules/providers/list/omo/omo-auth.provider.ts
@@ -13,7 +13,7 @@ export class OmoProviderAuth implements IProviderAuth {
       authenticated: installed,
       email: installed ? 'CLI managed' : null,
       method: installed ? 'cli' : null,
-      error: installed ? undefined : 'omo CLI is not installed',
+      error: installed ? undefined : 'Oh My OpenAgent (`omo`) CLI is not installed',
     };
   }
 }

--- a/server/modules/providers/list/omo/omo-mcp.provider.ts
+++ b/server/modules/providers/list/omo/omo-mcp.provider.ts
@@ -12,14 +12,14 @@ export class OmoMcpProvider extends McpProvider {
   }
 
   protected async writeScopedServers(): Promise<void> {
-    throw new AppError('omo MCP configuration is not supported by ChatMux.', {
+    throw new AppError('Oh My OpenAgent MCP configuration is not supported by ChatMux.', {
       code: 'MCP_WRITE_UNSUPPORTED',
       statusCode: 400,
     });
   }
 
   protected buildServerConfig(): Record<string, unknown> {
-    throw new AppError('omo MCP configuration is not supported by ChatMux.', {
+    throw new AppError('Oh My OpenAgent MCP configuration is not supported by ChatMux.', {
       code: 'MCP_WRITE_UNSUPPORTED',
       statusCode: 400,
     });

--- a/server/omo-cli.test.ts
+++ b/server/omo-cli.test.ts
@@ -103,13 +103,13 @@ test('normalizeOmoEvent ignores the non-message envelopes the CLI also emits', (
   }
 });
 
-test('normalizeOmoEvent surfaces errors with an omo-labelled fallback', () => {
+test('normalizeOmoEvent surfaces errors with an Oh My OpenAgent-labelled fallback', () => {
   assert.equal(
     normalizeOmoEvent({ type: 'error', error: { message: 'boom' } }, 'session-1').messages[0].content,
     'boom',
   );
   assert.equal(
     normalizeOmoEvent({ type: 'error' }, 'session-1').messages[0].content,
-    'omo failed.',
+    'Oh My OpenAgent failed.',
   );
 });

--- a/server/omo-cli.ts
+++ b/server/omo-cli.ts
@@ -11,7 +11,7 @@ import type { NormalizedMessage } from './shared/types.js';
 const OMO: PiCliDescriptor = {
   provider: 'omo',
   binary: 'omo',
-  label: 'omo',
+  label: 'Oh My OpenAgent',
 };
 
 const runtime = createPiCliRuntime(OMO);

--- a/src/components/chat/view/subcomponents/MessageComponent.tsx
+++ b/src/components/chat/view/subcomponents/MessageComponent.tsx
@@ -204,7 +204,7 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, s
                             : provider === 'omp'
                               ? t('messageTypes.omp', { defaultValue: 'Oh My Pi' })
                               : provider === 'omo'
-                                ? t('messageTypes.omo', { defaultValue: 'omo' })
+                                ? t('messageTypes.omo', { defaultValue: 'Oh My OpenAgent' })
                                 : t('messageTypes.claude'))}
               </div>
             </div>

--- a/src/components/chat/view/subcomponents/ProviderSelectionEmptyState.tsx
+++ b/src/components/chat/view/subcomponents/ProviderSelectionEmptyState.tsx
@@ -322,7 +322,7 @@ export default function ProviderSelectionEmptyState({
                 }),
                 omp: `Ready with Oh My Pi ${ompModel}`,
                 omo: t("providerSelection.readyPrompt.omo", {
-                  defaultValue: "Ready with omo",
+                  defaultValue: "Ready with Oh My OpenAgent",
                 }),
               }[provider]
             }

--- a/src/components/llm-logo-provider/OmoLogo.tsx
+++ b/src/components/llm-logo-provider/OmoLogo.tsx
@@ -3,7 +3,7 @@ type OmoLogoProps = {
 };
 
 /**
- * Official omo mark from oh-my-openagent `.github/assets/omo-icon-light.svg`.
+ * Official Oh My OpenAgent mark from `.github/assets/omo-icon-light.svg`.
  *
  * Cropped to the cat itself rather than to the source canvas. Measured from a
  * 512px render, the mark occupies x 190..832, y 220..794 of the 1024 canvas —
@@ -16,7 +16,7 @@ const OmoLogo = ({ className = 'w-5 h-5' }: OmoLogoProps) => (
   <svg
     viewBox="158 154 706 706"
     role="img"
-    aria-label="omo"
+    aria-label="Oh My OpenAgent"
     className={className}
     xmlns="http://www.w3.org/2000/svg"
   >

--- a/src/components/main-content/view/MainContent.tsx
+++ b/src/components/main-content/view/MainContent.tsx
@@ -328,7 +328,7 @@ function MainContent({
       cursor: 'Cursor',
       opencode: 'OpenCode',
       omp: 'Oh My Pi',
-      omo: 'omo',
+      omo: 'Oh My OpenAgent',
     }[externalTerminal.cliKind];
     const pendingCliAttachTarget = buildTranscriptCliAttachTarget({
       tmux: externalTerminal.tmux,

--- a/src/components/settings/view/tabs/agents-settings/AgentListItem.tsx
+++ b/src/components/settings/view/tabs/agents-settings/AgentListItem.tsx
@@ -41,7 +41,7 @@ const agentConfig: Record<AgentProvider, AgentConfig> = {
     color: 'gray',
   },
   omo: {
-    name: 'omo',
+    name: 'Oh My OpenAgent',
     color: 'gray',
   },
 };

--- a/src/components/settings/view/tabs/agents-settings/sections/AgentSelectorSection.tsx
+++ b/src/components/settings/view/tabs/agents-settings/sections/AgentSelectorSection.tsx
@@ -10,7 +10,7 @@ const AGENT_NAMES: Record<AgentProvider, string> = {
   opencode: 'OpenCode',
   gjc: 'Gajae Code',
   omp: 'Oh My Pi',
-  omo: 'omo',
+  omo: 'Oh My OpenAgent',
 };
 
 export default function AgentSelectorSection({

--- a/src/components/settings/view/tabs/agents-settings/sections/content/AccountContent.tsx
+++ b/src/components/settings/view/tabs/agents-settings/sections/content/AccountContent.tsx
@@ -65,8 +65,8 @@ const agentConfig: Record<AgentProvider, AgentVisualConfig> = {
     buttonClass: 'bg-zinc-900 hover:bg-zinc-800 active:bg-zinc-950 dark:bg-zinc-700 dark:hover:bg-zinc-600',
   },
   omo: {
-    name: 'omo',
-    description: 'omo coding agent',
+    name: 'Oh My OpenAgent',
+    description: 'Oh My OpenAgent coding agent',
     bgClass: 'bg-zinc-50 dark:bg-zinc-900/20',
     borderClass: 'border-zinc-200 dark:border-zinc-700',
     textClass: 'text-zinc-900 dark:text-zinc-100',

--- a/src/components/sidebar/view/subcomponents/SidebarExternalSection.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarExternalSection.tsx
@@ -19,7 +19,7 @@ const KIND_LABEL: Record<ExternalCliSession['kind'], string> = {
   cursor: 'Cursor',
   opencode: 'OpenCode',
   omp: 'Oh My Pi',
-  omo: 'omo',
+  omo: 'Oh My OpenAgent',
   ssh: 'ssh (remote)',
   shell: 'terminal',
 };

--- a/src/components/sidebar/view/subcomponents/SidebarNewSession.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarNewSession.tsx
@@ -20,7 +20,7 @@ const PROVIDERS: { id: SpawnProvider; label: string }[] = [
   { id: 'cursor', label: 'Cursor' },
   { id: 'opencode', label: 'OpenCode' },
   { id: 'omp', label: 'Oh My Pi' },
-  { id: 'omo', label: 'omo' },
+  { id: 'omo', label: 'Oh My OpenAgent' },
 ];
 
 // Working directories of successful spawns, most recent first. Typing an


### PR DESCRIPTION
## Summary
- use the official **Oh My OpenAgent** product name in README translations and user-facing UI
- keep `omo` unchanged as the internal provider id and CLI command
- update notifications, fallback errors, accessibility text, and generated session titles

## Verification
- `npm run typecheck`
- `npm test` (932 server + 266 client tests)
- staged ESLint checks
- `git diff --check`