### PR TITLE
fix(git): reject option-like refs, bound git children, contain worktree reads

### DIFF
--- a/server/routes/git.js
+++ b/server/routes/git.js
@@ -11,30 +11,59 @@ import { spawnCursor } from '../cursor-cli.js';
 
 const router = express.Router();
 const COMMIT_DIFF_CHARACTER_LIMIT = 500_000;
+// A git child that asks for credentials or a pager, or streams an unbounded
+// history, would otherwise hold the request open forever and leak a process.
+const GIT_TIMEOUT_MS = 5 * 60 * 1000;
+const GIT_MAX_OUTPUT_BYTES = 32 * 1024 * 1024;
 
 function spawnAsync(command, args, options = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       ...options,
+      // stdin is never a terminal here: an interactive subcommand (checkout -p,
+      // a credential prompt) must fail instead of waiting on a pipe nobody writes.
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, ...options.env, GIT_TERMINAL_PROMPT: '0', GIT_PAGER: 'cat', PAGER: 'cat' },
       shell: false,
     });
 
     let stdout = '';
     let stderr = '';
+    let settled = false;
+    let outputBytes = 0;
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.kill('SIGKILL');
+      reject(error);
+    };
+    const timer = setTimeout(() => {
+      fail(new Error(`Command timed out after ${GIT_TIMEOUT_MS / 1000}s: ${command} ${args.join(' ')}`));
+    }, GIT_TIMEOUT_MS);
+    const guard = (chunk) => {
+      outputBytes += chunk.length;
+      if (outputBytes > GIT_MAX_OUTPUT_BYTES) fail(new Error(`Command output exceeded ${GIT_MAX_OUTPUT_BYTES} bytes: ${command} ${args.join(' ')}`));
+    };
 
     child.stdout.on('data', (data) => {
+      guard(data);
       stdout += data.toString();
     });
 
     child.stderr.on('data', (data) => {
+      guard(data);
       stderr += data.toString();
     });
 
     child.on('error', (error) => {
-      reject(error);
+      fail(error);
     });
 
     child.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
       if (code === 0) {
         resolve({ stdout, stderr });
         return;
@@ -50,19 +79,32 @@ function spawnAsync(command, args, options = {}) {
 }
 
 // Input validation helpers (defense-in-depth)
-function validateCommitRef(commit) {
-  // Allow hex hashes, HEAD, HEAD~N, HEAD^N, tag names, branch names
-  if (!/^[a-zA-Z0-9._~^{}@\/-]+$/.test(commit)) {
-    throw new Error('Invalid commit reference');
+/**
+ * A value that reaches git as a positional argument must never look like an
+ * option: `-f`, `-p`, `--detach`, `--do-walk`, `--ext-diff` all pass the
+ * character allowlists below and would be honored by `git checkout`, `git
+ * show` and `git branch`.
+ */
+export function assertNotOptionLike(value, label) {
+  if (typeof value !== 'string' || value.startsWith('-')) {
+    throw new Error(`Invalid ${label}`);
   }
-  return commit;
+  return value;
 }
 
-function validateBranchName(branch) {
-  if (!/^[a-zA-Z0-9._\/-]+$/.test(branch)) {
+export function validateCommitRef(commit) {
+  // Allow hex hashes, HEAD, HEAD~N, HEAD^N, tag names, branch names
+  if (typeof commit !== 'string' || !/^[a-zA-Z0-9._~^{}@\/-]+$/.test(commit)) {
+    throw new Error('Invalid commit reference');
+  }
+  return assertNotOptionLike(commit, 'commit reference');
+}
+
+export function validateBranchName(branch) {
+  if (typeof branch !== 'string' || !/^[a-zA-Z0-9._\/-]+$/.test(branch)) {
     throw new Error('Invalid branch name');
   }
-  return branch;
+  return assertNotOptionLike(branch, 'branch name');
 }
 
 function validateFilePath(file, projectPath) {
@@ -81,11 +123,11 @@ function validateFilePath(file, projectPath) {
   return file;
 }
 
-function validateRemoteName(remote) {
-  if (!/^[a-zA-Z0-9._-]+$/.test(remote)) {
+export function validateRemoteName(remote) {
+  if (typeof remote !== 'string' || !/^[a-zA-Z0-9._-]+$/.test(remote)) {
     throw new Error('Invalid remote name');
   }
-  return remote;
+  return assertNotOptionLike(remote, 'remote name');
 }
 
 function validateProjectPath(projectPath) {
@@ -291,6 +333,24 @@ export function selectExactStatusEntry(statusOutput, relativePath) {
     throw new Error(`Refusing to act on "${relativePath}": git reports "${entry.path}" instead.`);
   }
   return entry;
+}
+
+/**
+ * Reads a worktree file for display. The path must sit inside the project both
+ * lexically and after symlink resolution, so a repository whose toplevel is
+ * above the project, or a symlink an agent dropped into it, cannot expose
+ * files outside the project directory. Returns null for a directory.
+ */
+export async function readProjectFileForDisplay(repositoryRootPath, relativePath, projectPath, io = fs) {
+  const absolutePath = resolvePathInsideProject(repositoryRootPath, relativePath, projectPath);
+  const [realFile, realProject] = await Promise.all([io.realpath(absolutePath), io.realpath(path.resolve(projectPath))]);
+  if (realFile !== realProject && !realFile.startsWith(realProject + path.sep)) {
+    throw new Error('Invalid file path: resolves outside the project directory');
+  }
+  const stats = await io.stat(realFile);
+  if (stats.isDirectory()) return null;
+  if (!stats.isFile()) throw new Error('Invalid file path: not a regular file');
+  return io.readFile(realFile, 'utf-8');
 }
 
 /** Absolute location of a repository-relative path, required to sit strictly inside the project. */
@@ -515,14 +575,12 @@ router.get('/diff', async (req, res) => {
     let diff;
     if (isUntracked) {
       // For untracked files, show the entire file content as additions
-      const filePath = path.join(repositoryRootPath, repositoryRelativeFilePath);
-      const stats = await fs.stat(filePath);
+      const fileContent = await readProjectFileForDisplay(repositoryRootPath, repositoryRelativeFilePath, projectPath);
 
-      if (stats.isDirectory()) {
+      if (fileContent === null) {
         // For directories, show a simple message
         diff = `Directory: ${repositoryRelativeFilePath}\n(Cannot show diff for directories)`;
       } else {
-        const fileContent = await fs.readFile(filePath, 'utf-8');
         const lines = fileContent.split('\n');
         diff = `--- /dev/null\n+++ b/${repositoryRelativeFilePath}\n@@ -0,0 +1,${lines.length} @@\n` +
                lines.map(line => `+${line}`).join('\n');
@@ -608,16 +666,15 @@ router.get('/file-with-diff', async (req, res) => {
       oldContent = headContent;
       currentContent = headContent; // Show the deleted content in editor
     } else {
-      // Get current file content
-      const filePath = path.join(repositoryRootPath, repositoryRelativeFilePath);
-      const stats = await fs.stat(filePath);
+      // Get current file content, contained to the project directory
+      const fileContent = await readProjectFileForDisplay(repositoryRootPath, repositoryRelativeFilePath, projectPath);
 
-      if (stats.isDirectory()) {
+      if (fileContent === null) {
         // Cannot show content for directories
         return res.status(400).json({ error: 'Cannot show diff for directories' });
       }
 
-      currentContent = await fs.readFile(filePath, 'utf-8');
+      currentContent = fileContent;
 
       if (!isUntracked) {
         // Get the old content from HEAD for tracked files
@@ -884,7 +941,9 @@ router.post('/checkout', async (req, res) => {
     
     // Checkout the branch
     validateBranchName(branch);
-    const { stdout } = await spawnAsync('git', ['checkout', branch], { cwd: projectPath });
+    // The trailing "--" makes git read the argument as a ref, never as a
+    // pathspec that would restore a same-named file from the index.
+    const { stdout } = await spawnAsync('git', ['checkout', branch, '--'], { cwd: projectPath });
     
     res.json({ success: true, output: stdout });
   } catch (error) {
@@ -926,6 +985,7 @@ router.post('/delete-branch', async (req, res) => {
   try {
     const projectPath = await getActualProjectPath(project);
     await validateGitRepository(projectPath);
+    validateBranchName(branch);
 
     // Safety: cannot delete the currently checked-out branch
     const { stdout: currentBranch } = await spawnAsync('git', ['branch', '--show-current'], { cwd: projectPath });
@@ -1047,7 +1107,7 @@ router.get('/commit-diff', async (req, res) => {
 
     // Get diff for the commit
     const { stdout } = await spawnAsync(
-      'git', ['show', commit],
+      'git', ['show', '--end-of-options', commit],
       { cwd: projectPath }
     );
 
@@ -1104,11 +1164,9 @@ router.post('/generate-commit-message', async (req, res) => {
       for (const file of files) {
         try {
           const { repositoryRelativeFilePath } = await resolveRepositoryFilePath(projectPath, file);
-          const filePath = path.join(repositoryRootPath, repositoryRelativeFilePath);
-          const stats = await fs.stat(filePath);
+          const content = await readProjectFileForDisplay(repositoryRootPath, repositoryRelativeFilePath, projectPath);
 
-          if (!stats.isDirectory()) {
-            const content = await fs.readFile(filePath, 'utf-8');
+          if (content !== null) {
             diffContext += `\n--- ${repositoryRelativeFilePath} (new file) ---\n${content.substring(0, 1000)}\n`;
           } else {
             diffContext += `\n--- ${repositoryRelativeFilePath} (new directory) ---\n`;

--- a/server/routes/git.test.js
+++ b/server/routes/git.test.js
@@ -1,8 +1,16 @@
 import assert from 'node:assert/strict';
+import { promises as fsPromises } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import test from 'node:test';
 
 import {
+  assertNotOptionLike,
   assertSafeRepositoryRelativePath,
+  readProjectFileForDisplay,
+  validateBranchName,
+  validateCommitRef,
+  validateRemoteName,
   normalizeRepositoryRelativeFilePath,
   parseGitLogWithStats,
   parseGitStatusOutput,
@@ -154,4 +162,40 @@ test('resolvePathInsideProject keeps destructive targets strictly inside the pro
   assert.throws(() => resolvePathInsideProject(root, 'other/a.ts', '/repo/app'), /outside the project directory/, 'a sibling directory under the same toplevel is off limits');
   assert.throws(() => resolvePathInsideProject(root, 'app', '/repo/app'), /outside the project directory/, 'the project directory itself is never a target');
   assert.throws(() => resolvePathInsideProject(root, 'application/a.ts', '/repo/app'), /outside the project directory/, 'prefix collisions do not count as inside');
+});
+
+test('ref-like git arguments never start like an option', () => {
+  for (const bad of ['-f', '-p', '--detach', '--do-walk', '--ext-diff', '-']) {
+    assert.throws(() => validateBranchName(bad), /Invalid branch name/, `branch ${bad}`);
+    assert.throws(() => validateCommitRef(bad), /Invalid commit reference/, `commit ${bad}`);
+    assert.throws(() => validateRemoteName(bad), /Invalid remote name/, `remote ${bad}`);
+  }
+  assert.equal(validateBranchName('feature/x-1'), 'feature/x-1');
+  assert.equal(validateCommitRef('HEAD~2'), 'HEAD~2');
+  assert.equal(validateCommitRef('v1.8.15'), 'v1.8.15');
+  assert.equal(validateRemoteName('origin'), 'origin');
+  assert.throws(() => validateBranchName(42), /Invalid branch name/);
+  assert.throws(() => assertNotOptionLike('--force', 'thing'), /Invalid thing/);
+});
+
+test('readProjectFileForDisplay stays inside the project after symlink resolution', async () => {
+  const root = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'git-read-'));
+  const project = path.join(root, 'repo', 'app');
+  const outside = path.join(root, 'secret.txt');
+  try {
+    await fsPromises.mkdir(path.join(project, 'src'), { recursive: true });
+    await fsPromises.writeFile(path.join(project, 'src', 'a.txt'), 'inside');
+    await fsPromises.writeFile(outside, 'outside');
+    await fsPromises.symlink(outside, path.join(project, 'escape.txt'));
+    await fsPromises.writeFile(path.join(root, 'repo', 'sibling.txt'), 'sibling');
+    const toplevel = path.join(root, 'repo');
+
+    assert.equal(await readProjectFileForDisplay(toplevel, 'app/src/a.txt', project), 'inside');
+    assert.equal(await readProjectFileForDisplay(toplevel, 'app/src', project), null, 'directories yield null');
+    await assert.rejects(readProjectFileForDisplay(toplevel, 'app/escape.txt', project), /outside the project directory/, 'a symlink out of the project is refused');
+    await assert.rejects(readProjectFileForDisplay(toplevel, 'sibling.txt', project), /outside the project directory/, 'a sibling under the same toplevel is refused');
+    await assert.rejects(readProjectFileForDisplay(toplevel, 'app/missing.txt', project), /ENOENT/);
+  } finally {
+    await fsPromises.rm(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary

First Medium batch from the review, all in `server/routes/git.js`.

1. **Option-like refs.** `validateBranchName`, `validateCommitRef` and `validateRemoteName` accepted a leading `-`. Verified consequences: `POST /api/git/checkout` with `branch: "-f"` discards every local modification; `-p` starts interactive patch mode and hangs on the never-closed stdin pipe; `GET /api/git/commit-diff` with `commit: "--do-walk"` buffers the whole history into one string; `--ext-diff` runs configured diff drivers. Ref-like arguments now reject anything starting with `-`, `git show` gets `--end-of-options` (git 2.43 honors it there but not on `checkout`), checkout passes a trailing `--` so the argument is read as a ref and never as a pathspec that restores a same-named file, and `delete-branch` validates its input at all.
2. **Child process bounds.** `spawnAsync` inherited a stdin pipe, had no timeout, no output cap, and let git prompt for credentials or a pager. A `fetch`/`pull`/`push` against a remote that needs credentials could hold the request open forever and leak a process. It now ignores stdin, sets `GIT_TERMINAL_PROMPT=0` and a plain pager, and kills the child after 5 minutes or 32 MiB of output with a clear error.
3. **Worktree read containment.** `diff`, `file-with-diff` and the commit-message preview read files by `path.join(toplevel, rel)` without a realpath check. `validateGitRepository` accepts any directory inside a worktree, so the toplevel can sit above the project (a dotfiles repository in `$HOME`), and symlinks an agent dropped into the project were followed. `readProjectFileForDisplay` now requires the path to sit inside the project both lexically and after realpath, returns null for directories, and refuses non-regular files.

## Verification

- `server/routes/git.test.js`: option-like values rejected for all three validators; `readProjectFileForDisplay` accepts a project file, yields null for a directory, refuses a symlink pointing outside the project and a sibling directory under the same toplevel (13 pass)
- Scratch repository: `git checkout <ref> --` switches branches; `git show --end-of-options --do-walk` is refused while `git show --end-of-options HEAD` works
- `eslint` on touched files, `tsc --noEmit -p server/tsconfig.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
