### PR TITLE
fix(git): refuse directory pathspecs in discard and delete-untracked

### DIFF
--- a/server/routes/git.js
+++ b/server/routes/git.js
@@ -219,12 +219,88 @@ async function getRepositoryRootPath(projectPath) {
   return stdout.trim();
 }
 
-function normalizeRepositoryRelativeFilePath(filePath) {
+export function normalizeRepositoryRelativeFilePath(filePath) {
   return String(filePath)
     .replace(/\\/g, '/')
     .replace(/^\.\/+/, '')
     .replace(/^\/+/, '')
+    .replace(/\/+$/, '')
     .trim();
+}
+
+/**
+ * A repository-relative pathspec that may be handed to a destructive git or
+ * filesystem operation. Rejects anything that resolves to the repository root
+ * (`.`, `src/..`) or escapes it, because the discard routes would otherwise
+ * `fs.rm` the whole worktree or `git restore` every change in it.
+ */
+export function assertSafeRepositoryRelativePath(relativePath) {
+  if (typeof relativePath !== 'string' || relativePath.includes('\0')) {
+    throw new Error('Invalid file path');
+  }
+  if (relativePath === '' || relativePath === '.' || path.posix.isAbsolute(relativePath)) {
+    throw new Error('Invalid file path: expected a path inside the repository');
+  }
+  const segments = relativePath.split('/');
+  if (segments.some((segment) => segment === '' || segment === '.' || segment === '..')) {
+    throw new Error('Invalid file path: path traversal detected');
+  }
+  return relativePath;
+}
+
+/**
+ * Parses `git status --porcelain=v1 -z` into { code, path, isDirectory }.
+ * Renames carry the original path as a second NUL-terminated field, which is
+ * skipped so `path` is always the post-rename location.
+ */
+export function parseStatusEntriesZ(statusOutput) {
+  const fields = String(statusOutput).split('\0').filter((field) => field.length > 0);
+  const entries = [];
+  for (let index = 0; index < fields.length; index += 1) {
+    const field = fields[index];
+    const code = field.substring(0, 2);
+    const rawPath = field.substring(3);
+    if (code.startsWith('R') || code.startsWith('C')) {
+      index += 1; // original path follows as its own field
+    }
+    entries.push({
+      code,
+      path: normalizeRepositoryRelativeFilePath(rawPath),
+      isDirectory: rawPath.endsWith('/'),
+    });
+  }
+  return entries;
+}
+
+/**
+ * The one status entry a destructive route may act on. Fails closed unless git
+ * reports exactly one entry and it is the requested path itself (a directory
+ * only qualifies when git collapsed it to a single untracked entry, i.e. it
+ * contains nothing tracked).
+ */
+export function selectExactStatusEntry(statusOutput, relativePath) {
+  const entries = parseStatusEntriesZ(statusOutput);
+  if (entries.length === 0) {
+    return null;
+  }
+  if (entries.length !== 1) {
+    throw new Error(`Refusing to act on "${relativePath}": git reports ${entries.length} entries under that path. Act on each file individually.`);
+  }
+  const [entry] = entries;
+  if (entry.path !== relativePath) {
+    throw new Error(`Refusing to act on "${relativePath}": git reports "${entry.path}" instead.`);
+  }
+  return entry;
+}
+
+/** Absolute location of a repository-relative path, required to sit strictly inside the project. */
+export function resolvePathInsideProject(repositoryRootPath, relativePath, projectPath) {
+  const absolutePath = path.resolve(repositoryRootPath, relativePath);
+  const projectRoot = path.resolve(projectPath);
+  if (absolutePath === projectRoot || !absolutePath.startsWith(projectRoot + path.sep)) {
+    throw new Error('Invalid file path: outside the project directory');
+  }
+  return absolutePath;
 }
 
 function parseStatusFilePaths(statusOutput) {
@@ -258,6 +334,7 @@ function buildFilePathCandidates(projectPath, repositoryRootPath, filePath) {
 
 async function resolveRepositoryFilePath(projectPath, filePath) {
   validateFilePath(filePath);
+  assertSafeRepositoryRelativePath(normalizeRepositoryRelativeFilePath(filePath));
 
   const repositoryRootPath = await getRepositoryRootPath(projectPath);
   const candidateFilePaths = buildFilePathCandidates(projectPath, repositoryRootPath, filePath);
@@ -1544,23 +1621,38 @@ router.post('/discard', async (req, res) => {
       repositoryRelativeFilePath,
     } = await resolveRepositoryFilePath(projectPath, file);
 
-    // Check file status to determine correct discard command
+    // Check file status to determine correct discard command. -z keeps paths
+    // exact (no C-quoting) and the entry must be the requested path itself so
+    // a directory pathspec can never fan out into a worktree-wide discard.
     const { stdout: statusOutput } = await spawnAsync(
       'git',
-      ['status', '--porcelain', '--', repositoryRelativeFilePath],
+      ['status', '--porcelain=v1', '-z', '--', repositoryRelativeFilePath],
       { cwd: repositoryRootPath },
     );
 
-    if (!statusOutput.trim()) {
+    let entry;
+    try {
+      entry = selectExactStatusEntry(statusOutput, repositoryRelativeFilePath);
+    } catch (error) {
+      return res.status(400).json({ error: error.message });
+    }
+    if (!entry) {
       return res.status(400).json({ error: 'No changes to discard for this file' });
     }
 
-    const status = statusOutput.substring(0, 2);
+    const status = entry.code;
 
     if (status === '??') {
-      // Untracked file or directory - delete it
-      const filePath = path.join(repositoryRootPath, repositoryRelativeFilePath);
-      const stats = await fs.stat(filePath);
+      // Untracked file or directory - delete it (the directory case only
+      // reaches here when git collapsed it to one entry, i.e. nothing inside
+      // is tracked). Never follow a symlink: remove the link itself.
+      let filePath;
+      try {
+        filePath = resolvePathInsideProject(repositoryRootPath, repositoryRelativeFilePath, projectPath);
+      } catch (error) {
+        return res.status(400).json({ error: error.message });
+      }
+      const stats = await fs.lstat(filePath);
 
       if (stats.isDirectory()) {
         await fs.rm(filePath, { recursive: true, force: true });
@@ -1598,26 +1690,36 @@ router.post('/delete-untracked', async (req, res) => {
       repositoryRelativeFilePath,
     } = await resolveRepositoryFilePath(projectPath, file);
 
-    // Check if file is actually untracked
+    // Check if file is actually untracked. The entry must be the requested
+    // path itself; a directory pathspec that fans out is refused.
     const { stdout: statusOutput } = await spawnAsync(
       'git',
-      ['status', '--porcelain', '--', repositoryRelativeFilePath],
+      ['status', '--porcelain=v1', '-z', '--', repositoryRelativeFilePath],
       { cwd: repositoryRootPath },
     );
-    
-    if (!statusOutput.trim()) {
+
+    let entry;
+    try {
+      entry = selectExactStatusEntry(statusOutput, repositoryRelativeFilePath);
+    } catch (error) {
+      return res.status(400).json({ error: error.message });
+    }
+    if (!entry) {
       return res.status(400).json({ error: 'File is not untracked or does not exist' });
     }
 
-    const status = statusOutput.substring(0, 2);
-    
-    if (status !== '??') {
+    if (entry.code !== '??') {
       return res.status(400).json({ error: 'File is not untracked. Use discard for tracked files.' });
     }
 
-    // Delete the untracked file or directory
-    const filePath = path.join(repositoryRootPath, repositoryRelativeFilePath);
-    const stats = await fs.stat(filePath);
+    // Delete the untracked file or directory without following symlinks.
+    let filePath;
+    try {
+      filePath = resolvePathInsideProject(repositoryRootPath, repositoryRelativeFilePath, projectPath);
+    } catch (error) {
+      return res.status(400).json({ error: error.message });
+    }
+    const stats = await fs.lstat(filePath);
 
     if (stats.isDirectory()) {
       // Use rm with recursive option for directories

--- a/server/routes/git.test.js
+++ b/server/routes/git.test.js
@@ -1,7 +1,15 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { parseGitLogWithStats, parseGitStatusOutput } from './git.js';
+import {
+  assertSafeRepositoryRelativePath,
+  normalizeRepositoryRelativeFilePath,
+  parseGitLogWithStats,
+  parseGitStatusOutput,
+  parseStatusEntriesZ,
+  resolvePathInsideProject,
+  selectExactStatusEntry,
+} from './git.js';
 
 // Builds `git status --porcelain=v1 -z` output: NUL-separated entries with a
 // trailing NUL, exactly as git emits it.
@@ -103,4 +111,47 @@ test('parseGitLogWithStats parses commits with parents, refs, and shortstat line
 
 test('parseGitLogWithStats handles empty output', () => {
   assert.deepEqual(parseGitLogWithStats(''), []);
+});
+
+test('assertSafeRepositoryRelativePath refuses the repository root and traversal', () => {
+  for (const bad of ['', '.', './', '/', 'src/..', '../etc/passwd', 'a/./b', 'a//b']) {
+    assert.throws(() => assertSafeRepositoryRelativePath(normalizeRepositoryRelativeFilePath(bad)), /Invalid file path/, `should reject ${JSON.stringify(bad)}`);
+  }
+  assert.equal(assertSafeRepositoryRelativePath(normalizeRepositoryRelativeFilePath('./src/a.ts')), 'src/a.ts');
+  assert.equal(assertSafeRepositoryRelativePath(normalizeRepositoryRelativeFilePath('newdir/')), 'newdir');
+  assert.equal(assertSafeRepositoryRelativePath(normalizeRepositoryRelativeFilePath('sp ace.txt')), 'sp ace.txt');
+  // Leading slashes have always been stripped: the value is repository-relative, never absolute.
+  assert.equal(assertSafeRepositoryRelativePath(normalizeRepositoryRelativeFilePath('/abs/path')), 'abs/path');
+});
+
+test('parseStatusEntriesZ reads porcelain -z output including renames, directories and unquoted names', () => {
+  // Captured from `git status --porcelain=v1 -z -- .` in a scratch repository.
+  const output = 'R  src/renamed.txt\0src/keep.txt\0 M tracked.txt\0?? newdir/\0?? quo"te.txt\0?? sp ace.txt\0';
+  assert.deepEqual(parseStatusEntriesZ(output), [
+    { code: 'R ', path: 'src/renamed.txt', isDirectory: false },
+    { code: ' M', path: 'tracked.txt', isDirectory: false },
+    { code: '??', path: 'newdir', isDirectory: true },
+    { code: '??', path: 'quo"te.txt', isDirectory: false },
+    { code: '??', path: 'sp ace.txt', isDirectory: false },
+  ]);
+  assert.deepEqual(parseStatusEntriesZ(''), []);
+});
+
+test('selectExactStatusEntry only yields the single entry that is the requested path', () => {
+  assert.equal(selectExactStatusEntry('', 'missing.txt'), null);
+  assert.deepEqual(selectExactStatusEntry(' M tracked.txt\0', 'tracked.txt'), { code: ' M', path: 'tracked.txt', isDirectory: false });
+  assert.deepEqual(selectExactStatusEntry('?? newdir/\0', 'newdir'), { code: '??', path: 'newdir', isDirectory: true });
+
+  const wholeTree = 'R  src/renamed.txt\0src/keep.txt\0 M tracked.txt\0?? newdir/\0';
+  assert.throws(() => selectExactStatusEntry(wholeTree, '.'), /git reports 3 entries/, 'a pathspec that fans out is refused before any rm or restore');
+  assert.throws(() => selectExactStatusEntry(' M src/a.ts\0 M src/b.ts\0', 'src'), /git reports 2 entries/);
+  assert.throws(() => selectExactStatusEntry(' M src/a.ts\0', 'src'), /reports "src\/a.ts" instead/, 'a directory holding tracked changes is not itself an entry');
+});
+
+test('resolvePathInsideProject keeps destructive targets strictly inside the project directory', () => {
+  const root = '/repo';
+  assert.equal(resolvePathInsideProject(root, 'app/src/a.ts', '/repo/app'), '/repo/app/src/a.ts');
+  assert.throws(() => resolvePathInsideProject(root, 'other/a.ts', '/repo/app'), /outside the project directory/, 'a sibling directory under the same toplevel is off limits');
+  assert.throws(() => resolvePathInsideProject(root, 'app', '/repo/app'), /outside the project directory/, 'the project directory itself is never a target');
+  assert.throws(() => resolvePathInsideProject(root, 'application/a.ts', '/repo/app'), /outside the project directory/, 'prefix collisions do not count as inside');
 });


### PR DESCRIPTION
## Summary

`POST /api/git/discard` and `POST /api/git/delete-untracked` could delete the repository or discard every change in it.

- `resolveRepositoryFilePath` called `validateFilePath(filePath)` without a project root, so its containment branch never ran, and `normalizeRepositoryRelativeFilePath` let `.` and `src/..` through.
- Each handler then inspected only the first two bytes of the first status entry. `git status --porcelain -- .` lists the whole worktree; if the first entry was `??`, the code ran `fs.rm(path.join(toplevel, '.'), { recursive: true })` and removed the repository including `.git`. Otherwise it ran `git restore -- .` and discarded every uncommitted change.
- `validateGitRepository` accepts any directory inside a worktree, so the toplevel can sit above the registered project (a dotfiles repo in `$HOME`), which widens what a single request could touch.

## Changes

- `assertSafeRepositoryRelativePath` rejects the repository root and any `.`/`..` segment before any git call; it runs for every route that goes through `resolveRepositoryFilePath` (discard, delete-untracked, diff, file-with-diff).
- Status is read with `--porcelain=v1 -z` so names with quotes or non-ASCII characters are exact, parsed by `parseStatusEntriesZ` (rename entries skip the original path field).
- `selectExactStatusEntry` fails closed unless git reports exactly one entry and it is the requested path itself. A directory qualifies only when git collapsed it to a single untracked entry, meaning nothing inside it is tracked. A pathspec that fans out returns 400 with the entry count.
- `resolvePathInsideProject` requires the filesystem target to sit strictly inside the project directory (not merely under the toplevel), and removal uses `lstat` so a symlink is unlinked rather than followed.
- Trailing slashes are normalized away so `newdir/` (git's own spelling for an untracked directory) matches `newdir`.

## Verification

- `server/routes/git.test.js`: 4 new tests using porcelain `-z` output captured from a scratch repository (`R  new\0old\0`, `?? dir/\0`, unquoted `quo"te.txt`), covering root/traversal refusal, fan-out refusal, single-entry acceptance, and project containment (12 pass)
- `eslint` on touched files, `tsc --noEmit -p server/tsconfig.json`

Follow-ups tracked separately: the diff read routes still join `toplevel + rel` without a realpath check, and `git checkout`/`git show` accept option-shaped arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
