### PR TITLE
fix(git): generate commit messages without tools or permission bypass

### DIFF
--- a/server/claude-sdk.js
+++ b/server/claude-sdk.js
@@ -254,7 +254,26 @@ function mapCliOptionsToSDK(options = {}) {
     sdkOptions.resume = sessionId;
   }
 
+  if (options.toolAccess === 'none') {
+    applyTextOnlyToolAccess(sdkOptions);
+  }
+
   return sdkOptions;
+}
+
+/**
+ * Text-only calls (commit message generation over repository content) feed
+ * untrusted text straight into the prompt. Whatever that text says, the run
+ * must be unable to act on it: no built-in tools, no repository-provided
+ * settings or hooks, a single model turn, and never a permission bypass, even
+ * when the operator's global tool settings enable one for interactive chat.
+ */
+function applyTextOnlyToolAccess(sdkOptions) {
+  sdkOptions.tools = [];
+  sdkOptions.allowedTools = [];
+  sdkOptions.maxTurns = 1;
+  sdkOptions.settingSources = [];
+  delete sdkOptions.permissionMode;
 }
 
 /**
@@ -554,7 +573,8 @@ async function queryClaudeSDK(command, options = {}, ws, runtime = {}) {
       effortModels,
     });
 
-    const mcpServers = await loadMcpConfigFn(options.cwd);
+    // MCP servers are tools too: a text-only run gets none of them.
+    const mcpServers = options.toolAccess === 'none' ? null : await loadMcpConfigFn(options.cwd);
     if (mcpServers) {
       sdkOptions.mcpServers = mcpServers;
     }

--- a/server/claude-sdk.test.ts
+++ b/server/claude-sdk.test.ts
@@ -115,3 +115,40 @@ test('Claude SDK keeps rejected notification publication fail-soft and observabl
   assert.ok(errors.some(([message, error]) => message === '[Claude SDK] Notification publication failed:' && (error as Error).message === 'publication rejected'));
   assert.equal((ws.messages.at(-1) as { exitCode?: number }).exitCode, 0);
 });
+
+test('a text-only run reaches the SDK with no tools, no MCP servers, one turn and no permission bypass', async () => {
+  const captured: Array<Record<string, unknown>> = [];
+  const capturingRuntime = (extra: Record<string, unknown> = {}) => ({
+    ...runtime(() => stream([{ type: 'result', subtype: 'success', uuid: 'completion-1', session_id: 'provider-1' }]), { stopped: [], failed: [] }),
+    query: (input: { options: Record<string, unknown> }) => {
+      captured.push(input.options);
+      return stream([{ type: 'result', subtype: 'success', uuid: 'completion-1', session_id: 'provider-1' }]);
+    },
+    loadMcpConfig: async () => ({ filesystem: { command: 'mcp-fs' } }),
+    ...extra,
+  });
+
+  await queryClaudeSDK('write a commit message', {
+    cwd: '/repo',
+    model: 'sonnet',
+    toolAccess: 'none',
+    // Even an operator-wide bypass setting must not leak into a text-only run.
+    toolsSettings: { allowedTools: ['Bash'], disallowedTools: [], skipPermissions: true },
+  }, writer('app-1'), capturingRuntime());
+
+  const textOnly = captured.at(-1)!;
+  assert.deepEqual(textOnly.tools, []);
+  assert.deepEqual(textOnly.allowedTools, []);
+  assert.equal(textOnly.maxTurns, 1);
+  assert.deepEqual(textOnly.settingSources, []);
+  assert.equal(textOnly.permissionMode, undefined);
+  assert.equal(textOnly.mcpServers, undefined, 'MCP servers are tools too');
+
+  // Control: an interactive run keeps the preset tools, MCP servers and the requested mode.
+  await queryClaudeSDK('hello', { cwd: '/repo', permissionMode: 'acceptEdits' }, writer('app-2'), capturingRuntime());
+  const interactive = captured.at(-1)!;
+  assert.deepEqual(interactive.tools, { type: 'preset', preset: 'claude_code' });
+  assert.equal(interactive.permissionMode, 'acceptEdits');
+  assert.deepEqual(interactive.mcpServers, { filesystem: { command: 'mcp-fs' } });
+  assert.equal(interactive.maxTurns, undefined);
+});

--- a/server/cursor-cli.js
+++ b/server/cursor-cli.js
@@ -28,8 +28,56 @@ function isWorkspaceTrustPrompt(text = '') {
   return WORKSPACE_TRUST_PATTERNS.some((pattern) => pattern.test(text));
 }
 
+const CURSOR_READ_ONLY_MODES = new Set(['ask', 'plan']);
+
+/**
+ * Builds the Cursor CLI argv for one run. Exported so the permission surface is
+ * testable: a read-only `mode` (ask/plan) never carries `-f`, because a run
+ * that is only meant to produce text must not be able to act on it.
+ */
+function buildCursorArgs({ sessionId, command, images, resolvedModel, mode, skipPermissions }) {
+  const baseArgs = [];
+
+  // Build flags allowing both resume and prompt together (reply in existing session)
+  // Treat presence of sessionId as intention to resume, regardless of resume flag
+  if (sessionId) {
+    baseArgs.push('--resume=' + sessionId);
+  }
+
+  if (command && command.trim()) {
+    // Provide a prompt (works for both new and resumed sessions). Image
+    // attachments ride along as an <images_input> path list appended to the
+    // prompt; the session history reader strips the tag back out for display.
+    // Cursor CLI is shimmed on Windows, so the whole argument must be
+    // newline-free or cmd.exe silently truncates it at the first newline.
+    baseArgs.push('-p', flattenPromptForWindowsShell(appendImagesInputTag(command, images)));
+
+    // Model overrides are applied to both new and resumed sessions so a
+    // session-scoped change request can take effect on the next turn.
+    if (resolvedModel) {
+      baseArgs.push('--model', resolvedModel);
+    }
+
+    // Request streaming JSON when we are providing a prompt
+    baseArgs.push('--output-format', 'stream-json');
+  }
+
+  const readOnly = CURSOR_READ_ONLY_MODES.has(mode);
+  if (readOnly) {
+    baseArgs.push('--mode', mode);
+  }
+
+  // Add skip permissions flag if enabled. Print mode already has every tool
+  // including shell; a read-only mode must never be combined with -f.
+  if (!readOnly && skipPermissions) {
+    baseArgs.push('-f');
+  }
+
+  return baseArgs;
+}
+
 async function spawnCursor(command, options = {}, ws) {
-  const { sessionId, projectPath, cwd, toolsSettings, skipPermissions, model, images } = options;
+  const { sessionId, projectPath, cwd, toolsSettings, skipPermissions, model, images, mode } = options;
   const resolvedModel = await providerModelsService.resolveResumeModel('cursor', sessionId, model);
   const cursorCommand = cursorCliCommandOrDefault();
 
@@ -50,36 +98,14 @@ async function spawnCursor(command, options = {}, ws) {
     };
 
     // Build Cursor CLI command
-    const baseArgs = [];
-
-    // Build flags allowing both resume and prompt together (reply in existing session)
-    // Treat presence of sessionId as intention to resume, regardless of resume flag
-    if (sessionId) {
-      baseArgs.push('--resume=' + sessionId);
-    }
-
-    if (command && command.trim()) {
-      // Provide a prompt (works for both new and resumed sessions). Image
-      // attachments ride along as an <images_input> path list appended to the
-      // prompt; the session history reader strips the tag back out for display.
-      // Cursor CLI is shimmed on Windows, so the whole argument must be
-      // newline-free or cmd.exe silently truncates it at the first newline.
-      baseArgs.push('-p', flattenPromptForWindowsShell(appendImagesInputTag(command, images)));
-
-      // Model overrides are applied to both new and resumed sessions so a
-      // session-scoped change request can take effect on the next turn.
-      if (resolvedModel) {
-        baseArgs.push('--model', resolvedModel);
-      }
-
-      // Request streaming JSON when we are providing a prompt
-      baseArgs.push('--output-format', 'stream-json');
-    }
-
-    // Add skip permissions flag if enabled
-    if (skipPermissions || settings.skipPermissions) {
-      baseArgs.push('-f');
-    }
+    const baseArgs = buildCursorArgs({
+      sessionId,
+      command,
+      images,
+      resolvedModel,
+      mode,
+      skipPermissions: Boolean(skipPermissions || settings.skipPermissions),
+    });
 
     // Use cwd (actual project directory) instead of projectPath
     const workingDir = cwd || projectPath || process.cwd();
@@ -317,6 +343,7 @@ function getActiveCursorSessions() {
 }
 
 export {
+  buildCursorArgs,
   spawnCursor,
   abortCursorSession,
   isCursorSessionActive,

--- a/server/cursor-cli.test.ts
+++ b/server/cursor-cli.test.ts
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { buildCursorArgs } from './cursor-cli.js';
+
+test('a read-only Cursor mode never carries the force flag, even when skip-permissions is on', () => {
+  const args = buildCursorArgs({
+    sessionId: undefined,
+    command: 'write a commit message',
+    images: undefined,
+    resolvedModel: undefined,
+    mode: 'ask',
+    skipPermissions: true,
+  });
+  assert.deepEqual(args, ['-p', 'write a commit message', '--output-format', 'stream-json', '--mode', 'ask']);
+  assert.equal(args.includes('-f'), false);
+});
+
+test('interactive Cursor runs keep resume, model and the operator-chosen force flag', () => {
+  assert.deepEqual(buildCursorArgs({
+    sessionId: 'chat-1',
+    command: 'continue',
+    images: undefined,
+    resolvedModel: 'gpt-5',
+    mode: undefined,
+    skipPermissions: true,
+  }), ['--resume=chat-1', '-p', 'continue', '--model', 'gpt-5', '--output-format', 'stream-json', '-f']);
+  assert.deepEqual(buildCursorArgs({
+    sessionId: undefined,
+    command: 'hello',
+    images: undefined,
+    resolvedModel: undefined,
+    mode: undefined,
+    skipPermissions: false,
+  }), ['-p', 'hello', '--output-format', 'stream-json']);
+  assert.deepEqual(buildCursorArgs({
+    sessionId: undefined,
+    command: 'hello',
+    images: undefined,
+    resolvedModel: undefined,
+    mode: 'yolo',
+    skipPermissions: false,
+  }), ['-p', 'hello', '--output-format', 'stream-json'], 'unknown modes are ignored rather than forwarded');
+});

--- a/server/routes/git.js
+++ b/server/routes/git.js
@@ -1126,17 +1126,19 @@ Generate the commit message:`;
     console.log('🚀 Calling AI agent with provider:', provider);
     console.log('📝 Prompt length:', prompt.length);
 
-    // Call the appropriate agent
+    // Call the appropriate agent. The prompt embeds repository content, so
+    // this is a text-only run: no tools, no permission bypass. A file that
+    // says "run this command" must only ever influence the wording.
     if (provider === 'claude') {
       await queryClaudeSDK(prompt, {
         cwd: projectPath,
-        permissionMode: 'bypassPermissions',
-        model: 'sonnet'
+        model: 'sonnet',
+        toolAccess: 'none'
       }, writer);
     } else if (provider === 'cursor') {
       await spawnCursor(prompt, {
         cwd: projectPath,
-        skipPermissions: true
+        mode: 'ask'
       }, writer);
     }
 


### PR DESCRIPTION
## Summary

`POST /api/git/generate-commit-message` builds a prompt from repository content (up to 4000 characters of diff, 1000 characters of each untracked file) and then ran a fully armed agent on it: the Claude SDK with `permissionMode: 'bypassPermissions'` and the `claude_code` tool preset (Bash included), or Cursor with `-f`. A file in a checked-out PR or clone that says "run this command" could be executed as the server user as soon as the operator clicked **Generate**, with no approval step. This works in password mode too; no cross-site trick is required.

This route is the only place in the repository that forced a bypass without operator choice; interactive chat keeps the permission mode the user selects.

## Changes

- `server/claude-sdk.js`: new `toolAccess: 'none'` option for text-only runs. It sets `tools: []`, `allowedTools: []`, `maxTurns: 1`, `settingSources: []` (no repository-provided hooks or settings), drops `permissionMode` even when the operator's global `skipPermissions` is on, and skips MCP server loading (MCP servers are tools too).
- `server/cursor-cli.js`: argv building extracted into `buildCursorArgs`. A read-only `mode` (`ask` or `plan`) adds `--mode <mode>` and never carries `-f`. Cursor's print mode otherwise "has access to all tools, including write and shell" per `agent --help`.
- `server/routes/git.js`: the commit-message route now calls Claude with `toolAccess: 'none'` and Cursor with `mode: 'ask'`.

## Verification

- `server/claude-sdk.test.ts`: new test captures the options handed to the SDK and asserts the text-only shape (no tools, no MCP, one turn, no permission mode) plus a control run that keeps the preset tools, MCP servers and the requested mode (8 pass in the file)
- `server/cursor-cli.test.ts` (new): read-only mode never carries `-f`; interactive argv unchanged; unknown modes ignored
- `eslint` on touched files, `tsc --noEmit -p server/tsconfig.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
