### PR TITLE
fix(fleet): never let an oversized or backlogged frame crash the peer

### DIFF
--- a/server/modules/fleet/hub/connection/peer-connection.ts
+++ b/server/modules/fleet/hub/connection/peer-connection.ts
@@ -87,7 +87,16 @@ export class HubPeerConnection {
   sendFrame(frame: Extract<Parameters<typeof encodeFleetFrame>[0], { readonly kind: 'request' }>): boolean {
     if (this.socket === undefined || !this.proofVerified || this.status.generation === null) return false;
     if (frame.connectionGeneration !== this.status.generation) return false;
-    this.socket.send(encodeFleetFrame(frame));
+    let encoded: string;
+    try {
+      encoded = encodeFleetFrame(frame);
+    } catch (error) {
+      // A request the wire cannot carry (oversized chat.send or paste) fails
+      // this call only; the peer connection stays up for everything else.
+      if (error instanceof FleetProtocolError && error.code === 'PROTOCOL_FRAME_TOO_LARGE') return false;
+      throw error;
+    }
+    this.socket.send(encoded);
     return true;
   }
 

--- a/server/modules/fleet/peer/endpoint.ts
+++ b/server/modules/fleet/peer/endpoint.ts
@@ -60,6 +60,9 @@ export function createFleetPeerEndpoint(options: FleetPeerEndpointOptions): Read
     const connection = new FleetProtocolConnection({
       local: options.local, trust: options.trust, registry: options.registry,
       replayGuard, transport, dispatch: options.dispatch,
+      onDroppedFrame: (code, frameKind) => {
+        console.warn(`[Fleet Peer] Dropped ${frameKind} frame (${code}); the connection stays up.`);
+      },
       onAuthenticated: (connectionState) => {
         authenticated = connectionState;
         options.onAuthenticated?.(connectionState);

--- a/server/modules/fleet/protocol/connection-types.ts
+++ b/server/modules/fleet/protocol/connection-types.ts
@@ -40,6 +40,8 @@ export type FleetProtocolConnectionOptions = Readonly<{
   readonly onAuthenticated?: (connection: FleetAuthenticatedConnection) => void;
   readonly onResponse?: (response: FleetResponseEnvelope) => void;
   readonly onError?: (code: FleetProtocolErrorCode) => void;
+  /** A frame that could not be sent without closing the connection (too large for the wire). */
+  readonly onDroppedFrame?: (code: FleetProtocolErrorCode, frameKind: string) => void;
   readonly scheduler?: FleetProtocolScheduler;
   readonly writer?: FleetWriterOptions;
   readonly requestCapacity?: number;

--- a/server/modules/fleet/protocol/connection.ts
+++ b/server/modules/fleet/protocol/connection.ts
@@ -61,10 +61,22 @@ export class FleetProtocolConnection {
     return this.incoming;
   }
 
-  publish(event: FleetEvent, eventId: string, body: JsonValue): void {
-    if (this.state.kind !== 'authenticated') return;
-    assertFleetCapability(this.state.capabilities, capabilityForEvent(event));
-    this.send({
+  /**
+   * Publishes one event. Never throws: publishers run inside unrelated
+   * emitters (node-pty data, chat run listeners), where an exception would
+   * take down the whole process rather than this one connection. An event
+   * the wire cannot carry is dropped and reported; a saturated writer closes
+   * this connection so the hub reconnects and resnapshots.
+   */
+  publish(event: FleetEvent, eventId: string, body: JsonValue): boolean {
+    if (this.state.kind !== 'authenticated') return false;
+    try {
+      assertFleetCapability(this.state.capabilities, capabilityForEvent(event));
+    } catch (error) {
+      this.options.onDroppedFrame?.(error instanceof FleetProtocolError ? error.code : 'PROTOCOL_FRAME_INVALID', 'event');
+      return false;
+    }
+    return this.send({
       kind: 'event', protocolVersion: FLEET_PROTOCOL_VERSION,
       connectionGeneration: this.state.generation, eventId, event,
       hostId: this.options.local.signer.installationId, body,
@@ -189,8 +201,41 @@ export class FleetProtocolConnection {
     });
   }
 
-  private send(frame: Parameters<typeof encodeFleetFrame>[0]): void {
-    this.writer.send(encodeFleetFrame(frame));
+  /**
+   * Encodes and queues one frame. A frame over the size bound is never a
+   * reason to drop the connection: a response is replaced by a bounded
+   * FLEET_FRAME_TOO_LARGE failure so the hub's request settles, any other
+   * frame is dropped and reported. Writer saturation closes the connection.
+   */
+  private send(frame: Parameters<typeof encodeFleetFrame>[0]): boolean {
+    if (this.state.kind === 'closed') return false;
+    let encoded: string;
+    try {
+      encoded = encodeFleetFrame(frame);
+    } catch (error) {
+      if (!(error instanceof FleetProtocolError) || error.code !== 'PROTOCOL_FRAME_TOO_LARGE') {
+        this.reject(error);
+        return false;
+      }
+      this.options.onDroppedFrame?.(error.code, frame.kind);
+      if (frame.kind === 'response') {
+        return this.send({
+          kind: 'response', protocolVersion: frame.protocolVersion, connectionGeneration: frame.connectionGeneration,
+          requestId: frame.requestId, target: frame.target, status: 'failure',
+          // An applied mutation whose result cannot be delivered is an uncertain outcome, never a silent 'none'.
+          sideEffect: frame.status === 'success' && frame.sideEffect === 'applied' ? 'possible' : frame.status === 'failure' ? frame.sideEffect : 'none',
+          error: 'FLEET_FRAME_TOO_LARGE', body: null,
+        });
+      }
+      return false;
+    }
+    try {
+      this.writer.send(encoded);
+      return true;
+    } catch (error) {
+      this.reject(error);
+      return false;
+    }
   }
 
   private scheduleLease(): void {

--- a/server/modules/fleet/terminal/peer.ts
+++ b/server/modules/fleet/terminal/peer.ts
@@ -10,6 +10,27 @@ import {
 
 const OUTPUT_ENTRY_LIMIT = 512;
 const OUTPUT_BYTE_LIMIT = 1024 * 1024;
+/**
+ * Largest pane.output payload, in UTF-16 code units. JSON escaping expands a
+ * control-heavy TUI redraw up to 6x (\u001b per escape byte) and the envelope
+ * adds a few hundred bytes, so 8 KiB of data always fits the 64 KiB frame.
+ */
+export const OUTPUT_CHUNK_CHARS = 8 * 1024;
+
+/** Splits pty output into frame-sized pieces without cutting a surrogate pair. */
+export function chunkTerminalOutput(data: string, limit = OUTPUT_CHUNK_CHARS): string[] {
+  if (data.length <= limit) return [data];
+  const chunks: string[] = [];
+  let start = 0;
+  while (start < data.length) {
+    let end = Math.min(start + limit, data.length);
+    const last = data.charCodeAt(end - 1);
+    if (end < data.length && last >= 0xd800 && last <= 0xdbff) end -= 1;
+    chunks.push(data.slice(start, end));
+    start = end;
+  }
+  return chunks;
+}
 type Output = Readonly<{ readonly seq: number; readonly data: string; readonly bytes: number }>;
 export interface RemoteTerminalProcess {
   onData(listener: (data: string) => void): void;
@@ -108,12 +129,14 @@ export function createRemoteTerminalPeer(options: RemoteTerminalPeerOptions): Re
     sessions.set(session.id, session);
     process.onData((data) => {
       if (!session.open) return;
-      const output = { seq: ++session.lastSeq, data, bytes: Buffer.byteLength(data) };
-      session.output.push(output); session.outputBytes += output.bytes;
-      while (session.output.length > OUTPUT_ENTRY_LIMIT || session.outputBytes > OUTPUT_BYTE_LIMIT) {
-        const removed = session.output.shift(); if (removed !== undefined) session.outputBytes -= removed.bytes;
+      for (const piece of chunkTerminalOutput(data)) {
+        const output = { seq: ++session.lastSeq, data: piece, bytes: Buffer.byteLength(piece) };
+        session.output.push(output); session.outputBytes += output.bytes;
+        while (session.output.length > OUTPUT_ENTRY_LIMIT || session.outputBytes > OUTPUT_BYTE_LIMIT) {
+          const removed = session.output.shift(); if (removed !== undefined) session.outputBytes -= removed.bytes;
+        }
+        publish(session, output);
       }
-      publish(session, output);
     });
     process.onExit(() => { session.open = false; sessions.delete(session.id); });
     return { terminalSessionId: session.id, streamEpoch: session.streamEpoch, peerProcessEpoch: options.processEpoch, replay: 'redraw', lastSeq: 0 };

--- a/server/modules/fleet/tests/fleet-protocol-connection.test.ts
+++ b/server/modules/fleet/tests/fleet-protocol-connection.test.ts
@@ -86,7 +86,7 @@ function request(generation: number, body: null | Readonly<Record<string, string
   });
 }
 
-function fixture(overrides: Partial<FleetProtocolConnectionOptions> = {}, suppliedHub?: ReturnType<typeof identity>) {
+function fixture(overrides: Partial<FleetProtocolConnectionOptions> = {}, suppliedHub?: ReturnType<typeof identity>, capabilities: FleetProtocolConnectionOptions['local']['capabilities'] = ['catalog.read']) {
   const hub = suppliedHub ?? identity();
   const peer = identity();
   const scheduler = new Scheduler();
@@ -95,7 +95,7 @@ function fixture(overrides: Partial<FleetProtocolConnectionOptions> = {}, suppli
   const activeTransport = overrides.transport instanceof Transport ? overrides.transport : transport;
   let dispatchCount = 0;
   const options: FleetProtocolConnectionOptions = {
-    local: { role: 'peer', signer: peer.signer, processEpoch: 'peer-epoch', capabilities: ['catalog.read'], transportMode: 'direct-wss' },
+    local: { role: 'peer', signer: peer.signer, processEpoch: 'peer-epoch', capabilities, transportMode: 'direct-wss' },
     trust: { find: async (installationId) => ({ installationId, pinnedPublicKey: hub.publicKey, state: 'active' }) },
     replayGuard: new FleetChallengeReplayGuard(), registry, transport: activeTransport, scheduler,
     dispatch: async (incoming) => { dispatchCount += 1; return successfulResponse(incoming); },
@@ -104,9 +104,9 @@ function fixture(overrides: Partial<FleetProtocolConnectionOptions> = {}, suppli
   return { hub, peer, scheduler, transport: activeTransport, registry, options, connection: new FleetProtocolConnection(options), dispatchCount: () => dispatchCount };
 }
 
-async function authenticate(subject: ReturnType<typeof fixture>, connectionId = randomUUID()): Promise<void> {
+async function authenticate(subject: ReturnType<typeof fixture>, connectionId = randomUUID(), capabilities: FleetProtocolConnectionOptions['local']['capabilities'] = ['catalog.read']): Promise<void> {
   const hello = createFleetHello({
-    role: 'hub', signer: subject.hub.signer, processEpoch: 'hub-epoch', capabilities: ['catalog.read'],
+    role: 'hub', signer: subject.hub.signer, processEpoch: 'hub-epoch', capabilities,
     transportMode: 'direct-wss', connectionId,
   });
   await subject.connection.receive(Buffer.from(encodeFleetFrame(hello)));
@@ -202,4 +202,72 @@ test('Given frame and writer bounds, when either is exceeded, then input never r
   await bounded.connection.receive(Buffer.from(encodeFleetFrame(hello)));
   assert.equal(bounded.transport.closes[0]?.reason, 'fleet writer capacity exceeded');
   assert.equal(bounded.dispatchCount(), 0);
+});
+
+test('Given an authenticated peer, when an event exceeds the frame bound, then it is dropped and the connection survives', async () => {
+  const dropped: Array<[string, string]> = [];
+  const errors: string[] = [];
+  const subject = fixture({ onDroppedFrame: (code, kind) => { dropped.push([code, kind]); }, onError: (code) => { errors.push(code); } });
+  await authenticate(subject);
+  const sentBefore = subject.transport.sent.length;
+
+  const oversized = subject.connection.publish('catalog.delta', 'event-big', { text: 'x'.repeat(FLEET_MAX_FRAME_BYTES) });
+  const normal = subject.connection.publish('catalog.delta', 'event-small', { text: 'hello' });
+
+  assert.equal(oversized, false);
+  assert.equal(normal, true);
+  assert.deepEqual(dropped, [['PROTOCOL_FRAME_TOO_LARGE', 'event']]);
+  assert.deepEqual(errors, []);
+  assert.deepEqual(subject.transport.closes, [], 'a frame the wire cannot carry never closes the connection');
+  assert.equal(subject.transport.sent.length, sentBefore + 1);
+  const last = decodeFleetFrame(Buffer.from(subject.transport.sent.at(-1) ?? ''));
+  assert.equal(last.kind === 'event' && last.eventId, 'event-small');
+});
+
+test('Given an authenticated peer, when a response exceeds the frame bound, then the hub gets a bounded FLEET_FRAME_TOO_LARGE failure', async () => {
+  const capabilities = ['catalog.read', 'chat.control'] as const;
+  const subject = fixture({
+    dispatch: async (incoming): Promise<FleetResponseEnvelope> => ({
+      kind: 'response', protocolVersion: incoming.protocolVersion, connectionGeneration: incoming.connectionGeneration,
+      requestId: incoming.requestId, target: incoming.target, status: 'success',
+      sideEffect: incoming.operation === 'chat.send' ? 'applied' : 'none',
+      body: { blob: 'y'.repeat(FLEET_MAX_FRAME_BYTES) },
+    }),
+  }, undefined, capabilities);
+  await authenticate(subject, undefined, capabilities);
+
+  const sentBefore = subject.transport.sent.length;
+  await subject.connection.receive(Buffer.from(encodeFleetFrame(request(1))));
+  await subject.transport.waitForCount(sentBefore + 1);
+  const readReply = decodeFleetFrame(Buffer.from(subject.transport.sent.at(-1) ?? ''));
+  assert.equal(readReply.kind, 'response');
+  if (readReply.kind !== 'response') return;
+  assert.equal(readReply.status, 'failure');
+  assert.equal(readReply.status === 'failure' && readReply.error, 'FLEET_FRAME_TOO_LARGE');
+  assert.equal(readReply.sideEffect, 'none');
+  assert.equal(readReply.requestId, 'request-1');
+
+  const mutation = { ...request(1, { value: 'go' }, 'chat.send'), requestId: 'request-2' };
+  await subject.connection.receive(Buffer.from(encodeFleetFrame(mutation)));
+  await subject.transport.waitForCount(sentBefore + 2);
+  const mutationReply = decodeFleetFrame(Buffer.from(subject.transport.sent.at(-1) ?? ''));
+  assert.equal(mutationReply.kind === 'response' && mutationReply.status === 'failure' && mutationReply.sideEffect, 'possible', 'an applied mutation whose result cannot be delivered is reported as uncertain, never as none');
+  assert.deepEqual(subject.transport.closes, []);
+});
+
+test('Given a saturated writer, when publishing continues, then the connection closes without throwing into the publisher', async () => {
+  const transport = new Transport();
+  transport.blocked = true;
+  const errors: string[] = [];
+  const subject = fixture({ transport, writer: { maxFrames: 4, maxBytes: 1024 * 1024 }, onError: (code) => { errors.push(code); } });
+  await authenticate(subject);
+
+  const results: boolean[] = [];
+  for (let index = 0; index < 8; index += 1) {
+    results.push(subject.connection.publish('catalog.delta', `event-${index}`, { index }));
+  }
+
+  assert.ok(results.includes(false), 'the publisher learns the connection is gone');
+  assert.deepEqual(subject.transport.closes[0], { code: 4008, reason: 'fleet writer capacity exceeded' });
+  assert.ok(errors.includes('PROTOCOL_QUEUE_FULL'));
 });

--- a/server/modules/fleet/tests/task-12-remote-terminal.test.ts
+++ b/server/modules/fleet/tests/task-12-remote-terminal.test.ts
@@ -225,3 +225,39 @@ test('authorization failures and disconnect between verification and spawn have 
     now += 1;
   }
 });
+
+test('pane output larger than one frame is published as consecutive chunks that never split a surrogate pair', async () => {
+  const { chunkTerminalOutput, OUTPUT_CHUNK_CHARS } = await import('../terminal/peer.js');
+  assert.deepEqual(chunkTerminalOutput('short'), ['short']);
+  const big = 'a'.repeat(OUTPUT_CHUNK_CHARS * 2 + 10);
+  assert.deepEqual(chunkTerminalOutput(big).map((piece) => piece.length), [OUTPUT_CHUNK_CHARS, OUTPUT_CHUNK_CHARS, 10]);
+  const emoji = 'x'.repeat(OUTPUT_CHUNK_CHARS - 1) + String.fromCodePoint(0x1f600) + 'y';
+  const pieces = chunkTerminalOutput(emoji);
+  assert.deepEqual(pieces.map((piece) => piece.length), [OUTPUT_CHUNK_CHARS - 1, 3], 'the boundary moves back rather than cutting the pair');
+  assert.equal(pieces.join(''), emoji);
+
+  let now = 1_000;
+  const spawned: FakeProcess[] = [];
+  const events: Array<Readonly<{ event: FleetEvent; body: JsonValue }>> = [];
+  const peer = createRemoteTerminalPeer({
+    hostId: HOST_A, processEpoch: 'peer-process-1', now: () => now,
+    isConnectionCurrent: (generation) => generation === 7,
+    verifyTarget: async (target) => target,
+    spawn: async () => { const process = new FakeProcess(); spawned.push(process); return process; },
+    publish: (event, eventBody) => events.push({ event, body: eventBody }),
+  });
+  await peer.handlers['pane.attach']?.({
+    kind: 'request', protocolVersion: 'fleet/1', connectionGeneration: 7,
+    requestId: 'attach-big', operation: 'pane.attach', target: pane,
+    body: { deadlineAtMs: 1_500, lease, cols: 80, rows: 24, resume: null },
+  });
+  now += 1;
+  const escape = String.fromCharCode(27);
+  const redraw = (escape + '[31m').repeat(OUTPUT_CHUNK_CHARS);
+  spawned[0]?.output(redraw);
+  const outputs = events.filter((entry) => entry.event === 'pane.output').map((entry) => body(entry.body));
+  assert.equal(outputs.length, Math.ceil(redraw.length / OUTPUT_CHUNK_CHARS));
+  assert.deepEqual(outputs.map((output) => output.seq), outputs.map((_output, index) => index + 1), 'chunks carry consecutive sequence numbers');
+  assert.equal(outputs.map((output) => output.data).join(''), redraw);
+  for (const output of outputs) assert.ok(JSON.stringify(output).length < 64 * 1024, 'each chunk fits one frame after JSON escaping');
+});

--- a/server/modules/websocket/services/chat-run-registry.service.ts
+++ b/server/modules/websocket/services/chat-run-registry.service.ts
@@ -125,7 +125,15 @@ function decorateAndRecordEvent(run: ChatRun, message: NormalizedMessage): Norma
   }
 
   notifyProcessingChanged();
-  for (const listener of eventListeners) listener(outbound);
+  for (const listener of eventListeners) {
+    try {
+      listener(outbound);
+    } catch (error) {
+      // Listeners are side channels (fleet publish, tests); the browser
+      // stream that recorded this event must never fail because one broke.
+      console.error('[Chat Run Registry] Event listener failed:', error instanceof Error ? error.message : error);
+    }
+  }
   return outbound;
 }
 

--- a/server/modules/websocket/tests/chat-run-registry-events.test.ts
+++ b/server/modules/websocket/tests/chat-run-registry-events.test.ts
@@ -49,3 +49,24 @@ test('Given a processing subscriber, when runs materially mutate, then notificat
   assert.deepEqual(observed, [0, 1, -1]);
   chatRunRegistry.clearAll();
 });
+
+test('Given a throwing event subscriber, when a run streams, then the other subscriber and the run itself are unaffected', () => {
+  chatRunRegistry.clearAll();
+  const observed: Array<{ readonly seq?: number }> = [];
+  const unsubscribeBad = chatRunRegistry.subscribeEvents(() => { throw new Error('listener bug'); });
+  const unsubscribeGood = chatRunRegistry.subscribeEvents((event) => observed.push(event));
+  const run = chatRunRegistry.startRun({
+    appSessionId: 'listener-isolation', provider: 'codex', providerSessionId: null,
+    connection: new Connection(), userId: null,
+  });
+  assert.ok(run);
+  try {
+    assert.doesNotThrow(() => run.writer.send({ kind: 'stream_delta', provider: 'codex', sessionId: 'native', content: 'one' }));
+    assert.doesNotThrow(() => run.writer.send({ kind: 'complete', provider: 'codex', sessionId: 'native', exitCode: 0 }));
+    assert.deepEqual(observed.map(({ seq }) => seq), [1, 2], 'the healthy subscriber still receives every event');
+  } finally {
+    unsubscribeBad();
+    unsubscribeGood();
+    chatRunRegistry.clearAll();
+  }
+});


### PR DESCRIPTION
## Summary

`encodeFleetFrame` (`PROTOCOL_FRAME_TOO_LARGE`, 64 KiB) and `FleetBoundedWriter.send` (`PROTOCOL_QUEUE_FULL`, 256 frames / 1 MiB) threw synchronously into whoever called `FleetProtocolConnection.publish`. On the terminal path that caller is node-pty's `onData` emitter and `server/index.js` registers no `uncaughtException` handler, so a single TUI redraw chunk that JSON-encodes past 64 KiB, or `cat bigfile` queuing more than 256 frames while the hub link is slower than the pty, **exited the peer process**. The same throw reached the local chat run through `chat-run-registry`'s listener loop, breaking the browser stream too.

## Changes

- `protocol/connection.ts`: `publish()` and `send()` never throw.
  - A frame over the bound: an event is dropped and reported through a new optional `onDroppedFrame(code, frameKind)` hook; a response is replaced by a bounded `FLEET_FRAME_TOO_LARGE` failure so the hub's request settles. An applied mutation whose result cannot be delivered is reported with `sideEffect: 'possible'`, never `'none'`. Both are closed error and side-effect values the RFC already defines.
  - Writer saturation closes that one connection (4008) so the hub reconnects and resnapshots; the publisher gets `false` back.
- `terminal/peer.ts`: pty output is split into 8 KiB pieces before publish (`chunkTerminalOutput`, never cutting a surrogate pair), each with its own `seq`, so `pane.output` cannot exceed the frame after JSON escaping (6x worst case for control bytes plus the envelope).
- `peer/endpoint.ts`: logs dropped frames.
- `websocket/services/chat-run-registry.service.ts`: each event listener is isolated; one failing side channel no longer fails the run that recorded the event.
- `hub/connection/peer-connection.ts`: `sendFrame` reports an oversized request as a failed send (`false`) instead of throwing into the RPC client.

This does not widen the wire contract: frame bounds, error codes and side-effect values are unchanged; only what the sender does when it hits them changes.

## Verification

- `fleet-protocol-connection.test.ts`: oversized event dropped while the connection survives and later events flow; oversized read response replaced by `FLEET_FRAME_TOO_LARGE` with `sideEffect: 'none'` and an applied mutation with `'possible'`; a saturated writer closes with 4008 without throwing into the publisher.
- `task-12-remote-terminal.test.ts`: chunking sizes and surrogate handling; a control-heavy redraw is published as consecutive `seq` chunks that each fit one frame.
- `chat-run-registry-events.test.ts`: a throwing subscriber does not affect the run or other subscribers.
- Full fleet plus websocket suites excluding tmux-backed e2e: 216 pass. `tsc --noEmit -p server/tsconfig.json`, `eslint` on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
