### PR TITLE
fix(fleet): retain only mutation results in the request ledger

### DIFF
--- a/server/modules/fleet/protocol/request-ledger.ts
+++ b/server/modules/fleet/protocol/request-ledger.ts
@@ -1,6 +1,26 @@
-import type { FleetRequestEnvelope, FleetResponseEnvelope } from '../../../../shared/fleet.js';
+import type { FleetOperation, FleetRequestEnvelope, FleetResponseEnvelope } from '../../../../shared/fleet.js';
 
 import { canonicalFleetJson } from './codec.js';
+
+/**
+ * Operations whose results the ledger keeps after completion, so a hub retry
+ * with the same request id replays the recorded outcome instead of acting
+ * twice. The RFC requires at-most-once delivery, and retention of at most
+ * 4,096 results, for mutations only. Reads and the lease-bound terminal
+ * stream (attach, per-keystroke input, resize) are coalesced while in flight
+ * but evicted on completion: retaining them would exhaust the ledger after a
+ * few thousand keystrokes and refuse every later mutation on the connection.
+ */
+const RETAINED_OPERATIONS: ReadonlySet<FleetOperation> = new Set<FleetOperation>([
+  'chat.send', 'chat.abort',
+  'prompt.respond', 'approval.respond',
+  'pane.interrupt', 'pane.escape', 'pane.terminate', 'process.terminate',
+  'session.spawn', 'session.terminate',
+]);
+
+export function isRetainedFleetOperation(operation: FleetOperation): boolean {
+  return RETAINED_OPERATIONS.has(operation);
+}
 
 type PendingEntry = Readonly<{
   readonly canonicalRequest: string;
@@ -53,7 +73,11 @@ export class FleetRequestLedger {
       complete: (response) => {
         const current = this.entries.get(request.requestId);
         if (current?.kind !== 'pending' || current.value.canonicalRequest !== canonicalRequest) return;
-        this.entries.set(request.requestId, { kind: 'complete', value: { canonicalRequest, response } });
+        if (isRetainedFleetOperation(request.operation)) {
+          this.entries.set(request.requestId, { kind: 'complete', value: { canonicalRequest, response } });
+        } else {
+          this.entries.delete(request.requestId);
+        }
         current.value.resolve(response);
       },
     };

--- a/server/modules/fleet/tests/fleet-protocol-live.test.ts
+++ b/server/modules/fleet/tests/fleet-protocol-live.test.ts
@@ -85,13 +85,13 @@ test('Given a real WebSocket pair, when the composed boundary authenticates then
       close: (code, reason) => socket.close(code, reason),
     };
     const connection = new FleetProtocolConnection({
-      local: { role: 'peer', signer: peer.signer, processEpoch: 'peer-epoch', capabilities: ['catalog.read'], transportMode: 'direct-wss' },
+      local: { role: 'peer', signer: peer.signer, processEpoch: 'peer-epoch', capabilities: ['catalog.read', 'chat.control'], transportMode: 'direct-wss' },
       trust: { find: async (installationId) => ({ installationId, pinnedPublicKey: hub.publicKey, state: 'active' }) },
       replayGuard, registry, transport,
       createHello: (connectionId) => {
         retainedPeerHello ??= createFleetHello({
           role: 'peer', signer: peer.signer, processEpoch: 'peer-epoch',
-          capabilities: ['catalog.read'], transportMode: 'direct-wss', connectionId,
+          capabilities: ['catalog.read', 'chat.control'], transportMode: 'direct-wss', connectionId,
         });
         return retainedPeerHello;
       },
@@ -113,7 +113,7 @@ test('Given a real WebSocket pair, when the composed boundary authenticates then
   const endpoint = `ws://127.0.0.1:${address.port}/fleet-ws`;
   const connectionId = randomUUID();
   const hubHello = createFleetHello({
-    role: 'hub', signer: hub.signer, processEpoch: 'hub-epoch', capabilities: ['catalog.read'],
+    role: 'hub', signer: hub.signer, processEpoch: 'hub-epoch', capabilities: ['catalog.read', 'chat.control'],
     transportMode: 'direct-wss', connectionId,
   });
   let savedProof: Awaited<ReturnType<typeof createFleetProof>> | undefined;
@@ -146,7 +146,7 @@ test('Given a real WebSocket pair, when the composed boundary authenticates then
   await withTimeout(authenticated.promise, 'auth');
   const canonical = parseFleetRequestEnvelope({
     kind: 'request', protocolVersion: 'fleet/1', connectionGeneration: 1, requestId: 'live-request',
-    operation: 'catalog.snapshot', target: { kind: 'host', hostId: peer.signer.installationId }, body: { value: 'one' },
+    operation: 'chat.send', target: { kind: 'session', hostId: peer.signer.installationId, localId: 'live-session' }, body: { value: 'one' },
   });
   active.send(encodeFleetFrame(canonical));
   active.send(encodeFleetFrame(canonical));

--- a/server/modules/fleet/tests/fleet-protocol-state.test.ts
+++ b/server/modules/fleet/tests/fleet-protocol-state.test.ts
@@ -27,16 +27,16 @@ class Connection implements FleetSupersedableConnection {
 function request(body: unknown = null) {
   return parseFleetRequestEnvelope({
     kind: 'request', protocolVersion: 'fleet/1', connectionGeneration: 1,
-    requestId: 'request-1', operation: 'catalog.snapshot',
-    target: { kind: 'host', hostId: HOST_ID }, body,
+    requestId: 'request-1', operation: 'chat.send',
+    target: { kind: 'session', hostId: HOST_ID, localId: 'session-1' }, body,
   });
 }
 
 function response() {
   return parseFleetResponseEnvelope({
     kind: 'response', protocolVersion: 'fleet/1', connectionGeneration: 1,
-    requestId: 'request-1', target: { kind: 'host', hostId: HOST_ID },
-    status: 'success', sideEffect: 'none', body: null,
+    requestId: 'request-1', target: { kind: 'session', hostId: HOST_ID, localId: 'session-1' },
+    status: 'success', sideEffect: 'applied', body: null,
   });
 }
 
@@ -116,7 +116,7 @@ test('Given a negotiated capability intersection, when an unsupported operation 
 
   assert.throws(() => assertFleetCapability([], required), /capability is unavailable/);
   assert.equal(dispatcherCount, 0);
-  assertFleetCapability(['catalog.read'], required);
+  assertFleetCapability(['chat.control'], required);
   dispatcherCount += 1;
   assert.equal(dispatcherCount, 1);
 });

--- a/server/modules/fleet/tests/task-11-mutation-ledger.test.ts
+++ b/server/modules/fleet/tests/task-11-mutation-ledger.test.ts
@@ -37,3 +37,46 @@ test('Given successful mutation dispatch, when the peer responds, then sideEffec
   const response = await dispatch(mutation('applied'));
   assert.equal(calls, 1); assert.equal(response.status, 'success'); assert.equal(response.sideEffect, 'applied');
 });
+
+function streamRequest(operation: 'pane.input' | 'catalog.snapshot', requestId: string) {
+  const target = operation === 'catalog.snapshot'
+    ? { kind: 'host', hostId: HOST }
+    : { kind: 'pane', hostId: HOST, localId: 'pane-1', lane: 'external', tmux: { socketPath: '/tmp/tmux-1000/default', sessionId: '$1', windowId: '@1', paneId: '%1' }, process: { pid: 42, startedAtMs: 100 } };
+  const body = operation === 'catalog.snapshot'
+    ? {}
+    : { deadlineAtMs: 9_000, lease: { token: 'lease-token-1234567890', expiresAtMs: 9_000, connectionGeneration: 3 }, streamEpoch: 'epoch-1', data: 'k' };
+  return parseFleetRequestEnvelope({ kind: 'request', protocolVersion: 'fleet/1', connectionGeneration: 3, requestId, operation, target, body });
+}
+function readSuccess(request: ReturnType<typeof streamRequest>): FleetResponseEnvelope { return { kind: 'response', protocolVersion: 'fleet/1', connectionGeneration: request.connectionGeneration, requestId: request.requestId, target: request.target, status: 'success', sideEffect: 'none', body: null }; }
+
+test('Given reads and terminal input, when they complete, then the ledger forgets them and only mutations are retained', async () => {
+  const ledger = new FleetRequestLedger();
+  const input = streamRequest('pane.input', 'input-1');
+  const admitted = ledger.admit(input); const concurrent = ledger.admit(input);
+  assert.equal(admitted.kind, 'dispatch'); assert.equal(concurrent.kind, 'pending', 'an in-flight duplicate still coalesces');
+  if (admitted.kind !== 'dispatch' || concurrent.kind !== 'pending') throw new TypeError('ledger admission mismatch');
+  admitted.complete(readSuccess(input)); assert.deepEqual(await concurrent.response, readSuccess(input));
+  assert.equal(ledger.size, 0, 'a completed keystroke leaves no entry behind');
+  const again = ledger.admit(input);
+  assert.equal(again.kind, 'dispatch', 'the same id dispatches again rather than replaying a stale result');
+  if (again.kind === 'dispatch') again.complete(readSuccess(input));
+  assert.equal(ledger.size, 0);
+
+  const snapshot = streamRequest('catalog.snapshot', 'read-1');
+  const read = ledger.admit(snapshot); if (read.kind !== 'dispatch') throw new TypeError('read admission mismatch');
+  read.complete(readSuccess(snapshot)); assert.equal(ledger.size, 0);
+
+  const mutate = mutation('mutation-1'); const write = ledger.admit(mutate); if (write.kind !== 'dispatch') throw new TypeError('mutation admission mismatch');
+  write.complete(success(mutate)); assert.equal(ledger.size, 1); assert.equal(ledger.admit(mutate).kind, 'replay');
+});
+
+test('Given thousands of keystrokes on one connection, when a mutation follows, then it is still admitted', () => {
+  const ledger = new FleetRequestLedger();
+  for (let index = 0; index < 5_000; index += 1) {
+    const request = streamRequest('pane.input', `key-${index}`); const admission = ledger.admit(request);
+    if (admission.kind !== 'dispatch') throw new TypeError(`keystroke ${index} was not admitted`);
+    admission.complete(readSuccess(request));
+  }
+  assert.equal(ledger.size, 0);
+  assert.equal(ledger.admit(mutation('after-typing')).kind, 'dispatch');
+});


### PR DESCRIPTION
## Summary

`FleetRequestLedger` retained every admitted request for the life of a connection, reads and per-keystroke `pane.input` included, under a 4,096-entry cap. Once full it answered every new request with `FLEET_REQUEST_CACHE_FULL`, and nothing on the hub reacts to that code. Typing roughly four thousand characters into a remote terminal therefore disabled `chat.send`, `approval.respond` and `pane.capture` on that peer until a network blip forced a reconnect.

`docs/FLEET-FEDERATION-RFC.md` ("Side-effect safety") requires at-most-once delivery and retention of at most 4,096 canonical results for **mutations**; the implementation was stricter than the contract. This PR aligns with the RFC and does not widen it.

## Changes

- `protocol/request-ledger.ts`: in-flight duplicates still coalesce and altered payloads still conflict for every operation. On completion the result is retained only for mutations: `chat.send`, `chat.abort`, `prompt.respond`, `approval.respond`, `pane.interrupt`, `pane.escape`, `pane.terminate`, `process.terminate`, `session.spawn`, `session.terminate`. Reads and the lease-bound terminal stream (`pane.attach`, `pane.input`, `pane.resize`) are evicted when they complete, so the cap is spent on outcomes a hub retry must never repeat. A completed read that is resent with the same id dispatches again instead of replaying a stale result, which matches the RFC's "a read MAY retry once".
- Two characterization tests that used `catalog.snapshot` to exercise replay now use `chat.send`, since read replay is no longer a ledger guarantee.

## Verification

- `task-11-mutation-ledger.test.ts`: reads and keystrokes coalesce while pending, leave no entry behind, and dispatch again on a repeated id; 5,000 completed keystrokes leave the ledger empty and a following mutation is admitted; mutations still replay and the 4,096 mutation cap still returns `full`.
- Full fleet suite excluding tmux-backed e2e: 162 pass. `tsc --noEmit -p server/tsconfig.json`, `eslint` on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
