### PR TITLE
chore(release): v1.8.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatmux",
-  "version": "1.8.14",
+  "version": "1.8.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatmux",
-      "version": "1.8.14",
+      "version": "1.8.15",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chatmux",
   "private": true,
-  "version": "1.8.14",
+  "version": "1.8.15",
   "productName": "ChatMux",
   "description": "A self-hosted web interface for coding-agent sessions running in tmux",
   "type": "module",

--- a/packaging/release/update-compatibility.json
+++ b/packaging/release/update-compatibility.json
@@ -174,6 +174,14 @@
           "1.8.13"
         ]
       }
+    },
+    "1.8.15": {
+      "database": {
+        "schemaGeneration": 19,
+        "rollbackCompatibleFrom": [
+          "1.8.14"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Bump version to 1.8.15 (`package.json`, `package-lock.json`)
- Declare 1.8.15 database compatibility: `schemaGeneration` 19, `rollbackCompatibleFrom` `["1.8.14"]`

Schema generation moved 16 -> 19 since v1.8.14 (fleet persistence schema, hub-grant rebuild, fleet role exclusivity), so the governance policy allows the singleton predecessor declaration; the release workflow proves the 1.8.14 rollback with the real published runtime.

First release prepared under the single-path release governance from #66.

## Test plan
- [x] `node scripts/release/check-release-metadata.mjs` passes locally with the canonical declaration and migration registry pinned at v1.8.14 (mirrors the release preflight)
- [ ] Required CI checks green
- [ ] After merge: dispatch the Release workflow on main