### PR TITLE
fix(security): reject cross-site API and WebSocket requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,11 @@ HOST=127.0.0.1
 # e.g. Tailscale Serve: VITE_ALLOWED_HOSTS=my-machine.tailnet-name.ts.net
 # VITE_ALLOWED_HOSTS=
 
+# Extra Host header names the API accepts in auth mode none (comma-separated).
+# Loopback names, the HOST bind address and *.ts.net are always accepted; any
+# other Host is refused there because the mode has no login to bind authority to.
+# CHATMUX_ALLOWED_HOSTS=my-desktop.lan
+
 # Authentication mode:
 #   none      - implicit local owner (default)
 #   password  - ChatMux username/password

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "compression": "^1.8.1",
-        "cors": "^2.8.5",
         "cross-spawn": "^7.0.3",
         "dompurify": "^3.4.7",
         "express": "^4.18.2",
@@ -6525,6 +6524,7 @@
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "object-assign": "^4",
         "vary": "^1"

--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "compression": "^1.8.1",
-    "cors": "^2.8.5",
     "cross-spawn": "^7.0.3",
     "dompurify": "^3.4.7",
     "express": "^4.18.2",

--- a/server/index.js
+++ b/server/index.js
@@ -8,7 +8,6 @@ import os from 'os';
 import http from 'http';
 
 import express from 'express';
-import cors from 'cors';
 import compression from 'compression';
 import Database from 'better-sqlite3';
 
@@ -107,6 +106,7 @@ import {
 import { filesRoutes } from './modules/files/index.js';
 import { configureWebPush } from './services/vapid-keys.js';
 import { authenticateToken, authenticateWebSocket, AUTH_MODE } from './middleware/auth.js';
+import { createCrossSiteGuard, parseAllowedHostList } from './middleware/cross-site-guard.js';
 import { c } from './utils/colors.js';
 import { evaluateExposure } from './utils/exposure-guard.js';
 
@@ -157,6 +157,16 @@ const app = express();
 app.set('trust proxy', 1);
 const server = http.createServer(app);
 
+// Browser API and WebSocket upgrades are same-site only. Origin must name this
+// deployment in every auth mode; in mode 'none' the Host header must as well,
+// because nothing else binds authority there (DNS rebinding otherwise turns a
+// loopback bind into remote shell access). CHATMUX_ALLOWED_HOSTS adds names.
+const crossSiteGuard = createCrossSiteGuard({
+    authMode: AUTH_MODE,
+    bindHost: process.env.HOST || '127.0.0.1',
+    allowedHosts: parseAllowedHostList(process.env.CHATMUX_ALLOWED_HOSTS),
+});
+
 // The collector is inert until the first authenticated discovery subscription.
 const discoveryCollector = createDiscoveryCollector();
 app.locals.discoveryCollector = discoveryCollector;
@@ -174,6 +184,7 @@ const stopTranscriptDiscoveryRefresh = onTranscriptChanged(() => {
 const wss = createWebSocketServer(server, {
     verifyClient: {
         authenticateWebSocket,
+        checkCrossSite: crossSiteGuard.check,
     },
     serverInfo: {
         version: RUNNING_VERSION,
@@ -280,7 +291,10 @@ app.use((req, res, next) => {
     }
     next();
 });
-app.use(cors());
+// No CORS: the app is same-origin (the Vite dev server proxies /api and every
+// WebSocket path), and a wildcard Access-Control-Allow-Origin would let any web
+// page read API responses from an unauthenticated (auth mode 'none') install.
+app.use('/api', crossSiteGuard.middleware);
 
 // Compress API responses (the project index alone is multi-megabyte JSON).
 // Event streams are excluded because compression buffering breaks incremental

--- a/server/middleware/cross-site-guard.js
+++ b/server/middleware/cross-site-guard.js
@@ -1,0 +1,144 @@
+// Same-site guard for the browser API and WebSocket upgrades.
+//
+// Two checks, both cheap and header-only:
+//   1. Origin must belong to this deployment. A browser attaches `Origin` to
+//      every cross-site fetch, every JSON POST and every WebSocket handshake,
+//      so a page on another site cannot drive `/api` or `/shell` even in auth
+//      mode 'none', where every request is otherwise the implicit owner.
+//   2. In auth mode 'none' the Host header must name this deployment. Without
+//      it, a DNS-rebinding page (attacker.example resolving to 127.0.0.1) is a
+//      same-origin request from the browser's point of view and check 1 never
+//      fires. Other modes already bind authority to a cookie or a Tailscale
+//      identity, so the allowlist stays off there to keep hostname-based LAN
+//      and reverse-proxy setups working.
+import { isTailscaleServeHost } from '../tailscale-auth.js';
+import { isLoopbackHost, isWildcardHost } from '../../shared/networkHosts.js';
+
+/**
+ * @param {unknown} value
+ * @returns {string | null} lowercase hostname (IPv6 keeps its brackets) or null
+ */
+export function requestHostname(value) {
+  if (typeof value !== 'string' || !value || /[\s/\\@]/.test(value)) return null;
+  try {
+    return new URL(`http://${value}`).hostname.toLowerCase() || null;
+  } catch {
+    return null;
+  }
+}
+
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
+
+/** @param {string | null} hostname */
+function isLoopbackHostname(hostname) {
+  return hostname !== null && LOOPBACK_HOSTNAMES.has(hostname);
+}
+
+/**
+ * Parses CHATMUX_ALLOWED_HOSTS: comma or whitespace separated hostnames.
+ * Ports are ignored; entries that do not parse as a host are dropped.
+ *
+ * @param {unknown} value
+ * @returns {string[]}
+ */
+export function parseAllowedHostList(value) {
+  if (typeof value !== 'string') return [];
+  const names = value
+    .split(/[\s,]+/)
+    .map((entry) => requestHostname(entry.trim()))
+    .filter((entry) => entry !== null);
+  return [...new Set(names)];
+}
+
+/**
+ * @param {unknown} hostHeader
+ * @param {{ bindHost?: string | null, allowedHosts?: readonly string[] }} options
+ */
+export function isAllowedRequestHost(hostHeader, { bindHost = null, allowedHosts = [] } = {}) {
+  const hostname = requestHostname(hostHeader);
+  if (hostname === null) return false;
+  if (isLoopbackHostname(hostname)) return true;
+  if (isTailscaleServeHost(hostHeader)) return true;
+  if (bindHost && !isWildcardHost(bindHost) && !isLoopbackHost(bindHost)) {
+    const bound = requestHostname(bindHost.includes(':') && !bindHost.startsWith('[') ? `[${bindHost}]` : bindHost);
+    if (bound !== null && bound === hostname) return true;
+  }
+  return allowedHosts.includes(hostname);
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string | null}
+ */
+function firstHeaderValue(value) {
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (typeof raw !== 'string') return null;
+  const first = raw.split(',')[0].trim();
+  return first || null;
+}
+
+/**
+ * True when the request carries no Origin, or when its Origin names this
+ * deployment: the same host (with port) as `Host` or as the first
+ * `X-Forwarded-Host` a TLS-terminating proxy recorded. Two loopback names on
+ * different ports are also accepted so the Vite dev server (:5173) can proxy
+ * to the API (:3001) without rewriting Origin.
+ *
+ * @param {unknown} originHeader
+ * @param {unknown} hostHeader
+ * @param {unknown} forwardedHostHeader
+ */
+export function originMatchesRequest(originHeader, hostHeader, forwardedHostHeader = undefined) {
+  if (originHeader === undefined) return true;
+  if (typeof originHeader !== 'string' || originHeader === 'null') return false;
+  let origin;
+  try {
+    origin = new URL(originHeader);
+  } catch {
+    return false;
+  }
+  if (origin.protocol !== 'http:' && origin.protocol !== 'https:') return false;
+  const originHost = origin.host.toLowerCase();
+  const candidates = [firstHeaderValue(hostHeader), firstHeaderValue(forwardedHostHeader)]
+    .filter((candidate) => candidate !== null)
+    .map((candidate) => candidate.toLowerCase());
+  if (candidates.includes(originHost)) return true;
+  return isLoopbackHostname(origin.hostname.toLowerCase()) && isLoopbackHostname(requestHostname(hostHeader));
+}
+
+/**
+ * @param {object} options
+ * @param {'none' | 'password' | 'tailscale'} options.authMode
+ * @param {string | null | undefined} [options.bindHost] the HOST the server listens on
+ * @param {readonly string[]} [options.allowedHosts] extra hostnames (CHATMUX_ALLOWED_HOSTS)
+ * @param {boolean} [options.enforceHostAllowlist] defaults to authMode === 'none'
+ */
+export function createCrossSiteGuard({ authMode, bindHost = null, allowedHosts = [], enforceHostAllowlist = authMode === 'none' }) {
+  const hostOptions = { bindHost, allowedHosts };
+
+  /**
+   * @param {{ headers?: Record<string, string | string[] | undefined> }} req
+   * @returns {{ ok: true } | { ok: false, error: string }}
+   */
+  const check = (req) => {
+    const headers = req.headers ?? {};
+    if (enforceHostAllowlist && !isAllowedRequestHost(headers.host, hostOptions)) {
+      return { ok: false, error: 'Request host is not allowed for this deployment.' };
+    }
+    if (!originMatchesRequest(headers.origin, headers.host, headers['x-forwarded-host'])) {
+      return { ok: false, error: 'Cross-site request rejected.' };
+    }
+    return { ok: true };
+  };
+
+  /** Express middleware form of `check`. */
+  const middleware = (req, res, next) => {
+    const result = check(req);
+    if (!result.ok) {
+      return res.status(403).json({ error: result.error });
+    }
+    next();
+  };
+
+  return { check, middleware, enforceHostAllowlist };
+}

--- a/server/middleware/cross-site-guard.test.js
+++ b/server/middleware/cross-site-guard.test.js
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  createCrossSiteGuard,
+  isAllowedRequestHost,
+  originMatchesRequest,
+  parseAllowedHostList,
+  requestHostname,
+} from './cross-site-guard.js';
+
+test('Origin must name the deployment host, with proxy and dev-server allowances', () => {
+  assert.equal(originMatchesRequest(undefined, 'localhost:3001'), true, 'no Origin header is not a cross-site request');
+  assert.equal(originMatchesRequest('http://localhost:3001', 'localhost:3001'), true);
+  assert.equal(originMatchesRequest('https://home.example.ts.net:8443', 'home.example.ts.net:8443'), true);
+  assert.equal(originMatchesRequest('https://chat.example.com', '127.0.0.1:3001', 'chat.example.com'), true, 'a TLS-terminating proxy records the public host');
+  assert.equal(originMatchesRequest('https://chat.example.com', '127.0.0.1:3001', 'chat.example.com, internal'), true, 'only the first forwarded host counts');
+  assert.equal(originMatchesRequest('http://localhost:5173', 'localhost:3001'), true, 'the Vite dev server proxies from another loopback port');
+  assert.equal(originMatchesRequest('http://127.0.0.1:5173', '[::1]:3001'), true);
+
+  assert.equal(originMatchesRequest('https://attacker.example', 'localhost:3001'), false, 'a foreign page cannot drive the API');
+  assert.equal(originMatchesRequest('https://attacker.example', '127.0.0.1:3001', 'attacker.example.internal'), false);
+  assert.equal(originMatchesRequest('null', 'localhost:3001'), false, 'an opaque origin is rejected');
+  assert.equal(originMatchesRequest('file:///etc/passwd', 'localhost:3001'), false);
+  assert.equal(originMatchesRequest('http://localhost:3001.attacker.example', 'localhost:3001'), false);
+  assert.equal(originMatchesRequest(42, 'localhost:3001'), false);
+});
+
+test('Host allowlist accepts loopback, the bind address, ts.net and configured names only', () => {
+  assert.equal(isAllowedRequestHost('localhost:3001'), true);
+  assert.equal(isAllowedRequestHost('127.0.0.1'), true);
+  assert.equal(isAllowedRequestHost('[::1]:3001'), true);
+  assert.equal(isAllowedRequestHost('home.example.ts.net:8443'), true);
+  assert.equal(isAllowedRequestHost('10.0.0.5:3001', { bindHost: '10.0.0.5' }), true, 'the configured bind address is this deployment');
+  assert.equal(isAllowedRequestHost('desktop.lan:3001', { allowedHosts: ['desktop.lan'] }), true);
+
+  assert.equal(isAllowedRequestHost('attacker.example:3001'), false, 'DNS rebinding hosts are refused');
+  assert.equal(isAllowedRequestHost('10.0.0.5:3001', { bindHost: '0.0.0.0' }), false, 'a wildcard bind does not whitelist arbitrary hosts');
+  assert.equal(isAllowedRequestHost('10.0.0.6:3001', { bindHost: '10.0.0.5' }), false);
+  assert.equal(isAllowedRequestHost('localhost.attacker.example'), false);
+  assert.equal(isAllowedRequestHost(''), false);
+  assert.equal(isAllowedRequestHost(undefined), false);
+  assert.equal(isAllowedRequestHost('local host'), false);
+});
+
+test('hostname parsing and CHATMUX_ALLOWED_HOSTS parsing are forgiving about ports and separators', () => {
+  assert.equal(requestHostname('Desktop.LAN:3001'), 'desktop.lan');
+  assert.equal(requestHostname('[::1]:3001'), '[::1]');
+  assert.equal(requestHostname('user@host'), null);
+  assert.deepEqual(parseAllowedHostList(' desktop.lan:3001, Nas.local\nchat.example.com '), ['desktop.lan', 'nas.local', 'chat.example.com']);
+  assert.deepEqual(parseAllowedHostList(undefined), []);
+});
+
+test('the guard enforces the Host allowlist only in auth mode none and the Origin check everywhere', () => {
+  const none = createCrossSiteGuard({ authMode: 'none', bindHost: '127.0.0.1' });
+  assert.deepEqual(none.check({ headers: { host: 'localhost:3001' } }), { ok: true });
+  assert.deepEqual(none.check({ headers: { host: 'localhost:3001', origin: 'http://localhost:3001' } }), { ok: true });
+  assert.equal(none.check({ headers: { host: 'attacker.example:3001' } }).ok, false, 'rebinding host is refused before any route runs');
+  assert.equal(none.check({ headers: { host: 'localhost:3001', origin: 'https://attacker.example' } }).ok, false);
+
+  const password = createCrossSiteGuard({ authMode: 'password', bindHost: '0.0.0.0' });
+  assert.deepEqual(password.check({ headers: { host: 'my-desktop:3001' } }), { ok: true }, 'hostname-based LAN access keeps working');
+  assert.equal(password.check({ headers: { host: 'my-desktop:3001', origin: 'https://attacker.example' } }).ok, false);
+
+  const tailscale = createCrossSiteGuard({ authMode: 'tailscale', bindHost: '127.0.0.1' });
+  assert.deepEqual(tailscale.check({ headers: { host: 'home.example.ts.net:3001', origin: 'https://home.example.ts.net:3001' } }), { ok: true });
+});
+
+test('the middleware answers 403 JSON and never calls next for a rejected request', () => {
+  const guard = createCrossSiteGuard({ authMode: 'none', bindHost: '127.0.0.1' });
+  const responses = [];
+  const res = {
+    status(code) { this.code = code; return this; },
+    json(body) { responses.push({ code: this.code, body }); return this; },
+  };
+  let nextCalls = 0;
+  guard.middleware({ headers: { host: 'localhost:3001', origin: 'https://attacker.example' } }, res, () => { nextCalls += 1; });
+  assert.equal(nextCalls, 0);
+  assert.deepEqual(responses, [{ code: 403, body: { error: 'Cross-site request rejected.' } }]);
+  guard.middleware({ headers: { host: 'localhost:3001' } }, res, () => { nextCalls += 1; });
+  assert.equal(nextCalls, 1);
+});

--- a/server/modules/websocket/services/websocket-auth.service.ts
+++ b/server/modules/websocket/services/websocket-auth.service.ts
@@ -4,6 +4,8 @@ import type { AuthenticatedWebSocketRequest } from '@/shared/types.js';
 import { AUTH_COOKIE_NAME, getBearerToken, parseCookieHeader } from '@/middleware/auth.js';
 
 type WebSocketAuthDependencies = {
+  /** Same-site guard shared with the HTTP API; runs before any credential is read. */
+  checkCrossSite?: (request: AuthenticatedWebSocketRequest) => { ok: true } | { ok: false; error: string };
   authenticateWebSocket: (
     token: string | null,
     request: AuthenticatedWebSocketRequest,
@@ -25,6 +27,12 @@ export function verifyWebSocketClient(
   const request = info.req as AuthenticatedWebSocketRequest;
   const upgradeUrl = new URL(request.url ?? '/', 'http://localhost');
   console.log('WebSocket connection attempt to:', upgradeUrl.pathname);
+
+  const crossSite = dependencies.checkCrossSite?.(request);
+  if (crossSite && !crossSite.ok) {
+    console.log('[WARN] WebSocket upgrade rejected:', crossSite.error);
+    return false;
+  }
 
   if (upgradeUrl.searchParams.has('token')) {
     console.log('[WARN] WebSocket authentication failed');


### PR DESCRIPTION
## Summary

In `CHATMUX_AUTH=none` (the fallback for an unset or unrecognized value, and the installer's `--vpn` mode) every request is the implicit owner. `server/index.js` answered any Origin with `app.use(cors())` and checked neither Origin nor Host on `/api` or on WebSocket upgrades. Any web page the operator visited could `fetch('http://127.0.0.1:3001/api/...')` and read the response, or open `ws://127.0.0.1:3001/shell` and drive a PTY as the server user. A DNS-rebinding page (attacker host resolving to 127.0.0.1) worked without CORS at all, because from the browser's point of view it is same-origin. Password mode was protected by the SameSite=Strict cookie and tailscale mode by its own Origin check; `none` had nothing.

## Changes

- New `server/middleware/cross-site-guard.js` with two header-only checks:
  - **Origin must name this deployment** in every auth mode: same host (with port) as `Host`, or as the first `X-Forwarded-Host` recorded by a TLS-terminating proxy (the nginx template forwards `Host $host`, Tailscale Serve sets `X-Forwarded-Host`). Two loopback names on different ports are accepted so the Vite dev server on :5173 can keep proxying to :3001 without rewriting Origin. `Origin: null` and non-http(s) origins are rejected.
  - **Host allowlist in auth mode `none` only**: loopback names, the `HOST` bind address, `*.ts.net`, and `CHATMUX_ALLOWED_HOSTS` (new, documented in `.env.example`). Password and tailscale installs reached by an arbitrary LAN hostname are unaffected.
- Mounted on `/api` in place of `cors()`, and wired into `verifyWebSocketClient` so it runs before any credential is read on `/ws`, `/shell`, `/remote-chat`, `/remote-shell`. The fleet `/fleet-ws` upgrade is dispatched separately and already rejects any Origin.
- `cors` removed from `dependencies` (it remains in the tree as a transitive dependency of the MCP SDK). Vite proxies `/api` and every WebSocket path, so the wildcard was not needed for development either.

## Verification

- `server/middleware/cross-site-guard.test.js` (new, 5 tests: Origin matching incl. proxy and dev-server cases, Host allowlist incl. rebinding refusal, env parsing, per-mode enforcement, middleware 403 shape)
- `server/middleware/auth.test.js`, `server/modules/websocket/tests/shell-websocket-protocol.test.ts` (39 pass in total)
- `tsc --noEmit` for server and client, `eslint` on touched files, `npm run check:identity`

## Notes

`exactUpdateRequestGuard` on `/api/system/update` keeps its stricter rules and still runs before this guard. `/health` stays public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
