### PR TITLE
fix(auth): refuse the local owner role for proxied loopback requests

### DIFF
--- a/server/tailscale-auth.test.ts
+++ b/server/tailscale-auth.test.ts
@@ -6,6 +6,7 @@ import {
   authenticateTailscaleRequest,
   getTailscaleAccessConfig,
   getTailscaleAccessRole,
+  hasProxyHeaders,
   isLoopbackHost,
   normalizeTailscaleLogin,
   revokeTailscaleUser,
@@ -98,4 +99,48 @@ test('local direct access remains an owner recovery path without accepting DNS r
     socket: { remoteAddress: '127.0.0.1' },
     headers: { host: 'malicious.example' },
   }, store), null);
+});
+
+test('a Tailscale Serve request that rewrites Host to a loopback name never becomes the local owner', () => {
+  const store = createStore();
+  setTailscaleOwner('owner@example.com', store);
+  // Observed on a real host: Serve forwards the client's Host verbatim and
+  // always stamps x-forwarded-* plus tailscale-user-* on the proxied request.
+  const serveWithLoopbackHost = {
+    host: 'localhost',
+    'x-forwarded-for': '100.64.0.2',
+    'x-forwarded-host': 'localhost',
+    'x-forwarded-proto': 'https',
+    'tailscale-user-login': 'owner@example.com',
+    'tailscale-user-name': 'Owner',
+  };
+  assert.equal(authenticateTailscaleRequest({
+    socket: { remoteAddress: '127.0.0.1' },
+    headers: serveWithLoopbackHost,
+  }, store), null, 'even the allowlisted owner must not be promoted to local through a rewritten Host');
+  assert.equal(authenticateTailscaleRequest({
+    socket: { remoteAddress: '127.0.0.1' },
+    headers: { ...serveWithLoopbackHost, 'tailscale-user-login': 'stranger@example.com' },
+  }, store), null, 'a tailnet user outside the allowlist cannot bypass it with Host: localhost');
+  assert.equal(authenticateTailscaleRequest({
+    socket: { remoteAddress: '127.0.0.1' },
+    headers: { host: '127.0.0.1:3001', 'x-forwarded-for': '100.64.0.2' },
+  }, store), null, 'any forwarded-for header marks the request as proxied');
+  assert.equal(authenticateTailscaleRequest({
+    socket: { remoteAddress: '127.0.0.1' },
+    headers: { host: '[::1]:3001', forwarded: 'for=100.64.0.2;proto=https' },
+  }, store), null, 'the RFC 7239 Forwarded header also marks the request as proxied');
+  assert.deepEqual(authenticateTailscaleRequest({
+    socket: { remoteAddress: '127.0.0.1' },
+    headers: { host: 'localhost:3001', 'accept-encoding': 'gzip' },
+  }, store), { login: null, name: null, role: 'local', source: 'local' }, 'an untouched loopback request keeps the recovery path');
+});
+
+test('proxy header detection is case-insensitive and ignores unset entries', () => {
+  assert.equal(hasProxyHeaders(undefined), false);
+  assert.equal(hasProxyHeaders({ host: 'localhost' }), false);
+  assert.equal(hasProxyHeaders({ host: 'localhost', 'x-forwarded-for': undefined }), false);
+  assert.equal(hasProxyHeaders({ host: 'localhost', 'X-Forwarded-Proto': 'https' }), true);
+  assert.equal(hasProxyHeaders({ host: 'localhost', 'tailscale-headers-info': 'https://tailscale.com/s/serve-headers' }), true);
+  assert.equal(hasProxyHeaders({ host: 'localhost', via: '1.1 proxy' }), true);
 });

--- a/server/tailscale-auth.ts
+++ b/server/tailscale-auth.ts
@@ -125,6 +125,30 @@ function isSameOrigin(headers: RequestLike['headers'], host: string, protocol: '
   }
 }
 
+/**
+ * Header names that only appear when a proxy sat between the client and this
+ * server. Tailscale Serve stamps `x-forwarded-for`, `x-forwarded-host`,
+ * `x-forwarded-proto` and `tailscale-*` on every request it forwards and
+ * overwrites any copies the client sent, while a direct loopback client (the
+ * browser on this machine, an SSH-forwarded port) carries none of them. Their
+ * presence is therefore proof that a loopback socket peer is not the local
+ * owner, even when the client rewrote `Host` to a loopback name: Serve routes
+ * TLS by SNI and forwards the request's `Host` header verbatim.
+ */
+const PROXY_HEADER_PREFIXES = ['x-forwarded-', 'tailscale-'];
+const PROXY_HEADER_NAMES = new Set(['forwarded', 'via']);
+
+export function hasProxyHeaders(headers: RequestLike['headers']): boolean {
+  if (!headers) return false;
+  for (const rawName of Object.keys(headers)) {
+    if (headers[rawName] === undefined) continue;
+    const name = rawName.toLowerCase();
+    if (PROXY_HEADER_NAMES.has(name)) return true;
+    if (PROXY_HEADER_PREFIXES.some((prefix) => name.startsWith(prefix))) return true;
+  }
+  return false;
+}
+
 export type TailscaleRequestIdentity = {
   login: string | null;
   name: string | null;
@@ -145,6 +169,11 @@ export function authenticateTailscaleRequest(
   if (!host || (!isLocalHost && !isServeHost)) return null;
   if (!isSameOrigin(request.headers, host, isServeHost ? 'https:' : 'http:')) return null;
   if (isLocalHost) {
+    // A loopback Host proves nothing on its own: Tailscale Serve proxies to
+    // this same loopback port and passes the client's Host through, so a
+    // tailnet peer could send `Host: localhost` to skip the identity check.
+    // Only a request that no proxy touched is the local owner recovery path.
+    if (hasProxyHeaders(request.headers)) return null;
     return { login: null, name: null, role: 'local', source: 'local' };
   }
 


### PR DESCRIPTION
## Summary

In `CHATMUX_AUTH=tailscale` mode, `authenticateTailscaleRequest` granted the local owner role to any loopback socket peer whose `Host` header was a loopback name, before reading the Tailscale identity header. Tailscale Serve proxies to that same loopback port, routes TLS by SNI, and forwards the client's `Host` verbatim, so any tailnet peer could send `Host: localhost` and skip both the identity check and the allowlist. The same `local` role also passed `canUpdate` in `server/self-update.ts` and the owner check for `/remote-shell`.

This PR treats the presence of any `x-forwarded-*`, `tailscale-*`, `Forwarded` or `Via` header as proof that a proxy sat in front of the request and refuses the `local` role in that case. The `*.ts.net` identity path and the untouched-loopback recovery path (local browser, SSH-forwarded port) are unchanged.

## Evidence

Reproduced against a live tailscale-mode install through its Serve address (read-only GET on the public status endpoint):

```
$ curl -s https://<node>.ts.net:3001/api/auth/status
{"authMode":"tailscale", ... "isAuthenticated":true,"identity":"<owner login>"}

$ curl -s -H 'Host: localhost' https://<node>.ts.net:3001/api/auth/status
{"authMode":"tailscale", ... "isAuthenticated":true,"identity":null}
```

Headers observed at a loopback backend behind Serve on the same host (echo server), which the fix relies on:

- Plain Serve request: `host: <node>.ts.net:10000`, `x-forwarded-for`, `x-forwarded-host`, `x-forwarded-proto: https`, `tailscale-user-login`, `tailscale-user-name`, `tailscale-user-profile-pic`, `tailscale-headers-info`.
- Serve request with client `Host: localhost`: `host: localhost`, `x-forwarded-host: localhost`, and the same `x-forwarded-for`, `x-forwarded-proto` and `tailscale-user-*` headers.
- Serve request with client-supplied `X-Forwarded-*` and `Tailscale-User-Login`: all overwritten by Serve with the real values.
- Direct loopback request: only `host: 127.0.0.1:8317`.

Vite's dev proxy shorthand does not set `xfwd`, so `npm run dev` keeps the local path working.

## Follow-up (not in this PR)

A more structural fix is to point Serve at a dedicated loopback listener that never yields the `local` role; that needs an installer change and a re-run of `chatmux access enable tailscale` on existing installs.

## Verification

- `node --import tsx --test server/tailscale-auth.test.ts` (6 pass, 4 new assertions cover the rewritten-Host case, `x-forwarded-for`, `Forwarded`, and the preserved recovery path)
- `server/middleware/auth.test.js`, `server/tailscale-access.test.ts` (17 pass)
- `tsc --noEmit -p server/tsconfig.json`, `eslint` on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
