### PR TITLE
fix(ui): place Oh My OpenAgent first

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="docs/assets/readme-hero.svg" alt="ChatMux — every coding agent, one command deck: Codex, Claude, Gajae Code, Cursor, OpenCode, Oh My Pi, and Oh My OpenAgent sessions multiplexed into one self-hosted interface" width="900">
+  <img src="docs/assets/readme-hero.svg" alt="ChatMux — every coding agent, one command deck: Oh My OpenAgent, Codex, Claude, Gajae Code, Cursor, OpenCode, and Oh My Pi sessions multiplexed into one self-hosted interface" width="900">
 </p>
 
 <p align="center"><sub><b>English</b> · <a href="docs/readme/README.ko.md">한국어</a> · <a href="docs/readme/README.ja.md">日本語</a> · <a href="docs/readme/README.zh-CN.md">简体中文</a></sub></p>
 
-<p align="center">One interface for Claude Code, Codex, Cursor, OpenCode, Gajae Code, Oh My Pi, and Oh My OpenAgent —<br>the agents already running in your tmux.</p>
+<p align="center">One interface for Oh My OpenAgent, Claude Code, Codex, Cursor, OpenCode, Gajae Code, and Oh My Pi —<br>the agents already running in your tmux.</p>
 
 <p align="center">
   <a href="https://github.com/devswha/chatmux/releases"><img src="https://img.shields.io/github/v/release/devswha/chatmux?display_name=tag&label=release&style=flat-square&color=6366f1" alt="GitHub release"></a>
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/runtime-tmux-ff6b4a?style=flat-square" alt="tmux runtime">
 </p>
 
-You run coding agents — Gajae Code, Claude Code, Codex, Cursor CLI, OpenCode, Oh My Pi, Oh My OpenAgent — inside tmux, like always. ChatMux finds them by itself and shows every session in one browser page, from your desktop or your phone.
+You run coding agents — Oh My OpenAgent, Gajae Code, Claude Code, Codex, Cursor CLI, OpenCode, Oh My Pi — inside tmux, like always. ChatMux finds them by itself and shows every session in one browser page, from your desktop or your phone.
 
 - **Zero registration:** Agents already running in tmux just appear in the sidebar. Nothing to wrap, wire, or restart.
 - **Multi-provider:** Every provider in a single drag-sortable list, with `RUN`, `READY`, and `ERROR` badges for live state.
@@ -80,13 +80,13 @@ Turn on Tailscale on the phone, scan the QR code from the install output, and us
 
 | Agent | Found automatically | Chat view | Send input | Start new session |
 |---|:---:|---|---|:---:|
+| **Oh My OpenAgent** (`omo`) | Yes | After its history is indexed | Prompts and `/skill:` skills | Yes |
 | **Gajae Code (GJC)** | Yes | Yes | Prompts and `/` commands | Yes |
 | **Codex CLI** | Yes | After its history is indexed | Prompts and `$` skills | Yes |
 | **Claude Code** | Yes | After its history is indexed | Prompts and `/` skills | Yes |
 | **Cursor CLI** | Yes | After its history is indexed | Prompts and `/` skills | Yes |
 | **OpenCode** | Yes | After its history is indexed | Prompts and `/` skills | Yes |
 | **Oh My Pi** | Yes | After its history is indexed | Prompts and `/skill:` skills | Yes |
-| **Oh My OpenAgent** (`omo`) | Yes | After its history is indexed | Prompts and `/skill:` skills | Yes |
 | **SSH tmux** | Yes | No — terminal only | Terminal keystrokes | No |
 | **Local shell** | Yes | No — terminal only | Terminal keystrokes | No |
 

--- a/docs/readme/README.ja.md
+++ b/docs/readme/README.ja.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="../assets/readme-hero.svg" alt="ChatMux — あらゆるコーディングエージェントをひとつのコマンドデッキに: Codex、Claude、Gajae Code、Cursor、OpenCode、Oh My Pi、Oh My OpenAgent のセッションをひとつのセルフホスト型インターフェースへ多重化" width="900">
+  <img src="../assets/readme-hero.svg" alt="ChatMux — あらゆるコーディングエージェントをひとつのコマンドデッキに: Oh My OpenAgent、Codex、Claude、Gajae Code、Cursor、OpenCode、Oh My Pi のセッションをひとつのセルフホスト型インターフェースへ多重化" width="900">
 </p>
 
 <p align="center"><sub><a href="../../README.md">English</a> · <a href="README.ko.md">한국어</a> · <b>日本語</b> · <a href="README.zh-CN.md">简体中文</a></sub></p>
 
-<p align="center">Claude Code、Codex、Cursor、OpenCode、Gajae Code、Oh My Pi、Oh My OpenAgent のためのひとつのインターフェース —<br>tmux ですでに動いているエージェントをまとめて管理できます。</p>
+<p align="center">Oh My OpenAgent、Claude Code、Codex、Cursor、OpenCode、Gajae Code、Oh My Pi のためのひとつのインターフェース —<br>tmux ですでに動いているエージェントをまとめて管理できます。</p>
 
 <p align="center">
   <a href="https://github.com/devswha/chatmux/releases"><img src="https://img.shields.io/github/v/release/devswha/chatmux?display_name=tag&label=release&style=flat-square&color=6366f1" alt="GitHub リリース"></a>
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/runtime-tmux-ff6b4a?style=flat-square" alt="tmux ランタイム">
 </p>
 
-コーディングエージェント — Gajae Code、Claude Code、Codex、Cursor CLI、OpenCode、Oh My Pi、Oh My OpenAgent — は、これまでどおり tmux の中で動かします。ChatMux が自動で見つけ出し、デスクトップからでもスマホからでも、すべてのセッションをブラウザの 1 ページに表示します。
+コーディングエージェント — Oh My OpenAgent、Gajae Code、Claude Code、Codex、Cursor CLI、OpenCode、Oh My Pi — は、これまでどおり tmux の中で動かします。ChatMux が自動で見つけ出し、デスクトップからでもスマホからでも、すべてのセッションをブラウザの 1 ページに表示します。
 
 - **登録不要:** tmux ですでに動いているエージェントがサイドバーにそのまま現れます。ラップも配線も再起動も不要です。
 - **マルチプロバイダー:** すべてのプロバイダーを、ドラッグで並べ替えられるひとつのリストにまとめ、ライブ状態を `RUN`、`READY`、`ERROR` バッジで表示します。
@@ -80,13 +80,13 @@ Linux x86_64 (glibc 2.35+)、tmux、ユーザーレベルの systemd、`curl`/`t
 
 | エージェント | 自動検出 | チャットビュー | 入力送信 | 新規セッションの開始 |
 |---|:---:|---|---|:---:|
+| **Oh My OpenAgent** (`omo`) | はい | 履歴のインデックス後 | プロンプトと `/skill:` スキル | はい |
 | **Gajae Code (GJC)** | はい | はい | プロンプトと `/` コマンド | はい |
 | **Codex CLI** | はい | 履歴のインデックス後 | プロンプトと `$` スキル | はい |
 | **Claude Code** | はい | 履歴のインデックス後 | プロンプトと `/` スキル | はい |
 | **Cursor CLI** | はい | 履歴のインデックス後 | プロンプトと `/` スキル | はい |
 | **OpenCode** | はい | 履歴のインデックス後 | プロンプトと `/` スキル | はい |
 | **Oh My Pi** | はい | 履歴のインデックス後 | プロンプトと `/skill:` スキル | はい |
-| **Oh My OpenAgent** (`omo`) | はい | 履歴のインデックス後 | プロンプトと `/skill:` スキル | はい |
 | **SSH tmux** | はい | いいえ — ターミナルのみ | ターミナルのキー入力 | いいえ |
 | **Local shell** | はい | いいえ — ターミナルのみ | ターミナルのキー入力 | いいえ |
 

--- a/docs/readme/README.ko.md
+++ b/docs/readme/README.ko.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="../assets/readme-hero.svg" alt="ChatMux — 모든 코딩 에이전트를 하나의 커맨드 데크로: Codex, Claude, Gajae Code, Cursor, OpenCode, Oh My Pi, Oh My OpenAgent 세션을 하나의 셀프호스트 인터페이스로 멀티플렉싱" width="900">
+  <img src="../assets/readme-hero.svg" alt="ChatMux — 모든 코딩 에이전트를 하나의 커맨드 데크로: Oh My OpenAgent, Codex, Claude, Gajae Code, Cursor, OpenCode, Oh My Pi 세션을 하나의 셀프호스트 인터페이스로 멀티플렉싱" width="900">
 </p>
 
 <p align="center"><sub><a href="../../README.md">English</a> · <b>한국어</b> · <a href="README.ja.md">日本語</a> · <a href="README.zh-CN.md">简体中文</a></sub></p>
 
-<p align="center">Claude Code, Codex, Cursor, OpenCode, Gajae Code, Oh My Pi, omo를 위한 하나의 인터페이스 —<br>tmux에서 이미 실행 중인 에이전트를 한곳에 모읍니다.</p>
+<p align="center">Oh My OpenAgent, Claude Code, Codex, Cursor, OpenCode, Gajae Code, Oh My Pi를 위한 하나의 인터페이스 —<br>tmux에서 이미 실행 중인 에이전트를 한곳에 모읍니다.</p>
 
 <p align="center">
   <a href="https://github.com/devswha/chatmux/releases"><img src="https://img.shields.io/github/v/release/devswha/chatmux?display_name=tag&label=release&style=flat-square&color=6366f1" alt="GitHub 릴리즈"></a>
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/runtime-tmux-ff6b4a?style=flat-square" alt="tmux 런타임">
 </p>
 
-Gajae Code, Claude Code, Codex, Cursor CLI, OpenCode, Oh My Pi, Oh My OpenAgent 같은 코딩 에이전트를 늘 하던 대로 tmux 안에서 실행하세요. ChatMux가 알아서 찾아 데스크톱이나 휴대폰에서 모든 세션을 하나의 브라우저 페이지에 보여줍니다.
+Oh My OpenAgent, Gajae Code, Claude Code, Codex, Cursor CLI, OpenCode, Oh My Pi 같은 코딩 에이전트를 늘 하던 대로 tmux 안에서 실행하세요. ChatMux가 알아서 찾아 데스크톱이나 휴대폰에서 모든 세션을 하나의 브라우저 페이지에 보여줍니다.
 
 - **등록 절차 없음:** tmux에서 이미 실행 중인 에이전트가 사이드바에 바로 나타납니다. 감싸거나 연결하거나 재시작할 것이 없습니다.
 - **멀티 프로바이더:** 모든 프로바이더가 드래그로 정렬할 수 있는 하나의 목록에 모이고, `RUN`, `READY`, `ERROR` 배지로 실시간 상태를 보여줍니다.
@@ -80,13 +80,13 @@ Linux x86_64(glibc 2.35+)와 tmux, 사용자 레벨 systemd, `curl`/`tar`/`sha25
 
 | 에이전트 | 자동 발견 | 채팅 뷰 | 입력 전송 | 새 세션 시작 |
 |---|:---:|---|---|:---:|
+| **Oh My OpenAgent** (`omo`) | 예 | 히스토리 인덱싱 후 | 프롬프트와 `/skill:` 스킬 | 예 |
 | **Gajae Code (GJC)** | 예 | 예 | 프롬프트와 `/` 명령 | 예 |
 | **Codex CLI** | 예 | 히스토리 인덱싱 후 | 프롬프트와 `$` 스킬 | 예 |
 | **Claude Code** | 예 | 히스토리 인덱싱 후 | 프롬프트와 `/` 스킬 | 예 |
 | **Cursor CLI** | 예 | 히스토리 인덱싱 후 | 프롬프트와 `/` 스킬 | 예 |
 | **OpenCode** | 예 | 히스토리 인덱싱 후 | 프롬프트와 `/` 스킬 | 예 |
 | **Oh My Pi** | 예 | 히스토리 인덱싱 후 | 프롬프트와 `/skill:` 스킬 | 예 |
-| **Oh My OpenAgent** (`omo`) | 예 | 히스토리 인덱싱 후 | 프롬프트와 `/skill:` 스킬 | 예 |
 | **SSH tmux** | 예 | 아니오 — 터미널 전용 | 터미널 키 입력 | 아니오 |
 | **Local shell** | 예 | 아니오 — 터미널 전용 | 터미널 키 입력 | 아니오 |
 

--- a/docs/readme/README.zh-CN.md
+++ b/docs/readme/README.zh-CN.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img src="../assets/readme-hero.svg" alt="ChatMux — 所有编码代理，一个指挥台：Codex、Claude、Gajae Code、Cursor、OpenCode、Oh My Pi 和 Oh My OpenAgent 会话多路复用到一个自托管界面" width="900">
+  <img src="../assets/readme-hero.svg" alt="ChatMux — 所有编码代理，一个指挥台：Oh My OpenAgent、Codex、Claude、Gajae Code、Cursor、OpenCode 和 Oh My Pi 会话多路复用到一个自托管界面" width="900">
 </p>
 
 <p align="center"><sub><a href="../../README.md">English</a> · <a href="README.ko.md">한국어</a> · <a href="README.ja.md">日本語</a> · <b>简体中文</b></sub></p>
 
-<p align="center">One interface for Claude Code, Codex, Cursor, OpenCode, Gajae Code, Oh My Pi, and Oh My OpenAgent —<br>the agents already running in your tmux.</p>
+<p align="center">One interface for Oh My OpenAgent, Claude Code, Codex, Cursor, OpenCode, Gajae Code, and Oh My Pi —<br>the agents already running in your tmux.</p>
 
 <p align="center">
   <a href="https://github.com/devswha/chatmux/releases"><img src="https://img.shields.io/github/v/release/devswha/chatmux?display_name=tag&label=release&style=flat-square&color=6366f1" alt="GitHub 发布"></a>
@@ -13,7 +13,7 @@
   <img src="https://img.shields.io/badge/runtime-tmux-ff6b4a?style=flat-square" alt="tmux 运行时">
 </p>
 
-你照常在 tmux 中运行编码代理 — Gajae Code、Claude Code、Codex、Cursor CLI、OpenCode、Oh My Pi、Oh My OpenAgent。ChatMux 会自动发现它们，并把所有会话显示在一个浏览器页面中，无论你使用桌面还是手机。
+你照常在 tmux 中运行编码代理 — Oh My OpenAgent、Gajae Code、Claude Code、Codex、Cursor CLI、OpenCode、Oh My Pi。ChatMux 会自动发现它们，并把所有会话显示在一个浏览器页面中，无论你使用桌面还是手机。
 
 - **无需注册：** 已在 tmux 中运行的代理会直接出现在侧边栏。不用包装、接线或重启。
 - **多提供方：** 所有提供方都在一个可拖拽排序的列表中，实时显示 `RUN`、`READY` 和 `ERROR` 徽章。
@@ -80,13 +80,13 @@ curl -fsSL https://github.com/devswha/chatmux/releases/latest/download/install.s
 
 | 代理 | 自动发现 | 聊天视图 | 发送输入 | 新建会话 |
 |---|:---:|---|---|:---:|
+| **Oh My OpenAgent** (`omo`) | 是 | 历史索引后 | 提示词与 `/skill:` 技能 | 是 |
 | **Gajae Code (GJC)** | 是 | 是 | 提示词与 `/` 命令 | 是 |
 | **Codex CLI** | 是 | 历史索引后 | 提示词与 `$` 技能 | 是 |
 | **Claude Code** | 是 | 历史索引后 | 提示词与 `/` 技能 | 是 |
 | **Cursor CLI** | 是 | 历史索引后 | 提示词与 `/` 技能 | 是 |
 | **OpenCode** | 是 | 历史索引后 | 提示词与 `/` 技能 | 是 |
 | **Oh My Pi** | 是 | 历史索引后 | 提示词与 `/skill:` 技能 | 是 |
-| **Oh My OpenAgent** (`omo`) | 是 | 历史索引后 | 提示词与 `/skill:` 技能 | 是 |
 | **SSH tmux** | 是 | 否 — 仅终端 | 终端按键 | 否 |
 | **Local shell** | 是 | 否 — 仅终端 | 终端按键 | 否 |
 

--- a/src/components/settings/view/tabs/agents-settings/AgentsSettingsTab.tsx
+++ b/src/components/settings/view/tabs/agents-settings/AgentsSettingsTab.tsx
@@ -27,7 +27,7 @@ export default function AgentsSettingsTab({
   }, [selectedAgent]);
 
   const visibleAgents = useMemo<AgentProvider[]>(() => {
-    return ['claude', 'cursor', 'codex', 'opencode', 'omp', 'omo'];
+    return ['omo', 'claude', 'cursor', 'codex', 'opencode', 'omp'];
   }, []);
 
   const agentContextById = useMemo<Record<AgentProvider, AgentContext>>(() => ({

--- a/src/components/sidebar/view/subcomponents/SidebarNewSession.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarNewSession.tsx
@@ -14,13 +14,13 @@ type SpawnStatus =
   | { kind: 'error'; text: string };
 
 const PROVIDERS: { id: SpawnProvider; label: string }[] = [
+  { id: 'omo', label: 'Oh My OpenAgent' },
   { id: 'gjc', label: 'GJC' },
   { id: 'codex', label: 'Codex' },
   { id: 'claude', label: 'Claude' },
   { id: 'cursor', label: 'Cursor' },
   { id: 'opencode', label: 'OpenCode' },
   { id: 'omp', label: 'Oh My Pi' },
-  { id: 'omo', label: 'Oh My OpenAgent' },
 ];
 
 // Working directories of successful spawns, most recent first. Typing an


### PR DESCRIPTION
## Summary
- place Oh My OpenAgent first in the settings agent selector
- place Oh My OpenAgent first in the new-session provider list
- lead with Oh My OpenAgent in all README translations and agent-support tables
- leave runtime classification and existing-session ordering unchanged

## Verification
- `npm run typecheck`
- `npm test` (932 server + 266 client tests)
- ESLint on changed UI files
- `git diff --check`