### PR TITLE
test(fleet): capture the peer B baseline after its prompt settles

### DIFF
--- a/server/modules/fleet/tests/task-12-remote-terminal.live.test.ts
+++ b/server/modules/fleet/tests/task-12-remote-terminal.live.test.ts
@@ -23,6 +23,21 @@ function armCreated(directory: string, expected: string): Promise<void> {
     }, 5_000);
   });
 }
+/**
+ * Captures a pane only once it shows `marker`: the readiness file is touched
+ * before bash prints its prompt, so an immediate capture races the shell and
+ * the "unchanged" comparison later flakes on whether the prompt arrived.
+ */
+async function settledCapture(socketPath: string, paneId: string, marker: string): Promise<string> {
+  const deadline = Date.now() + 5_000;
+  let screen = tmux(socketPath, ['capture-pane', '-p', '-t', paneId]);
+  while (!screen.includes(marker) && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    screen = tmux(socketPath, ['capture-pane', '-p', '-t', paneId]);
+  }
+  if (!screen.includes(marker)) throw new TypeError(`fixture pane never showed ${marker}`);
+  return screen;
+}
 function controllerState(): string {
   const result = spawnSync('tmux', [
     'list-sessions', '-F', '#{socket_path}\t#{pid}\t#{session_id}\t#{session_name}',
@@ -46,7 +61,7 @@ test('real peer-owned PTY attaches peer A, accepts input and resize, and leaves 
     const peerBReady = armCreated(root, 'peer-b-ready');
     tmux(socketB, ['new-session', '-d', '-s', 'peer-b', `touch '${path.join(root, 'peer-b-ready')}'; exec bash --noprofile --norc`]);
     await peerBReady;
-    const peerBPipeBefore = tmux(socketB, ['capture-pane', '-p', '-t', '%0']);
+    const peerBPipeBefore = await settledCapture(socketB, '%0', 'bash-');
     const identity = tmux(socketA, ['display-message', '-p', '-t', '%0', '#{session_id}\t#{window_id}\t#{pane_id}']).trim().split('\t');
     const [sessionId, windowId, paneId] = identity;
     if (sessionId === undefined || windowId === undefined || paneId === undefined) throw new TypeError('tmux identity fixture is invalid');


### PR DESCRIPTION
## Summary

`task-12-remote-terminal.live.test.ts` touched a readiness file from peer B's pane command and captured the baseline screen immediately. bash prints its prompt only after that touch, so when the prompt landed between the baseline and the final capture the "peer B unchanged" assertion failed with `bash-5.1$` against an empty screen. It failed on #75 (Node 22) and #80 (Node 24) today, both unrelated to the test.

## Change

Wait for peer B's prompt before taking the baseline, so both captures compare settled screens. Test-only.

## Verification

The live test passes locally three times in a row with tmux 3.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)