### PR TITLE
fix(fleet): bound pre-auth input, keep the replay guard alive, protect attach

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -314,6 +314,12 @@ app.use('/api/auth', express.json({
     type: (req) => (req.headers['content-type'] || '').includes('json')
 }));
 app.use('/api/auth', express.urlencoded({ limit: '64kb', extended: true }));
+// Machine pairing endpoints are reachable without browser auth and carry a
+// signed identity plus a token; they never need the upload budget below.
+app.use('/api/fleet/pairing', express.json({
+    limit: '64kb',
+    type: (req) => (req.headers['content-type'] || '').includes('json')
+}));
 
 app.use(express.json({
     limit: '50mb',

--- a/server/modules/fleet/hub/connection/websocket-dialer.ts
+++ b/server/modules/fleet/hub/connection/websocket-dialer.ts
@@ -1,11 +1,13 @@
 import { WebSocket, type RawData } from 'ws';
 
+import { FLEET_MAX_FRAME_BYTES } from '../../protocol/codec.js';
+
 import type { HubPeerSocket } from './types.js';
 
 const MAX_BUFFERED_BYTES = 64 * 1024;
 
 export function dialFleetWebSocket(target: URL): HubPeerSocket {
-  const socket = new WebSocket(target, { followRedirects: false, perMessageDeflate: false });
+  const socket = new WebSocket(target, { followRedirects: false, perMessageDeflate: false, maxPayload: FLEET_MAX_FRAME_BYTES });
   return {
     onOpen: (listener) => { socket.on('open', listener); },
     onMessage: (listener) => {

--- a/server/modules/fleet/peer/endpoint.ts
+++ b/server/modules/fleet/peer/endpoint.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../../../shared/fleet.js';
 import { FleetChallengeReplayGuard } from '../protocol/auth.js';
 import type { FleetWritableTransport } from '../protocol/bounded-writer.js';
+import { FLEET_MAX_FRAME_BYTES } from '../protocol/codec.js';
 import { FleetProtocolConnection } from '../protocol/connection.js';
 import type { FleetProtocolConnectionOptions } from '../protocol/connection-types.js';
 import { validateFleetUpgrade } from '../protocol/transport-policy.js';
@@ -46,7 +47,9 @@ export function createFleetPeerEndpoint(options: FleetPeerEndpointOptions): Read
   /** Closes every live hub connection after the local grant was revoked. */
   readonly revokeConnections: () => void;
 }> {
-  const wss = new WebSocketServer({ noServer: true });
+  // ws would otherwise assemble up to 100 MiB per message before the codec's
+  // 64 KiB check runs, and /fleet-ws needs no credentials to upgrade.
+  const wss = new WebSocketServer({ noServer: true, maxPayload: FLEET_MAX_FRAME_BYTES });
   const replayGuard = new FleetChallengeReplayGuard();
   const connections = new Set<FleetProtocolConnection>();
   const catalogReleases = new Map<FleetProtocolConnection, () => void>();
@@ -75,6 +78,13 @@ export function createFleetPeerEndpoint(options: FleetPeerEndpointOptions): Read
       },
     });
     connections.add(connection);
+    // ws reports a payload over maxPayload (and transport faults) as an 'error'
+    // event before closing; without a listener Node would throw it as an
+    // unhandled error event and take the process down.
+    socket.on('error', (error: Error) => {
+      console.warn(`[Fleet Peer] Socket error, closing: ${error.message}`);
+      connection.stop();
+    });
     socket.on('message', (raw: RawData) => { void connection.receive(raw); });
     socket.on('close', () => {
       catalogReleases.get(connection)?.(); catalogReleases.delete(connection); connection.stop(); connections.delete(connection);

--- a/server/modules/fleet/protocol/auth.ts
+++ b/server/modules/fleet/protocol/auth.ts
@@ -169,13 +169,27 @@ export class FleetAuthDeadline {
   }
 }
 
+/**
+ * Remembers recently accepted challenge ids so an identical proof cannot be
+ * accepted twice. The set is a bounded window of the newest ids: an endpoint
+ * that reaches capacity forgets the oldest entry rather than refusing every
+ * later handshake, which a flaky link or a laptop that sleeps would otherwise
+ * trigger after a few thousand reconnects. Replay of an old id past the window
+ * is still impossible because both fresh nonces are part of the signed
+ * transcript.
+ */
 export class FleetChallengeReplayGuard {
   private readonly seen = new Set<string>();
 
   constructor(private readonly capacity = 4_096) {}
 
   reserve(challengeId: string): boolean {
-    if (this.seen.has(challengeId) || this.seen.size >= this.capacity) return false;
+    if (this.seen.has(challengeId)) return false;
+    while (this.seen.size >= this.capacity) {
+      const oldest = this.seen.values().next().value;
+      if (oldest === undefined) break;
+      this.seen.delete(oldest);
+    }
     this.seen.add(challengeId);
     return true;
   }

--- a/server/modules/fleet/terminal/local-peer.ts
+++ b/server/modules/fleet/terminal/local-peer.ts
@@ -9,18 +9,35 @@ import {
 import type { FleetPaneReference } from '../../../../shared/fleet.js';
 import type { TmuxPaneIdentity } from '../../../../shared/tmux.js';
 
-import type { RemoteTerminalProcess } from './peer.js';
+import { RemoteTerminalPeerError, type RemoteTerminalProcess } from './peer.js';
 
-async function verify(target: FleetPaneReference): Promise<VerifiedTmuxActionTarget> {
+export type LocalTerminalVerifiers = Readonly<{
+  readonly external?: typeof assertFreshExternalTmuxTarget;
+  readonly live?: typeof assertLineageTmuxTarget;
+}>;
+
+/**
+ * Attach plus input is a raw keyboard, so the same `company*` protection that
+ * local attach and fleet mutations enforce applies here; otherwise a hub could
+ * Ctrl-C a protected agent the interrupt path refuses to touch.
+ */
+export function assertNotProtectedTerminalTarget(target: VerifiedTmuxActionTarget): VerifiedTmuxActionTarget {
+  if ((target.tmuxName ?? '').toLowerCase().startsWith('company')) {
+    throw new RemoteTerminalPeerError('FLEET_UNAUTHORIZED', 'tmux target is protected');
+  }
+  return target;
+}
+
+async function verify(target: FleetPaneReference, verifiers: LocalTerminalVerifiers = {}): Promise<VerifiedTmuxActionTarget> {
   switch (target.lane) {
-    case 'external': return assertFreshExternalTmuxTarget(target.tmux, target.process);
-    case 'live': return assertLineageTmuxTarget(target.tmux, target.process);
+    case 'external': return assertNotProtectedTerminalTarget(await (verifiers.external ?? assertFreshExternalTmuxTarget)(target.tmux, target.process));
+    case 'live': return assertNotProtectedTerminalTarget(await (verifiers.live ?? assertLineageTmuxTarget)(target.tmux, target.process));
     default: throw new TypeError('remote terminal lane is invalid');
   }
 }
 
-export async function verifyLocalRemoteTerminalTarget(target: FleetPaneReference): Promise<FleetPaneReference> {
-  await verify(target);
+export async function verifyLocalRemoteTerminalTarget(target: FleetPaneReference, verifiers: LocalTerminalVerifiers = {}): Promise<FleetPaneReference> {
+  await verify(target, verifiers);
   return target;
 }
 
@@ -42,6 +59,6 @@ export function attachVerifiedLocalTmuxTerminal(verified: Readonly<{ readonly tm
   };
 }
 
-export async function spawnLocalRemoteTerminal(target: FleetPaneReference, cols: number, rows: number): Promise<RemoteTerminalProcess> {
-  return attachVerifiedLocalTmuxTerminal(await verify(target), cols, rows);
+export async function spawnLocalRemoteTerminal(target: FleetPaneReference, cols: number, rows: number, verifiers: LocalTerminalVerifiers = {}): Promise<RemoteTerminalProcess> {
+  return attachVerifiedLocalTmuxTerminal(await verify(target, verifiers), cols, rows);
 }

--- a/server/modules/fleet/tests/fleet-protocol-auth.test.ts
+++ b/server/modules/fleet/tests/fleet-protocol-auth.test.ts
@@ -3,6 +3,7 @@ import { generateKeyPairSync, randomUUID, sign, type KeyObject } from 'node:cryp
 import test from 'node:test';
 
 import {
+  FleetChallengeReplayGuard,
   createFleetHello,
   createFleetProof,
   FleetAuthDeadline,
@@ -122,4 +123,16 @@ test('Given unknown or revoked installation trust, when auth admission runs, the
     () => requireAuthorizedFleetPeer(revoked, randomUUID()),
     (error: unknown) => error instanceof Error && !error.message.includes('sensitive-key'),
   );
+});
+
+test('the challenge replay guard refuses repeats but keeps accepting fresh ids past its window', () => {
+  const guard = new FleetChallengeReplayGuard(3);
+  assert.equal(guard.reserve('c1'), true);
+  assert.equal(guard.reserve('c1'), false, 'an identical challenge is a replay');
+  assert.equal(guard.reserve('c2'), true);
+  assert.equal(guard.reserve('c3'), true);
+  assert.equal(guard.reserve('c4'), true, 'capacity evicts the oldest id instead of refusing the handshake');
+  assert.equal(guard.reserve('c4'), false);
+  assert.equal(guard.reserve('c3'), false, 'recent ids stay remembered');
+  for (let index = 0; index < 10_000; index += 1) assert.equal(guard.reserve(`later-${index}`), true, `reconnect ${index} is still accepted`);
 });

--- a/server/modules/fleet/tests/security/task-22-live-denials.test.ts
+++ b/server/modules/fleet/tests/security/task-22-live-denials.test.ts
@@ -195,7 +195,7 @@ test('Given an authenticated link, when oversized or malformed frames arrive, th
   // An oversized message never reaches the codec: ws enforces the frame bound
   // before assembly and closes with its own status, so nothing past 64 KiB is
   // ever buffered for an authenticated peer either.
-  const tooLarge = { code: 1009, reason: 'Max payload size exceeded' };
+  const tooLarge = { code: 1009, reason: '' };
   const cases: ReadonlyArray<Readonly<{ name: string; payload: (generation: number) => string | Buffer; close: typeof rejected }>> = [
     { name: 'oversized', payload: () => Buffer.alloc(FLEET_MAX_FRAME_BYTES + 1), close: tooLarge },
     { name: 'not-json', payload: () => 'this-is-not-json{', close: rejected },

--- a/server/modules/fleet/tests/security/task-22-live-denials.test.ts
+++ b/server/modules/fleet/tests/security/task-22-live-denials.test.ts
@@ -191,11 +191,16 @@ test('Given browser upgrade metadata, when the fleet endpoint is dialed, then th
 test('Given an authenticated link, when oversized or malformed frames arrive, then the socket closes and dispatch stays zero', async (context) => {
   // Given
   const world = await startWorld(context);
-  const cases: ReadonlyArray<Readonly<{ name: string; payload: (generation: number) => string | Buffer }>> = [
-    { name: 'oversized', payload: () => Buffer.alloc(FLEET_MAX_FRAME_BYTES + 1) },
-    { name: 'not-json', payload: () => 'this-is-not-json{' },
-    { name: 'unknown-kind', payload: () => JSON.stringify({ kind: 'mystery' }) },
-    { name: 'extra-field', payload: (generation) => JSON.stringify({ kind: 'request', protocolVersion: 'fleet/1', connectionGeneration: generation, requestId: 'x', operation: 'catalog.snapshot', target: { kind: 'host', hostId: world.a.hostId }, body: null, extra: true }) },
+  const rejected = { code: 4002, reason: 'fleet protocol rejected' };
+  // An oversized message never reaches the codec: ws enforces the frame bound
+  // before assembly and closes with its own status, so nothing past 64 KiB is
+  // ever buffered for an authenticated peer either.
+  const tooLarge = { code: 1009, reason: 'Max payload size exceeded' };
+  const cases: ReadonlyArray<Readonly<{ name: string; payload: (generation: number) => string | Buffer; close: typeof rejected }>> = [
+    { name: 'oversized', payload: () => Buffer.alloc(FLEET_MAX_FRAME_BYTES + 1), close: tooLarge },
+    { name: 'not-json', payload: () => 'this-is-not-json{', close: rejected },
+    { name: 'unknown-kind', payload: () => JSON.stringify({ kind: 'mystery' }), close: rejected },
+    { name: 'extra-field', payload: (generation) => JSON.stringify({ kind: 'request', protocolVersion: 'fleet/1', connectionGeneration: generation, requestId: 'x', operation: 'catalog.snapshot', target: { kind: 'host', hostId: world.a.hostId }, body: null, extra: true }), close: rejected },
   ];
   for (const entry of cases) {
     // When: each hostile frame crosses an authenticated real socket.
@@ -204,11 +209,11 @@ test('Given an authenticated link, when oversized or malformed frames arrive, th
     const closed = session.link.closed();
     session.link.sendRaw(entry.payload(session.generation));
     // Then: the connection fails closed with the redacted reason.
-    assert.deepEqual(await closed, { code: 4002, reason: 'fleet protocol rejected' }, entry.name);
+    assert.deepEqual(await closed, entry.close, entry.name);
   }
   assert.deepEqual(world.a.chain.dispatchLog, []);
   assert.deepEqual(world.a.chain.actionLog, []);
-  recordTrace({ case: 'live.oversized-malformed-frames', surface: 'websocket', request: 'oversized/not-json/unknown-kind/extra-field frames', outcome: 'close 4002 fleet protocol rejected x4', sideEffects: 'dispatch=0 actions=0' });
+  recordTrace({ case: 'live.oversized-malformed-frames', surface: 'websocket', request: 'oversized/not-json/unknown-kind/extra-field frames', outcome: 'close 1009 max payload (oversized) + close 4002 fleet protocol rejected x3', sideEffects: 'dispatch=0 actions=0' });
 });
 
 test('Given a catalog-only peer, when a chat mutation arrives, then capability denial precedes dispatch', async (context) => {

--- a/server/modules/fleet/tests/task-12-remote-terminal-protection.test.ts
+++ b/server/modules/fleet/tests/task-12-remote-terminal-protection.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createVerifiedTmuxActionTarget } from '@/modules/providers/index.js';
+
+import { RemoteTerminalPeerError } from '../terminal/peer.js';
+import { verifyLocalRemoteTerminalTarget } from '../terminal/local-peer.js';
+
+const HOST = '123e4567-e89b-42d3-a456-426614174000';
+const tmux = { socketPath: '/tmp/tmux-1000/default', sessionId: '$1', windowId: '@1', paneId: '%1' } as const;
+const process = { pid: 42, startedAtMs: 100 } as const;
+const reference = { kind: 'pane', hostId: HOST, localId: 'pane-1', lane: 'external', tmux, process } as const;
+
+test('fleet terminal attach refuses a protected company* pane like local attach and fleet mutations do', async () => {
+  const verifiers = {
+    external: async () => createVerifiedTmuxActionTarget(tmux, process, 'codex', 'company-ops', null),
+    live: async () => createVerifiedTmuxActionTarget(tmux, process, 'gjc', 'company-ops', null),
+  };
+  await assert.rejects(verifyLocalRemoteTerminalTarget(reference, verifiers), (error: unknown) => error instanceof RemoteTerminalPeerError && error.code === 'FLEET_UNAUTHORIZED');
+  await assert.rejects(verifyLocalRemoteTerminalTarget({ ...reference, lane: 'live' }, verifiers), (error: unknown) => error instanceof RemoteTerminalPeerError && error.code === 'FLEET_UNAUTHORIZED');
+
+  const plain = {
+    external: async () => createVerifiedTmuxActionTarget(tmux, process, 'codex', 'agent-1', null),
+    live: async () => createVerifiedTmuxActionTarget(tmux, process, 'gjc', 'agent-1', null),
+  };
+  assert.deepEqual(await verifyLocalRemoteTerminalTarget(reference, plain), reference);
+});

--- a/server/modules/fleet/tests/task-12-remote-terminal-protection.test.ts
+++ b/server/modules/fleet/tests/task-12-remote-terminal-protection.test.ts
@@ -1,27 +1,32 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { createVerifiedTmuxActionTarget } from '@/modules/providers/index.js';
+import { assertFreshExternalTmuxTarget, assertLineageTmuxTarget } from '@/modules/providers/index.js';
 
 import { RemoteTerminalPeerError } from '../terminal/peer.js';
 import { verifyLocalRemoteTerminalTarget } from '../terminal/local-peer.js';
 
 const HOST = '123e4567-e89b-42d3-a456-426614174000';
 const tmux = { socketPath: '/tmp/tmux-1000/default', sessionId: '$1', windowId: '@1', paneId: '%1' } as const;
-const process = { pid: 42, startedAtMs: 100 } as const;
-const reference = { kind: 'pane', hostId: HOST, localId: 'pane-1', lane: 'external', tmux, process } as const;
+const generation = { pid: 42, startedAtMs: 100 } as const;
+const reference = { kind: 'pane', hostId: HOST, localId: 'pane-1', lane: 'external', tmux, process: generation } as const;
+
+/** Verifiers backed by an injected roster: the real gates run, only discovery is replaced. */
+function verifiersFor(tmuxName: string) {
+  const external = { kind: 'codex', tmux, tmuxName, agentPid: generation.pid, startedAtMs: generation.startedAtMs, connectionIssue: null, providerSessionId: null } as never;
+  const live = { id: 'live-1', tmux, tmuxName, claim: 'lineage', process: generation, connectionIssue: null } as never;
+  return {
+    external: (tmuxValue: unknown, processValue: unknown) => assertFreshExternalTmuxTarget(tmuxValue, processValue, { scan: async () => [external], assertPaneIdentity: async () => {} }),
+    live: (tmuxValue: unknown, processValue: unknown) => assertLineageTmuxTarget(tmuxValue as typeof tmux, processValue as typeof generation, async () => [live], async () => {}),
+  };
+}
 
 test('fleet terminal attach refuses a protected company* pane like local attach and fleet mutations do', async () => {
-  const verifiers = {
-    external: async () => createVerifiedTmuxActionTarget(tmux, process, 'codex', 'company-ops', null),
-    live: async () => createVerifiedTmuxActionTarget(tmux, process, 'gjc', 'company-ops', null),
-  };
-  await assert.rejects(verifyLocalRemoteTerminalTarget(reference, verifiers), (error: unknown) => error instanceof RemoteTerminalPeerError && error.code === 'FLEET_UNAUTHORIZED');
-  await assert.rejects(verifyLocalRemoteTerminalTarget({ ...reference, lane: 'live' }, verifiers), (error: unknown) => error instanceof RemoteTerminalPeerError && error.code === 'FLEET_UNAUTHORIZED');
+  const protectedPane = verifiersFor('company-ops');
+  await assert.rejects(verifyLocalRemoteTerminalTarget(reference, protectedPane), (error: unknown) => error instanceof RemoteTerminalPeerError && error.code === 'FLEET_UNAUTHORIZED');
+  await assert.rejects(verifyLocalRemoteTerminalTarget({ ...reference, lane: 'live' }, protectedPane), (error: unknown) => error instanceof RemoteTerminalPeerError && error.code === 'FLEET_UNAUTHORIZED');
 
-  const plain = {
-    external: async () => createVerifiedTmuxActionTarget(tmux, process, 'codex', 'agent-1', null),
-    live: async () => createVerifiedTmuxActionTarget(tmux, process, 'gjc', 'agent-1', null),
-  };
+  const plain = verifiersFor('agent-1');
   assert.deepEqual(await verifyLocalRemoteTerminalTarget(reference, plain), reference);
+  assert.deepEqual(await verifyLocalRemoteTerminalTarget({ ...reference, lane: 'live' }, plain), { ...reference, lane: 'live' });
 });

--- a/server/modules/fleet/tests/task-7-peer-endpoint-live.test.ts
+++ b/server/modules/fleet/tests/task-7-peer-endpoint-live.test.ts
@@ -164,3 +164,31 @@ test('Given a live peer endpoint, when authenticated requests are allowed or mal
   assert.equal(localCalls, 1);
   assert.equal(trustLookups, 2);
 });
+
+test('Given a live peer endpoint, when an unauthenticated client sends a message over the frame bound, then ws closes it before assembly', async (context) => {
+  const peer = identity();
+  const server = createServer();
+  const endpoint = createFleetPeerEndpoint({
+    server,
+    browserUpgradeListeners: [],
+    local: { role: 'peer', signer: peer.signer, processEpoch: 'peer-epoch', capabilities: ['catalog.read'], transportMode: 'direct-wss' },
+    trust: { find: async () => undefined },
+    registry: new FleetConnectionRegistry(new Generations()),
+    dispatch: createPeerOperationDispatcher(peer.signer.installationId, {}),
+  });
+  endpoint.start();
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (address === null || typeof address === 'string') throw new TypeError('test server address is unavailable');
+  const socket = new WebSocket(`ws://127.0.0.1:${address.port}/fleet-ws`);
+  context.after(async () => {
+    socket.terminate();
+    await endpoint.stop();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+  await once(socket, 'open');
+  const closed = once(socket, 'close');
+  socket.send('x'.repeat(64 * 1024 + 1));
+  const [code] = await bounded(closed, 'oversized frame close') as [number];
+  assert.equal(code, 1009, 'the payload bound is enforced by ws itself, so nothing is buffered past 64 KiB before authentication');
+});

--- a/server/modules/providers/index.ts
+++ b/server/modules/providers/index.ts
@@ -45,7 +45,6 @@ export {
   type CurrentTmuxPaneIdentity,
 } from './services/external-cli-sessions.service.js';
 export {
-  createVerifiedTmuxActionTarget,
   assertFreshExternalTmuxTarget,
   type VerifiedTmuxActionTarget,
 } from './services/tmux-fresh-verifier.service.js';

--- a/server/modules/providers/index.ts
+++ b/server/modules/providers/index.ts
@@ -45,6 +45,7 @@ export {
   type CurrentTmuxPaneIdentity,
 } from './services/external-cli-sessions.service.js';
 export {
+  createVerifiedTmuxActionTarget,
   assertFreshExternalTmuxTarget,
   type VerifiedTmuxActionTarget,
 } from './services/tmux-fresh-verifier.service.js';


### PR DESCRIPTION
## Summary

Third Medium batch: four findings on the fleet edge.

1. **Replay guard lifetime cap.** `FleetChallengeReplayGuard` refused every handshake once 4,096 challenge ids had been seen in the process lifetime, so a flaky link or a sleeping laptop eventually locked a hub out until the peer restarted. It is now a bounded window of the newest ids that evicts the oldest instead of refusing. Replay of an old id past the window stays impossible because both fresh nonces are part of the signed transcript.
2. **`maxPayload` on both sockets.** The peer `WebSocketServer` and the hub dialer used ws's 100 MiB default, so a message was fully assembled before the codec's 64 KiB check ran, and `/fleet-ws` needs no credentials to upgrade. Both now stop at `FLEET_MAX_FRAME_BYTES`. The peer socket also handles the `'error'` event ws emits on an oversized frame; the live test showed that without a listener Node throws it as an unhandled error event.
3. **Pairing body budget.** `/api/fleet/pairing/*` is reachable without browser auth and was served by the global 50 MB JSON parser; it now gets the 64 KB parser like `/api/auth`.
4. **Attach protection.** `verifyLocalRemoteTerminalTarget` skipped the `company*` protection that local attach (`shell-websocket.service.ts`) and fleet mutations (`rpc/mutations/local-services.ts`) enforce. Attach plus `pane.input` is a raw keyboard, so a hub could Ctrl-C a protected agent the interrupt path refuses to touch. The verifier now rejects protected panes with `FLEET_UNAUTHORIZED`, and the two verifier calls are injectable for tests.

## Verification

- `fleet-protocol-auth.test.ts`: the guard refuses repeats, evicts the oldest id at capacity, and keeps accepting 10,000 later handshakes
- `task-7-peer-endpoint-live.test.ts`: an unauthenticated client sending 64 KiB + 1 byte is closed with 1009 before assembly, and the process survives
- `task-12-remote-terminal-protection.test.ts` (new): `company*` panes are refused on both lanes; ordinary panes pass
- Full fleet suite excluding tmux-backed e2e: 178 pass. `tsc --noEmit -p server/tsconfig.json`, `eslint` on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
