### PR TITLE
chore(release): v1.8.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatmux",
-  "version": "1.8.15",
+  "version": "1.8.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatmux",
-      "version": "1.8.15",
+      "version": "1.8.16",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chatmux",
   "private": true,
-  "version": "1.8.15",
+  "version": "1.8.16",
   "productName": "ChatMux",
   "description": "A self-hosted web interface for coding-agent sessions running in tmux",
   "type": "module",

--- a/packaging/release/update-compatibility.json
+++ b/packaging/release/update-compatibility.json
@@ -182,6 +182,15 @@
           "1.8.14"
         ]
       }
+    },
+    "1.8.16": {
+      "database": {
+        "schemaGeneration": 19,
+        "rollbackCompatibleFrom": [
+          "1.8.14",
+          "1.8.15"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Release bookkeeping for **v1.8.16**, the first release carrying the fixes merged since 1.8.15:

- #68 Tailscale Serve `Host` bypass of the tailnet allowlist (Critical)
- #69 cross-site guard for `/api` and WebSocket upgrades, `cors()` removed
- #70 git discard and delete-untracked no longer accept directory pathspecs
- #71 commit-message generation runs without tools or permission bypass
- #72 peer closes the hub connection when its grant is revoked
- #73 tmux sessions spawned in a transient scope outside the service cgroup
- #74 updater probes health on the bound address
- #76 oversized or backlogged fleet frames no longer crash the peer
- #77 request ledger retains mutation results only
- #78 / #79 RFC rev.2 and the bounded catalog snapshot with `omitted`
- #75 browserslist advisory

## Compatibility declaration

No migration was added, so `1.8.16` keeps `schemaGeneration: 19` and carries forward every version `1.8.15` declared plus `1.8.15` itself: `["1.8.14", "1.8.15"]`.

## Verification

- `npm run release:check-metadata` passes for 1.8.16 (schema generation 19, 2 rollback-compatible versions declared)
- `npm run check:identity` passes
- `package.json` and both `package-lock.json` version fields agree (`npm version 1.8.16 --no-git-tag-version`)

After merge, the **Release ChatMux Server** workflow is dispatched from `main` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
