### PR TITLE
fix(tmux): spawn sessions in a transient scope outside the service cgroup

### DIFF
--- a/server/modules/providers/services/builtin-relay.service.ts
+++ b/server/modules/providers/services/builtin-relay.service.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 
 import { recordHostCommand } from './host-command-metrics.service.js';
 import type { LiveSpawnResult } from './live-send.service.js';
+import { resolveTmuxSpawnLaunch } from './tmux-spawn-scope.service.js';
 
 /**
  * Built-in tmux session creation used when the optional control tower is
@@ -28,6 +29,7 @@ export type TmuxRunner = (args: string[], stdin?: string) => Promise<TmuxRunResu
 function tmuxSubcommand(args: readonly string[]): string {
   for (let index = 0; index < args.length; index += 1) {
     if (args[index] === '-S') { index += 1; continue; }
+    if (args[index] === 'tmux') continue; // systemd-run prefix ends with the tmux binary
     if (!args[index].startsWith('-')) return args[index];
   }
   return 'unknown';
@@ -35,9 +37,23 @@ function tmuxSubcommand(args: readonly string[]): string {
 
 
 export function runTmux(args: string[], stdin?: string): Promise<TmuxRunResult> {
+  return runCollected('tmux', args, stdin);
+}
+
+/**
+ * Runs `tmux new-session` (and only that) through a transient systemd scope
+ * when ChatMux itself is a systemd service, so a tmux server forked by this
+ * spawn does not land in chatmux.service's cgroup and die with it.
+ */
+export async function runTmuxSpawn(args: string[]): Promise<TmuxRunResult> {
+  const launch = await resolveTmuxSpawnLaunch();
+  return runCollected(launch.command, [...launch.prefixArgs, ...args]);
+}
+
+function runCollected(command: string, args: string[], stdin?: string): Promise<TmuxRunResult> {
   recordHostCommand('tmux', [tmuxSubcommand(args)]);
   return new Promise((resolve, reject) => {
-    const child = spawn('tmux', args, { stdio: [stdin === undefined ? 'ignore' : 'pipe', 'pipe', 'pipe'] });
+    const child = spawn(command, args, { stdio: [stdin === undefined ? 'ignore' : 'pipe', 'pipe', 'pipe'] });
     let output = '';
     const timer = setTimeout(() => {
       child.kill('SIGKILL');
@@ -106,9 +122,12 @@ export async function resolveSpawnCwd(cwd: string, home: string = homedir()): Pr
 export async function builtinSpawn(
   name: string,
   cwd: string,
-  deps: { run?: TmuxRunner; home?: string } = {},
+  deps: { run?: TmuxRunner; spawnRun?: TmuxRunner; home?: string } = {},
 ): Promise<LiveSpawnResult> {
   const run = deps.run ?? runTmux;
+  // Session creation may fork the tmux server, so it goes through the
+  // cgroup-isolating runner; every other command talks to an existing server.
+  const spawnRun = deps.spawnRun ?? (deps.run === undefined ? runTmuxSpawn : deps.run);
   const fail = (detail: string): LiveSpawnResult => ({ ok: false, reachable: true, conflict: false, detail });
   if (!NAME_RE.test(name) || name.toLowerCase().startsWith('company')) {
     return fail('잘못된 세션명 (company*는 예약됨)');
@@ -124,7 +143,7 @@ export async function builtinSpawn(
     // Start the agent as the pane command. Creating an interactive shell and
     // immediately typing into it races shell initialization and can lose the
     // boot command while still reporting a successful spawn.
-    const created = await run(['new-session', '-d', '-s', name, '-c', resolvedCwd, 'gjc']);
+    const created = await spawnRun(['new-session', '-d', '-s', name, '-c', resolvedCwd, 'gjc']);
     if (created.code !== 0) {
       return fail(`tmux 세션 생성 실패: ${created.output.slice(0, 200)}`);
     }

--- a/server/modules/providers/services/external-cli-sessions/inference-and-spawn.ts
+++ b/server/modules/providers/services/external-cli-sessions/inference-and-spawn.ts
@@ -7,6 +7,7 @@ import { CURSOR_CLI_COMMAND_CANDIDATES } from '@/modules/providers/list/cursor/c
 
 import type { TmuxPaneIdentity } from '../../../../../shared/tmux.js';
 import { tmuxPaneIdentityKey } from '../../../../../shared/tmux.js';
+import { resolveTmuxSpawnLaunch } from '../tmux-spawn-scope.service.js';
 
 import type { ExternalCliSession, ExternalLocalCliKind, ExternalPane, ProcessTreeEntry } from './contracts-and-resume.js';
 import type { ExternalProviderSessionInference } from './provider-runtime-inference.js';
@@ -205,18 +206,25 @@ export function buildExternalCliTmuxSpawnArgs(
   ];
 }
 
-/** Boots and tags a native CLI in a fresh detached tmux session. */
+/**
+ * Boots and tags a native CLI in a fresh detached tmux session. Session
+ * creation may fork the tmux server, so under systemd it runs in a transient
+ * scope instead of chatmux.service's cgroup (see tmux-spawn-scope.service).
+ */
 export async function spawnExternalCliSession(
   cli: ExternalSpawnCli,
   tmuxName: string,
   cwd: string,
+  deps: { launch?: typeof resolveTmuxSpawnLaunch; run?: typeof runCommand } = {},
 ): Promise<void> {
+  const run = deps.run ?? runCommand;
   const executable = await resolveExternalCliExecutable(cli);
-  await runCommand('tmux', buildExternalCliTmuxSpawnArgs(executable, tmuxName, cwd));
+  const launch = await (deps.launch ?? resolveTmuxSpawnLaunch)();
+  await run(launch.command, [...launch.prefixArgs, ...buildExternalCliTmuxSpawnArgs(executable, tmuxName, cwd)]);
   try {
-    await runCommand('tmux', ['set-option', '-t', tmuxName, '@chatmux_cli_kind', cli]);
+    await run('tmux', ['set-option', '-t', tmuxName, '@chatmux_cli_kind', cli]);
   } catch (error) {
-    await runCommand('tmux', ['kill-session', '-t', `=${tmuxName}`]).catch(() => undefined);
+    await run('tmux', ['kill-session', '-t', `=${tmuxName}`]).catch(() => undefined);
     throw error;
   }
 }

--- a/server/modules/providers/services/tmux-spawn-scope.service.ts
+++ b/server/modules/providers/services/tmux-spawn-scope.service.ts
@@ -1,0 +1,86 @@
+import { spawn } from 'node:child_process';
+
+/**
+ * Where a ChatMux-initiated `tmux new-session` may run.
+ *
+ * Under systemd the server process lives in chatmux.service's control group,
+ * and the default KillMode=control-group kills every process in that group
+ * on stop or restart. When ChatMux is the first client to talk to a tmux
+ * socket, the tmux client forks the tmux *server*, which then inherits the
+ * service cgroup: the next self-update restart would take the server and
+ * every agent inside it down with ChatMux, violating the invariant that a
+ * ChatMux restart never terminates tmux work.
+ *
+ * Running the spawn through `systemd-run --user --scope` puts the client, and
+ * therefore any server it forks, in a transient scope unit of its own. The
+ * scope outlives chatmux.service and is collected once its processes exit.
+ */
+export const SYSTEMD_RUN_SCOPE_ARGS = ['--user', '--scope', '--collect', '--quiet', '--'] as const;
+
+export type TmuxSpawnLaunch = Readonly<{
+  readonly command: string;
+  readonly prefixArgs: readonly string[];
+}>;
+
+const PROBE_TIMEOUT_MS = 5_000;
+
+/** True when this process runs as a systemd service, i.e. inside a unit cgroup. */
+export function runsInsideSystemdUnit(
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform === 'linux' && typeof env.INVOCATION_ID === 'string' && env.INVOCATION_ID.length > 0;
+}
+
+export function tmuxSpawnLaunch(isolate: boolean): TmuxSpawnLaunch {
+  return isolate
+    ? { command: 'systemd-run', prefixArgs: [...SYSTEMD_RUN_SCOPE_ARGS, 'tmux'] }
+    : { command: 'tmux', prefixArgs: [] };
+}
+
+/** One cheap end-to-end check that transient scopes work for this user manager. */
+export function probeSystemdRunScope(): Promise<boolean> {
+  return new Promise((resolve) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn('systemd-run', [...SYSTEMD_RUN_SCOPE_ARGS, 'true'], { stdio: 'ignore' });
+    } catch {
+      resolve(false);
+      return;
+    }
+    let settled = false;
+    const settle = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+    const timer = setTimeout(() => { child.kill('SIGKILL'); settle(false); }, PROBE_TIMEOUT_MS);
+    child.on('error', () => settle(false));
+    child.on('close', (code) => settle(code === 0));
+  });
+}
+
+let probe: Promise<boolean> | undefined;
+
+/**
+ * Decides once per process whether spawns go through a transient scope.
+ * Outside systemd, or when systemd-run is missing or the user manager refuses
+ * scopes, the plain tmux command is used so spawning keeps working.
+ */
+export function resolveTmuxSpawnLaunch(deps: {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  probe?: () => Promise<boolean>;
+} = {}): Promise<TmuxSpawnLaunch> {
+  if (!runsInsideSystemdUnit(deps.env, deps.platform)) {
+    return Promise.resolve(tmuxSpawnLaunch(false));
+  }
+  probe ??= (deps.probe ?? probeSystemdRunScope)().catch(() => false);
+  return probe.then(tmuxSpawnLaunch);
+}
+
+/** Test seam: forget the cached probe result. */
+export function resetTmuxSpawnLaunchForTests(): void {
+  probe = undefined;
+}

--- a/server/modules/providers/tests/builtin-relay.service.test.ts
+++ b/server/modules/providers/tests/builtin-relay.service.test.ts
@@ -77,3 +77,16 @@ test('builtinRelayEnabled: on by default, CHATMUX_BUILTIN_RELAY=0 restores tower
   assert.equal(builtinRelayEnabled({ CHATMUX_BUILTIN_RELAY: '0' }), false);
   assert.equal(builtinRelayEnabled({ CHATMUX_BUILTIN_RELAY: '1' }), true);
 });
+
+test('builtinSpawn: session creation goes through the spawn runner, other commands through the plain runner', async () => {
+  const home = mkdtempSync(path.join(tmpdir(), 'relay-home-'));
+  mkdirSync(path.join(home, 'workspace', 'proj'), { recursive: true });
+  const plain = runner(() => ({ code: 1, output: '' }));
+  const spawnRun = runner(() => ok);
+
+  const created = await builtinSpawn('scoped', '~/workspace/proj', { run: plain.run, spawnRun: spawnRun.run, home });
+
+  assert.equal(created.ok, true);
+  assert.deepEqual(plain.calls.map((call) => call.args[0]), ['has-session'], 'the existence check talks to the existing server');
+  assert.deepEqual(spawnRun.calls.map((call) => call.args[0]), ['new-session'], 'only the command that may fork a tmux server is isolated');
+});

--- a/server/modules/providers/tests/external-cli-sessions.service.test.ts
+++ b/server/modules/providers/tests/external-cli-sessions.service.test.ts
@@ -8,6 +8,7 @@ import {
   assignUniqueIndexedProviderSessionIds,
   classifyExternalSessions,
   buildExternalCliTmuxSpawnArgs,
+  spawnExternalCliSession,
   buildExternalCliRuntimePath,
   createExternalCliSessionDiscovery,
   createExternalCliSessionInferenceRetryBackoff,
@@ -1104,4 +1105,16 @@ test('classifyExternalSessions: sorted by tmux name for stable rendering', () =>
     ],
   });
   assert.deepEqual(result.map((s) => s.tmuxName), ['alpha', 'zeta']);
+});
+
+test('external CLI spawns run tmux new-session through the resolved launch command', async () => {
+  const calls: Array<{ command: string; args: string[] }> = [];
+  await spawnExternalCliSession('codex', 'scoped', '/workspace', {
+    launch: async () => ({ command: 'systemd-run', prefixArgs: ['--user', '--scope', '--collect', '--quiet', '--', 'tmux'] }),
+    run: async (command, args) => { calls.push({ command, args }); return ''; },
+  });
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].command, 'systemd-run');
+  assert.deepEqual(calls[0].args.slice(0, 8), ['--user', '--scope', '--collect', '--quiet', '--', 'tmux', 'new-session', '-d'], 'session creation is wrapped in a transient scope');
+  assert.deepEqual([calls[1].command, calls[1].args.slice(0, 3)], ['tmux', ['set-option', '-t', 'scoped']], 'tagging talks to the now-running server directly');
 });

--- a/server/modules/providers/tests/tmux-spawn-scope.service.test.ts
+++ b/server/modules/providers/tests/tmux-spawn-scope.service.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  resetTmuxSpawnLaunchForTests,
+  resolveTmuxSpawnLaunch,
+  runsInsideSystemdUnit,
+  SYSTEMD_RUN_SCOPE_ARGS,
+  tmuxSpawnLaunch,
+} from '@/modules/providers/services/tmux-spawn-scope.service.js';
+
+test('only a linux process started by systemd isolates its tmux spawns', () => {
+  assert.equal(runsInsideSystemdUnit({ INVOCATION_ID: 'abc' }, 'linux'), true);
+  assert.equal(runsInsideSystemdUnit({}, 'linux'), false, 'an interactive shell has no invocation id');
+  assert.equal(runsInsideSystemdUnit({ INVOCATION_ID: '' }, 'linux'), false);
+  assert.equal(runsInsideSystemdUnit({ INVOCATION_ID: 'abc' }, 'darwin'), false);
+});
+
+test('the transient-scope launch wraps tmux; the plain launch is tmux itself', () => {
+  assert.deepEqual(tmuxSpawnLaunch(true), { command: 'systemd-run', prefixArgs: [...SYSTEMD_RUN_SCOPE_ARGS, 'tmux'] });
+  assert.deepEqual(tmuxSpawnLaunch(false), { command: 'tmux', prefixArgs: [] });
+  assert.deepEqual([...SYSTEMD_RUN_SCOPE_ARGS], ['--user', '--scope', '--collect', '--quiet', '--']);
+});
+
+test('resolveTmuxSpawnLaunch probes systemd-run once and falls back to plain tmux when the probe fails', async () => {
+  resetTmuxSpawnLaunchForTests();
+  let probes = 0;
+  const env = { INVOCATION_ID: 'abc' };
+  const first = await resolveTmuxSpawnLaunch({ env, platform: 'linux', probe: async () => { probes += 1; return true; } });
+  const second = await resolveTmuxSpawnLaunch({ env, platform: 'linux', probe: async () => { probes += 1; return false; } });
+  assert.equal(first.command, 'systemd-run');
+  assert.equal(second.command, 'systemd-run', 'the first probe result is cached for the process lifetime');
+  assert.equal(probes, 1);
+
+  resetTmuxSpawnLaunchForTests();
+  const failed = await resolveTmuxSpawnLaunch({ env, platform: 'linux', probe: async () => { throw new Error('no bus'); } });
+  assert.deepEqual(failed, { command: 'tmux', prefixArgs: [] });
+
+  resetTmuxSpawnLaunchForTests();
+  const outside = await resolveTmuxSpawnLaunch({ env: {}, platform: 'linux', probe: async () => { throw new Error('must not probe'); } });
+  assert.deepEqual(outside, { command: 'tmux', prefixArgs: [] });
+  resetTmuxSpawnLaunchForTests();
+});


### PR DESCRIPTION
## Summary

`packaging/systemd/chatmux.service` sets `KillSignal=SIGTERM` and `TimeoutStopSec=30` but no `KillMode`, so systemd's default `control-group` applies: on stop or restart every process in the unit's cgroup is killed. Both spawn paths (`spawnExternalCliSession`, `builtinSpawn`) ran `tmux new-session -d` from the server process. When no tmux server existed on that socket yet, the tmux client forked the **server** inside `chatmux.service`'s cgroup. The next `systemctl --user restart chatmux.service` (self-update, `chatmux access ...`) then killed the tmux server and every agent inside it. This violates the repository invariant that a ChatMux restart or upgrade never terminates tmux work.

The trigger is ChatMux being the first client on the socket: a headless box, autostart at login, first action is **spawn** from the web UI. A server the user started interactively is outside the cgroup and unaffected.

## Changes

- New `tmux-spawn-scope.service.ts`: when the process runs under systemd (`INVOCATION_ID` set, linux), session creation is launched as `systemd-run --user --scope --collect --quiet -- tmux new-session ...`. The tmux client, and therefore any server it forks, lands in a transient scope unit that outlives `chatmux.service` and is collected once its processes exit. One probe per process (`systemd-run ... -- true`) falls back to plain `tmux` when `systemd-run` is missing or the user manager refuses scopes.
- `builtinSpawn` uses the isolating runner for `new-session` only; `has-session` and all exact-pane actions keep talking to the existing server directly. A `spawnRun` seam keeps the existing test harness valid.
- `spawnExternalCliSession` resolves the launch command the same way; tagging (`set-option`) and the failure cleanup still address the now-running server directly.

The unit file is intentionally unchanged: flipping `KillMode` would also leave ChatMux's own children (gjc worker, `chatmux-core watch`) unreaped on stop, whereas the scope approach only moves the tmux server out.

## Verification

- Verified on this host: `systemd-run --user --scope --collect --quiet -- tmux -S <sock> new-session -d ...` places the tmux server in `.../app.slice/run-<id>.scope`, not in a service cgroup.
- New `tmux-spawn-scope.service.test.ts` (environment gate, launch shapes, cached probe with fallback); `builtin-relay.service.test.ts` (only `new-session` goes through the spawn runner); `external-cli-sessions.service.test.ts` (argv wrapped in the scope prefix, tagging direct). Provider route contract tests still pass (86 in the four files).
- `tsc --noEmit -p server/tsconfig.json`, `eslint` on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
