### PR TITLE
fix(fleet): close the hub connection when the peer revokes its grant

### DIFF
--- a/server/modules/fleet/peer/composition.ts
+++ b/server/modules/fleet/peer/composition.ts
@@ -20,6 +20,7 @@ import { PeerCatalogPublisher } from './catalog-publisher.js';
 import { createPeerCatalogSource } from './catalog-source.js';
 import { createFleetPeerEndpoint, type UpgradeListener } from './endpoint.js';
 import { createPeerOperationDispatcher } from './operation-dispatcher.js';
+import { fleetPeerRevocationGateway } from './revocation-gateway.js';
 import {
   loadFleetPeerSigner,
   SqliteFleetGenerationStore,
@@ -86,10 +87,12 @@ export async function createLocalFleetPeerRuntime(options: LocalFleetPeerOptions
   const releaseCompletionEvents = completionPublisher.subscribe((event) => {
     endpoint.publish('completion.ready', `completion-${randomUUID()}`, json(event));
   });
+  fleetPeerRevocationGateway.bind(endpoint.revokeConnections);
   return {
     capabilities,
     start: endpoint.start,
     stop: async () => {
+      fleetPeerRevocationGateway.unbind(endpoint.revokeConnections);
       releaseCompletionGateway();
       releaseCompletionEvents();
       releaseChatEvents();

--- a/server/modules/fleet/peer/endpoint.ts
+++ b/server/modules/fleet/peer/endpoint.ts
@@ -43,6 +43,8 @@ export function createFleetPeerEndpoint(options: FleetPeerEndpointOptions): Read
   readonly publish: FleetPeerEventPublisher;
   readonly start: () => void;
   readonly stop: () => Promise<void>;
+  /** Closes every live hub connection after the local grant was revoked. */
+  readonly revokeConnections: () => void;
 }> {
   const wss = new WebSocketServer({ noServer: true });
   const replayGuard = new FleetChallengeReplayGuard();
@@ -118,5 +120,9 @@ export function createFleetPeerEndpoint(options: FleetPeerEndpointOptions): Read
     for (const connection of connections) connection.publish(event, eventId, body);
   };
 
-  return { capabilities: options.local.capabilities, publish, start, stop };
+  const revokeConnections = (): void => {
+    for (const connection of [...connections]) connection.revoke();
+  };
+
+  return { capabilities: options.local.capabilities, publish, start, stop, revokeConnections };
 }

--- a/server/modules/fleet/peer/revocation-gateway.ts
+++ b/server/modules/fleet/peer/revocation-gateway.ts
@@ -1,0 +1,25 @@
+/**
+ * Lets the owner's revoke routes reach the live peer endpoint without a
+ * module dependency in that direction: the settings router is composed at
+ * startup, the peer runtime only when fleet is enabled and started.
+ */
+class FleetPeerRevocationGateway {
+  private handler: (() => void) | undefined;
+
+  bind(handler: () => void): void {
+    this.handler = handler;
+  }
+
+  unbind(handler: () => void): void {
+    if (this.handler === handler) this.handler = undefined;
+  }
+
+  /** Closes every live hub connection; a no-op while no peer runtime is bound. */
+  notifyRevoked(): boolean {
+    if (this.handler === undefined) return false;
+    this.handler();
+    return true;
+  }
+}
+
+export const fleetPeerRevocationGateway = new FleetPeerRevocationGateway();

--- a/server/modules/fleet/protocol/connection.ts
+++ b/server/modules/fleet/protocol/connection.ts
@@ -193,26 +193,38 @@ export class FleetProtocolConnection {
     this.writer.send(encodeFleetFrame(frame));
   }
 
+  /**
+   * Ends the connection because the remote installation's grant was revoked.
+   * Used by the owner's in-process revoke so reads, terminal streams and
+   * events stop immediately instead of at the next lease tick.
+   */
+  revoke(): void {
+    this.reject(new FleetProtocolError('AUTH_PEER_UNAUTHORIZED', 'fleet peer grant revoked'));
+  }
+
   private scheduleLease(): void {
     this.leaseTimer = this.scheduler.schedule(10_000, () => {
-      try {
-        this.checkLease();
-      } catch (error) {
-        this.reject(error);
-      }
+      void this.checkLease().catch((error: unknown) => this.reject(error));
     });
   }
 
-  private checkLease(): void {
+  private async checkLease(): Promise<void> {
     if (this.state.kind !== 'authenticated') return;
-    const result = this.state.lease.poll(this.scheduler.now());
+    const state = this.state;
+    const result = state.lease.poll(this.scheduler.now());
     if (result.kind === 'expired') {
       this.reject(new FleetProtocolError('PROTOCOL_LEASE_EXPIRED', 'fleet heartbeat lease expired'));
       return;
     }
+    // The trust store was consulted at hello; re-check it on every lease tick
+    // so a grant the owner revoked (in this process or from the CLI) cuts off
+    // reads, terminal streams and events within one interval, not at the next
+    // reconnect. Mutations already re-check the grant per request.
+    await requireAuthorizedFleetPeer(this.options.trust, state.remoteInstallationId);
+    if (this.state !== state) return;
     if (result.kind === 'heartbeat_due') {
-      this.send({ kind: 'heartbeat', connectionGeneration: this.state.generation, sentAtMs: Math.max(1, this.scheduler.now()) });
-      this.state.lease.markSent(this.scheduler.now());
+      this.send({ kind: 'heartbeat', connectionGeneration: state.generation, sentAtMs: Math.max(1, this.scheduler.now()) });
+      state.lease.markSent(this.scheduler.now());
     }
     this.scheduleLease();
   }

--- a/server/modules/fleet/settings/composition.ts
+++ b/server/modules/fleet/settings/composition.ts
@@ -4,6 +4,7 @@ import { fleetInstallationRole, fleetPeersDb, getConnection } from '@/modules/da
 import { createFleetPairingRouter } from '@/modules/fleet/fleet-pairing.routes.js';
 import { fleetBrowserDiscoveryGateway } from '@/modules/fleet/browser-discovery/index.js';
 import { loadFleetSignedIdentity } from '@/modules/fleet/peer/persistence.js';
+import { fleetPeerRevocationGateway } from '@/modules/fleet/peer/revocation-gateway.js';
 import { FleetHubPairingService } from '@/modules/fleet/services/fleet-hub-pairing.service.js';
 import { FleetPairingFailureLimiter } from '@/modules/fleet/services/fleet-pairing-limiter.service.js';
 import { FleetPairingService } from '@/modules/fleet/services/fleet-pairing.service.js';
@@ -58,7 +59,13 @@ export function createLocalFleetSettingsRouter(authMode: AuthMode): express.Rout
     pairing: {
       issueToken: async () => (await services()).pairing.issueToken(),
       redeem: async (input) => (await services()).pairing.redeem(input),
-      revokeHubGrant: async (hub) => (await services()).pairing.revokeHubGrant(hub),
+      revokeHubGrant: async (hub) => {
+        const revoked = (await services()).pairing.revokeHubGrant(hub);
+        // The durable grant is gone; drop the live hub connection as well so
+        // reads, terminal streams and events stop now, not at the next tick.
+        if (revoked) fleetPeerRevocationGateway.notifyRevoked();
+        return revoked;
+      },
     },
     hubPairing: {
       enroll: async (input) => {

--- a/server/modules/fleet/tests/fleet-protocol-connection.test.ts
+++ b/server/modules/fleet/tests/fleet-protocol-connection.test.ts
@@ -203,3 +203,42 @@ test('Given frame and writer bounds, when either is exceeded, then input never r
   assert.equal(bounded.transport.closes[0]?.reason, 'fleet writer capacity exceeded');
   assert.equal(bounded.dispatchCount(), 0);
 });
+
+test('Given an authenticated hub, when its grant is revoked, then the next lease tick closes the connection', async () => {
+  const errors: string[] = [];
+  const hub = identity();
+  let grantState: 'active' | 'revoked' = 'active';
+  const subject = fixture({
+    trust: { find: async (installationId) => ({ installationId, pinnedPublicKey: hub.publicKey, state: grantState }) },
+    onError: (code) => { errors.push(code); },
+  }, hub);
+  await authenticate(subject);
+  assert.deepEqual(subject.transport.closes, []);
+
+  // An active grant keeps the connection through a lease tick.
+  subject.scheduler.advance(10_000);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(subject.transport.closes, []);
+
+  grantState = 'revoked';
+  subject.scheduler.advance(10_000);
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(subject.transport.closes, [{ code: 4002, reason: 'fleet protocol rejected' }]);
+  assert.deepEqual(errors, ['AUTH_PEER_UNAUTHORIZED']);
+  await subject.connection.receive(Buffer.from(encodeFleetFrame(request(1))));
+  assert.equal(subject.dispatchCount(), 0, 'a revoked hub gets no dispatch afterwards');
+});
+
+test('Given an authenticated hub, when the owner revokes in-process, then the connection closes immediately', async () => {
+  const errors: string[] = [];
+  const subject = fixture({ onError: (code) => { errors.push(code); } });
+  await authenticate(subject);
+
+  subject.connection.revoke();
+
+  assert.deepEqual(subject.transport.closes, [{ code: 4002, reason: 'fleet protocol rejected' }]);
+  assert.deepEqual(errors, ['AUTH_PEER_UNAUTHORIZED']);
+  subject.connection.revoke();
+  assert.equal(subject.transport.closes.length, 1, 'revoking a closed connection is a no-op');
+});

--- a/server/modules/fleet/tests/peer-revocation-gateway.test.ts
+++ b/server/modules/fleet/tests/peer-revocation-gateway.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { fleetPeerRevocationGateway } from '../peer/revocation-gateway.js';
+
+test('the revocation gateway forwards to the bound peer runtime only while it is bound', () => {
+  let calls = 0;
+  const handler = () => { calls += 1; };
+
+  assert.equal(fleetPeerRevocationGateway.notifyRevoked(), false, 'no runtime bound yet');
+  fleetPeerRevocationGateway.bind(handler);
+  assert.equal(fleetPeerRevocationGateway.notifyRevoked(), true);
+  assert.equal(calls, 1);
+
+  const other = () => {};
+  fleetPeerRevocationGateway.unbind(other);
+  assert.equal(fleetPeerRevocationGateway.notifyRevoked(), true, 'unbinding a different handler leaves the bound one');
+  fleetPeerRevocationGateway.unbind(handler);
+  assert.equal(fleetPeerRevocationGateway.notifyRevoked(), false);
+  assert.equal(calls, 2);
+});


### PR DESCRIPTION
## Summary

Revoking the hub grant on a peer (`DELETE /api/fleet/hub-grant`, the machine `POST /api/fleet/pairing/revoke`, or `chatmux fleet revoke`) only updated `fleet_hub_grants`. `FleetProtocolConnection` consulted the trust store once at hello, and only mutation handlers re-checked the grant per request. Reads (`session.history`, `pane.capture`), terminal streams (`pane.output`) and every catalog, chat and completion event kept flowing to the revoked hub for as long as its heartbeats kept the lease alive.

## Changes

- `server/modules/fleet/protocol/connection.ts`: the lease tick now re-runs `requireAuthorizedFleetPeer` for the authenticated remote installation. A grant that is no longer `active` closes the connection with `AUTH_PEER_UNAUTHORIZED` (4002) within one 10 s interval, whichever process revoked it. A new `revoke()` method closes a connection on demand.
- `server/modules/fleet/peer/endpoint.ts`: exposes `revokeConnections()` which revokes every live hub connection.
- `server/modules/fleet/peer/revocation-gateway.ts` (new): a small bind/notify gateway so the settings router, which is composed at startup, can reach the peer runtime, which is composed only when fleet starts. The peer runtime binds on creation and unbinds on stop.
- `server/modules/fleet/settings/composition.ts`: after `revokeHubGrant` reports success, the gateway drops live hub connections immediately.

## Verification

- `fleet-protocol-connection.test.ts`: two new tests. An active grant survives a lease tick; flipping the trust store to `revoked` closes the connection on the next tick with `AUTH_PEER_UNAUTHORIZED` and later requests are not dispatched. `revoke()` closes immediately and is idempotent.
- `peer-revocation-gateway.test.ts` (new): bind, notify, unbind semantics.
- Full fleet suite excluding the tmux-backed e2e files: 163 pass. `tsc --noEmit -p server/tsconfig.json`, `eslint` on touched files.

## Notes

The hub side already reconciles its own revocations (`hub/connection/registry.ts`); this PR covers the peer side. The `/pairing/revoke` machine route still authenticates with a static self-signed hub identity blob, which is tracked separately as a Low finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
