### PR TITLE
fix(update): gate incompatible releases early, retry the state lock, reconcile on demand

### DIFF
--- a/server/release-update-state.test.ts
+++ b/server/release-update-state.test.ts
@@ -302,3 +302,31 @@ test('manual_required and failed_rollback records are exempt from count pruning 
     for (let index = 1; index <= UPDATE_STATE_TERMINAL_CAP + 2; index += 1) assert.ok(store.get(id(index)));
   } finally { cleanup(directory); }
 });
+
+test('a live lock holder is waited out with bounded retries instead of failing the caller', () => {
+  const stateRoot = root();
+  let contended = 3;
+  const sleeps: number[] = [];
+  const contendingFs = new Proxy(fs, {
+    get(target, property, receiver) {
+      if (property === 'openSync') {
+        return (filePath: string, flags: string) => {
+          if (flags === 'wx' && filePath.endsWith('release-update-state.lock') && contended > 0) {
+            contended -= 1;
+            const error = new Error('EEXIST: file already exists') as NodeJS.ErrnoException; error.code = 'EEXIST'; throw error;
+          }
+          return fs.openSync(filePath, flags);
+        };
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  }) as typeof fs;
+  const state = new ReleaseUpdateStateStore(stateRoot, { fs: contendingFs as never, now: () => 10, isProcessAlive: () => true, sleepMs: (ms) => { sleeps.push(ms); } });
+  state.initialize();
+  assert.deepEqual(sleeps, [50, 50, 50], 'three contended attempts, three short waits, then success');
+  assert.equal(state.publicActiveStatus(), null);
+
+  contended = Number.POSITIVE_INFINITY;
+  assert.throws(() => state.publicActiveStatus(), /locked or unavailable/, 'a holder that never releases is still reported, after the bounded wait');
+  assert.ok(sleeps.length >= 3 + 39, 'the bounded wait ran to its limit');
+});

--- a/server/release-update-state.ts
+++ b/server/release-update-state.ts
@@ -66,6 +66,8 @@ export interface ReleaseUpdateStateStoreOptions {
   fs?: StateFileSystem;
   now?: () => number;
   isProcessAlive?: (pid: number) => boolean;
+  /** Test seam for the synchronous lock wait. */
+  sleepMs?: (milliseconds: number) => void;
 }
 
 export class ReleaseUpdateStateError extends Error {}
@@ -116,6 +118,13 @@ function parseState(text: string): PersistedState {
   return { schemaVersion: 1, jobs };
 }
 
+const LOCK_RETRY_ATTEMPTS = 40;
+const LOCK_RETRY_INTERVAL_MS = 50;
+/** Synchronous wait for the synchronous store; contention holds are milliseconds long. */
+function blockingSleep(milliseconds: number): void {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, milliseconds);
+}
+
 /** A small synchronous store: every externally visible mutation is a durable atomic replace. */
 export class ReleaseUpdateStateStore {
   private readonly fs: StateFileSystem;
@@ -124,6 +133,7 @@ export class ReleaseUpdateStateStore {
   private readonly allocatorPath: string;
   private readonly lockPath: string;
   private readonly isProcessAlive: (pid: number) => boolean;
+  private readonly sleepMs: (milliseconds: number) => void;
   private readonly progressPath: string;
 
   constructor(private readonly root: string, options: ReleaseUpdateStateStoreOptions = {}) {
@@ -132,6 +142,7 @@ export class ReleaseUpdateStateStore {
     this.isProcessAlive = options.isProcessAlive ?? ((pid) => {
       try { process.kill(pid, 0); return true; } catch (error) { return !(error && typeof error === 'object' && 'code' in error && error.code === 'ESRCH'); }
     });
+    this.sleepMs = options.sleepMs ?? blockingSleep;
     this.statePath = path.join(root, 'release-update-state.json');
     this.allocatorPath = path.join(root, 'release-update-completion-ordinal.json');
     this.lockPath = path.join(root, 'release-update-state.lock');
@@ -374,14 +385,20 @@ export class ReleaseUpdateStateStore {
 
   private withExclusiveLock<T>(operation: () => T): T {
     this.ensureSafeRoot();
-    let fd: number;
-    try {
-      fd = this.fs.openSync(this.lockPath, 'wx');
-    } catch {
-      if (!this.recoverDeadLock()) throw new ReleaseUpdateStateError('Update state is locked or unavailable.');
-      try { fd = this.fs.openSync(this.lockPath, 'wx'); }
-      catch { throw new ReleaseUpdateStateError('Update state is locked or unavailable.'); }
+    // The server's status poll and the worker's transitions contend for this
+    // lock for milliseconds at a time. A live holder is waited out for a
+    // bounded interval rather than reported as a failure, which after cutover
+    // would roll back a healthy release.
+    let fd: number | undefined;
+    for (let attempt = 0; attempt < LOCK_RETRY_ATTEMPTS && fd === undefined; attempt += 1) {
+      try {
+        fd = this.fs.openSync(this.lockPath, 'wx');
+      } catch {
+        if (this.recoverDeadLock()) continue;
+        if (attempt + 1 < LOCK_RETRY_ATTEMPTS) this.sleepMs(LOCK_RETRY_INTERVAL_MS);
+      }
     }
+    if (fd === undefined) throw new ReleaseUpdateStateError('Update state is locked or unavailable.');
     try {
       try { this.fs.writeFileSync(this.lockPath, `${process.pid}\n`, { encoding: 'utf8', mode: 0o600, flag: 'w' }); }
       catch (error) { throw new ReleaseUpdateStateError(`Unable to persist update state lock: ${error instanceof Error ? error.message : 'unknown error'}`); }

--- a/server/release-update-worker.ts
+++ b/server/release-update-worker.ts
@@ -27,7 +27,10 @@ const REQUEST_TIMEOUT_MS = 300_000;
 const PROCESS_TIMEOUT_MS = 120_000;
 const MAX_PROCESS_STDOUT_BYTES = 16 * 1024 * 1024;
 const MAX_PROCESS_STDERR_BYTES = 1 * 1024 * 1024;
-const HEALTH_ATTEMPTS = 12;
+// A fresh release runs schema migrations and loads native modules on first
+// boot; the installer allows 30 s and deploy.sh 60 s, and a miss here rolls
+// back and deletes the download. Poll for 90 s before giving up.
+const HEALTH_ATTEMPTS = 90;
 const HEALTH_INTERVAL_MS = 1_000;
 const HEALTH_REQUEST_TIMEOUT_MS = 5_000;
 const RELEASE_HOSTS = new Set(['github.com', 'objects.githubusercontent.com', 'release-assets.githubusercontent.com']);

--- a/server/self-update.test.ts
+++ b/server/self-update.test.ts
@@ -51,7 +51,9 @@ function releaseJob(index: number): ImmutableUpdateJobDescriptor {
   return {
     id, createdAt: 1, installMode: 'release', sourceVersion: '1.0.0', sourceBootId: 'boot', serverPort: 3000,
     release: { repository: 'devswha/chatmux', tag: `v${version}`, version, archiveName, checksumName: `${archiveName}.sha256`, bootstrapName: 'install.sh', archiveSha256: 'a'.repeat(64), publishedAt: '2026-01-01T00:00:00.000Z' },
-    compatibility: { database: { rollbackCompatibleFrom: [] } },
+    // The running version in these tests is 1.0.0; a target must name it as
+    // rollback-compatible or the router refuses it before any download.
+    compatibility: { database: { rollbackCompatibleFrom: ['1.0.0'] } },
   };
 }
 
@@ -920,4 +922,81 @@ test('the release worker is launched with the bound address to probe, wildcards 
   assert.ok(args.includes('--setenv=SERVER_PORT=3001'));
   assert.ok(buildReleaseSystemdRunArgs('u', '/w.js', 'abcdefghijklmnopqrstuv', '/home/u', 3001, '/usr/bin', '0.0.0.0').includes('--setenv=CHATMUX_HEALTH_HOST=127.0.0.1'));
   assert.ok(buildReleaseSystemdRunArgs('u', '/w.js', 'abcdefghijklmnopqrstuv', '/home/u', 3001, '/usr/bin').includes('--setenv=CHATMUX_HEALTH_HOST=127.0.0.1'), 'callers without a bind address keep the loopback probe');
+});
+
+test('release status and start refuse a target that does not declare rollback compatibility from the running version', async () => {
+  const home = tempRoot();
+  const state = new ReleaseUpdateStateStore(path.join(home, '.chatmux', 'update'), { now: () => 1 });
+  let launches = 0;
+  const incompatible = { ...releaseJob(9), compatibility: { database: { rollbackCompatibleFrom: ['1.0.8'] } } };
+  const app = express();
+  app.use((req, _res, next) => { (req as any).user = {}; next(); });
+  app.use(exactUpdateRequestGuard);
+  app.use(createSystemRouter({
+    appRoot: home, home, serverPort: 3000, bootId: 'boot', runningVersion: '1.0.0', mode: 'release', authMode: 'password', state, now: () => 1,
+    discoverRelease: async () => ({ release: incompatible.release, compatibility: incompatible.compatibility, notes: { body: null, url: null } }),
+    launchRelease: async () => { launches += 1; },
+  }));
+  const server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  assert.ok(address && typeof address !== 'string');
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  try {
+    const status = await (await fetch(`${baseUrl}/update/status`)).json() as { release: { available: boolean; targetVersion: string; blockedReason?: string } };
+    assert.equal(status.release.available, false, 'a newer but incompatible release is not offered');
+    assert.equal(status.release.targetVersion, '1.0.9');
+    assert.match(status.release.blockedReason ?? '', /does not declare rollback compatibility from 1\.0\.0/);
+
+    const started = await fetch(`${baseUrl}/update`, { method: 'POST', headers: { origin: baseUrl, 'x-chatmux-update-intent': 'start' } });
+    assert.equal(started.status, 409);
+    assert.equal((await started.json() as { code?: string }).code, 'RELEASE_ROLLBACK_INCOMPATIBLE');
+    assert.equal(launches, 0, 'nothing is downloaded for a release the worker would refuse anyway');
+    assert.equal(state.publicActiveStatus(), null, 'no job record is created');
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+});
+
+test('a worker that dies before cutover is reconciled on the next status read or update request, not only at router start', async () => {
+  const home = tempRoot();
+  const workerPath = path.join(home, 'dist-server', 'server', 'release-update-worker.js');
+  mkdirSync(path.dirname(workerPath), { recursive: true });
+  writeFileSync(workerPath, '');
+  const state = new ReleaseUpdateStateStore(path.join(home, '.chatmux', 'update'), { now: () => 1 });
+  let unitLive = true;
+  const launches: string[] = [];
+  const app = express();
+  app.use((req, _res, next) => { (req as any).user = {}; next(); });
+  app.use(exactUpdateRequestGuard);
+  app.use(createSystemRouter({
+    appRoot: home, home, serverPort: 3000, bootId: 'boot', runningVersion: '1.0.0', mode: 'release', authMode: 'password', state, now: () => 1,
+    isReleaseUpdateUnitLive: () => unitLive,
+    discoverRelease: async () => ({ release: releaseJob(9).release, compatibility: releaseJob(9).compatibility, notes: { body: null, url: null } }),
+    launchRelease: async (_unit, _worker, id) => { launches.push(id); },
+  }));
+  const server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  assert.ok(address && typeof address !== 'string');
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+  const headers = { origin: baseUrl, 'x-chatmux-update-intent': 'start' };
+  try {
+    const first = await fetch(`${baseUrl}/update`, { method: 'POST', headers });
+    assert.equal(first.status, 202);
+    const firstJob = (await first.json() as { jobId: string }).jobId;
+    assert.equal((await fetch(`${baseUrl}/update`, { method: 'POST', headers })).status, 409, 'the live worker keeps single flight');
+
+    // The worker dies (OOM, session teardown) before cutover; the server does not restart.
+    unitLive = false;
+    const status = await (await fetch(`${baseUrl}/update/status`)).json() as { activeJob: unknown };
+    assert.equal(status.activeJob, null, 'the status read reconciles the dead worker');
+    assert.equal(state.publicStatus(firstJob)?.phase, 'failed');
+
+    const second = await fetch(`${baseUrl}/update`, { method: 'POST', headers });
+    assert.equal(second.status, 202, 'a new update can start without a server restart');
+    assert.equal(launches.length, 2);
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
 });

--- a/server/self-update.ts
+++ b/server/self-update.ts
@@ -483,6 +483,17 @@ function makesReleaseStateUnavailable(error: unknown): boolean {
   return error instanceof ReleaseUpdateStateError && /(?:corrupt|unsafe|ambiguous)/i.test(error.message);
 }
 
+/**
+ * The worker refuses a target whose metadata does not name the running version
+ * as rollback-compatible, but only after downloading and extracting it, and it
+ * records that refusal as a permanent manual_required job. The router already
+ * holds the same metadata, so it decides first and tells the UI why.
+ */
+export function rollbackBlockedReason(target: Discovery, runningVersion: string): string | undefined {
+  if (target.compatibility.database.rollbackCompatibleFrom.includes(runningVersion)) return undefined;
+  return `Release ${target.release.version} does not declare rollback compatibility from ${runningVersion}; reinstall with install.sh to move to it.`;
+}
+
 export function createSystemRouter(options: SystemRouterOptions): Router {
   const router = express.Router(); const mode = options.mode ?? detectInstallMode(options.appRoot); const now = options.now ?? Date.now; const home = options.home ?? homedir();
   const runningVersion = options.runningVersion;
@@ -490,11 +501,17 @@ export function createSystemRouter(options: SystemRouterOptions): Router {
   const releaseVersionUnavailable = mode === 'release' && !releaseVersion;
   const state = options.state ?? new ReleaseUpdateStateStore(path.join(home, '.chatmux', 'update'), { now });
   let releaseStateUnavailable = false;
+  // A worker that died before cutover leaves a nonterminal job behind. Only the
+  // updater restarts a release install, so this must run on every status read
+  // and update request, not just once at router construction.
+  const reconcileInactiveWorker = (): void => {
+    const active = state.publicActiveStatus();
+    if (active) state.failIfInactive(active.id, () => (options.isReleaseUpdateUnitLive ?? isReleaseUpdateUnitLive)(`chatmux-release-update-${active.id}`));
+  };
   if (mode === 'release' && !releaseVersionUnavailable) {
     try {
       state.initialize();
-      const active = state.publicActiveStatus();
-      if (active) state.failIfInactive(active.id, () => (options.isReleaseUpdateUnitLive ?? isReleaseUpdateUnitLive)(`chatmux-release-update-${active.id}`));
+      reconcileInactiveWorker();
     } catch (error) {
       if (makesReleaseStateUnavailable(error)) releaseStateUnavailable = true;
     }
@@ -522,13 +539,15 @@ export function createSystemRouter(options: SystemRouterOptions): Router {
     if (mode !== 'release') return res.json({ ...base, source, release: null, activeJob: null });
     if (releaseStateUnavailable) return res.json({ ...base, source, release: null, activeJob: null, updateUnavailable: 'Release update state is unavailable. Repair the updater state before retrying.' });
     let activeJob;
-    try { activeJob = state.publicActiveStatus(); } catch (error) {
+    try { reconcileInactiveWorker(); activeJob = state.publicActiveStatus(); } catch (error) {
       if (makesReleaseStateUnavailable(error)) releaseStateUnavailable = true;
       return res.json({ ...base, source, release: null, activeJob: null, ...(releaseStateUnavailable ? { updateUnavailable: 'Release update state is unavailable. Repair the updater state before retrying.' } : {}) });
     }
     try {
       const target = await cachedDiscovery();
-      return res.json({ ...base, source, release: { available: compareStrictSemVer(target.release.version, releaseVersion!.version) === 1, targetVersion: target.release.version, notes: target.notes.body, url: target.notes.url }, activeJob });
+      const blockedReason = rollbackBlockedReason(target, releaseVersion!.version);
+      const newer = compareStrictSemVer(target.release.version, releaseVersion!.version) === 1;
+      return res.json({ ...base, source, release: { available: newer && blockedReason === undefined, targetVersion: target.release.version, notes: target.notes.body, url: target.notes.url, ...(newer && blockedReason !== undefined ? { blockedReason } : {}) }, activeJob });
     } catch {
       return res.json({ ...base, source, release: null, activeJob });
     }
@@ -563,6 +582,8 @@ export function createSystemRouter(options: SystemRouterOptions): Router {
     if (releaseVersionUnavailable) return res.status(503).json({ error: 'Release updates require a valid installed version.', mode });
     if (releaseStateUnavailable) return res.status(503).json({ error: 'Release updates are unavailable until updater state is repaired.', mode });
     const target = await discover(); const comparison = compareStrictSemVer(target.release.version, releaseVersion!.version); if (comparison !== 1) return res.status(409).json({ error: 'No newer release is available.', mode });
+    const blockedReason = rollbackBlockedReason(target, releaseVersion!.version); if (blockedReason !== undefined) return res.status(409).json({ error: blockedReason, code: 'RELEASE_ROLLBACK_INCOMPATIBLE', mode });
+    try { reconcileInactiveWorker(); } catch (error) { if (makesReleaseStateUnavailable(error)) { releaseStateUnavailable = true; return res.status(503).json({ error: 'Release updates are unavailable until updater state is repaired.', mode }); } throw error; }
     const oldRelease = realpathSync(options.appRoot); const workerPath = path.join(oldRelease, 'dist-server', 'server', 'release-update-worker.js'); if (!existsSync(workerPath)) throw new Error('Release update worker is unavailable.');
     const id = randomBytes(16).toString('base64url').slice(0, 22); const descriptor: ImmutableUpdateJobDescriptor = { id, release: target.release, compatibility: target.compatibility, createdAt: now(), installMode: 'release', sourceVersion: releaseVersion!.version, sourceBootId: options.bootId, serverPort: options.serverPort };
     if (!state.createIfNoActive(descriptor)) return res.status(409).json({ error: 'An update is already in progress.', mode });


### PR DESCRIPTION
## Summary

Fourth Medium batch: the release updater.

1. **Rollback-compatibility gate in the router.** `GET /api/system/update/status` set `available` from the semver comparison alone and `POST /api/system/update` never checked `rollbackCompatibleFrom`; the worker did, after downloading and extracting, and recorded the refusal as a permanent `manual_required` job. With 1.8.15 declaring only `1.8.14`, every install on 1.8.13 or older was offered the update and landed there. The router now returns `available: false` with a `blockedReason` and refuses the POST with `RELEASE_ROLLBACK_INCOMPATIBLE` before any download or job record.
2. **State lock retry.** `withExclusiveLock` failed immediately when the lock file existed and its owner was alive. The 5 s status poll and the worker's transitions contend for milliseconds; a collision after cutover was indistinguishable from a failure and rolled back a healthy release. A live holder is now waited out for up to 2 s in 50 ms steps (synchronous wait, test seam `sleepMs`).
3. **Reconcile dead workers on demand.** `failIfInactive` ran only at router construction. A worker killed before cutover left a nonterminal job that answered every later `POST /update` with 409 until the server restarted, which in release mode only the updater does. Reconciliation now runs on every status read and update request.
4. **Health window.** 12 attempts at 1 s against 30 s in the installer and 60 s in `deploy.sh`; a miss rolled back and deleted the download. Now 90 attempts.

## Verification

- `self-update.test.ts`: an incompatible target is not offered, carries `blockedReason`, and POST returns 409 with no download and no job record; a worker that dies before cutover is reconciled by the next status read and a new update starts without a restart. Existing release fixtures now declare rollback compatibility from the running version, as a real release must.
- `release-update-state.test.ts`: three contended lock attempts wait 50 ms each and then succeed; a holder that never releases is still reported after the bounded wait.
- `release-update-worker.test.ts` unchanged and passing (70 pass across the three files). `eslint` on touched files, `tsc --noEmit -p server/tsconfig.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
