### PR TITLE
fix(tmux): derive process generations from the start tick and gate session kills

### DIFF
--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -1000,6 +1000,7 @@ router.post(
       tmux?: unknown;
       process?: unknown;
       mode?: unknown;
+      confirmOtherPanes?: unknown;
     };
     const mode = readTerminationMode(body.mode);
     const target = await assertFreshExternalTmuxTarget(body.tmux, body.process);
@@ -1009,7 +1010,7 @@ router.post(
     } else if (mode === 'pane') {
       await killTmuxPane(target);
     } else {
-      await killTmuxSession(target);
+      await killTmuxSession(target, undefined, { allowOtherPanes: body.confirmOtherPanes === true });
     }
     res.json(createApiSuccessResponse({ ok: true, mode }));
   }),
@@ -1371,6 +1372,7 @@ router.post(
       tmux?: unknown;
       process?: unknown;
       mode?: unknown;
+      confirmOtherPanes?: unknown;
     };
     const tmux = readTmuxPaneIdentity(body.tmux);
     const processGeneration = readTmuxProcessGeneration(body.process);
@@ -1382,7 +1384,7 @@ router.post(
     } else if (mode === 'pane') {
       await killTmuxPane(target);
     } else {
-      await killTmuxSession(target);
+      await killTmuxSession(target, undefined, { allowOtherPanes: body.confirmOtherPanes === true });
     }
     res.json(createApiSuccessResponse({ ok: true, mode }));
   }),

--- a/server/modules/providers/services/process-start-time.service.ts
+++ b/server/modules/providers/services/process-start-time.service.ts
@@ -1,12 +1,15 @@
 import { spawn } from 'node:child_process';
-import { stat } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 
 import { recordHostCommand } from '@/modules/providers/services/host-command-metrics.service.js';
 
-function runCommand(command: string, cmdArgs: readonly string[], timeoutMs = 4_000): Promise<string> {
+type RunOptions = Readonly<{ timeoutMs?: number; env?: NodeJS.ProcessEnv }>;
+
+function runCommand(command: string, cmdArgs: readonly string[], options: RunOptions = {}): Promise<string> {
+  const timeoutMs = options.timeoutMs ?? 4_000;
   recordHostCommand(command, cmdArgs);
   return new Promise((resolve, reject) => {
-    const child = spawn(command, [...cmdArgs], { stdio: ['ignore', 'pipe', 'ignore'], windowsHide: true });
+    const child = spawn(command, [...cmdArgs], { stdio: ['ignore', 'pipe', 'ignore'], windowsHide: true, ...(options.env ? { env: options.env } : {}) });
     let stdout = '';
     let settled = false;
     const timer = setTimeout(() => {
@@ -31,26 +34,75 @@ function runCommand(command: string, cmdArgs: readonly string[], timeoutMs = 4_0
   });
 }
 
-/** Parses the portable `ps -o lstart=` fallback format. */
+/** Parses the portable `ps -o lstart=` fallback format (C locale). */
 export function parseProcessStartTime(output: string): number | null {
   const parsed = Date.parse(output.trim());
   return Number.isFinite(parsed) ? parsed : null;
 }
 
 /**
- * Process start time used as a tmux pane/agent generation identity. The
- * identity crosses the fleet catalog wire, whose schema requires safe
- * integers, so the fractional `/proc` mtime precision is truncated once here
- * instead of at every producer, matcher, and verifier downstream.
+ * Field 22 of /proc/<pid>/stat: the process start time in clock ticks since
+ * boot. It is written once by the kernel and never changes for the life of
+ * the pid, unlike the /proc/<pid> directory timestamps, which reflect when
+ * the procfs inode was last instantiated. The comm field may contain spaces
+ * and parentheses, so fields are counted from the last ')'.
  */
-export async function processStartMs(pid: number): Promise<number | null> {
+export function parseProcStatStartTicks(stat: string): number | null {
+  const close = stat.lastIndexOf(')');
+  if (close < 0) return null;
+  const fields = stat.slice(close + 1).trim().split(/\s+/);
+  // fields[0] is field 3 (state); field 22 is therefore index 19.
+  const ticks = Number(fields[19]);
+  return Number.isSafeInteger(ticks) && ticks >= 0 ? ticks : null;
+}
+
+export function parseBootTimeMs(procStat: string): number | null {
+  const match = /^btime (\d+)$/m.exec(procStat);
+  if (!match) return null;
+  const seconds = Number(match[1]);
+  return Number.isSafeInteger(seconds) ? seconds * 1000 : null;
+}
+
+export type ProcessStartTimeDeps = Readonly<{
+  readFile?: (path: string) => Promise<string>;
+  run?: (command: string, args: readonly string[], options?: RunOptions) => Promise<string>;
+  clockTicksPerSecond?: () => Promise<number>;
+}>;
+
+const defaultReadFile = (path: string): Promise<string> => readFile(path, 'utf8');
+let clockTicksCache: Promise<number> | undefined;
+async function defaultClockTicksPerSecond(run: NonNullable<ProcessStartTimeDeps['run']>): Promise<number> {
+  clockTicksCache ??= run('getconf', ['CLK_TCK'], { env: { ...process.env, LC_ALL: 'C' } })
+    .then((output) => { const ticks = Number(output.trim()); return Number.isSafeInteger(ticks) && ticks > 0 ? ticks : 100; })
+    .catch(() => 100);
+  return clockTicksCache;
+}
+
+/**
+ * Process start time used as the tmux pane/agent generation identity. Derived
+ * from the immutable start tick in /proc/<pid>/stat plus the boot time, so it
+ * is stable for the life of the pid and PID reuse cannot collide with it. The
+ * value crosses the fleet catalog wire as a safe integer. Outside Linux the
+ * portable `ps lstart` is parsed in the C locale, because the default locale
+ * (Korean on the reference host) produced text Date.parse cannot read.
+ */
+export async function processStartMs(pid: number, deps: ProcessStartTimeDeps = {}): Promise<number | null> {
+  const read = deps.readFile ?? defaultReadFile;
+  const run = deps.run ?? runCommand;
   try {
-    return Math.trunc((await stat(`/proc/${pid}`)).mtimeMs);
-  } catch {
-    try {
-      return parseProcessStartTime(await runCommand('ps', ['-p', String(pid), '-o', 'lstart=']));
-    } catch {
-      return null;
+    const [stat, procStat] = await Promise.all([read(`/proc/${pid}/stat`), read('/proc/stat')]);
+    const ticks = parseProcStatStartTicks(stat);
+    const bootMs = parseBootTimeMs(procStat);
+    if (ticks !== null && bootMs !== null) {
+      const hz = await (deps.clockTicksPerSecond ?? (() => defaultClockTicksPerSecond(run)))();
+      return Math.trunc(bootMs + (ticks * 1000) / hz);
     }
+  } catch {
+    // Not Linux, or the pid vanished: fall through to the portable form.
+  }
+  try {
+    return parseProcessStartTime(await run('ps', ['-p', String(pid), '-o', 'lstart='], { env: { ...process.env, LC_ALL: 'C' } }));
+  } catch {
+    return null;
   }
 }

--- a/server/modules/providers/services/tmux-pane-actions.service.ts
+++ b/server/modules/providers/services/tmux-pane-actions.service.ts
@@ -236,11 +236,38 @@ export async function killTmuxPane(
   await requireTmuxSuccess(identity, ['kill-pane', '-t', identity.paneId], run);
 }
 
+export type KillTmuxSessionOptions = Readonly<{
+  /** The caller has shown the user the other panes and they chose to close them too. */
+  readonly allowOtherPanes?: boolean;
+}>;
+
+/**
+ * Ends the whole tmux session that hosts the verified pane. Only that one pane
+ * was verified, so when the session holds other panes (other agents, editors,
+ * shells) the caller must have confirmed the wider blast radius explicitly.
+ */
 export async function killTmuxSession(
   target: VerifiedTmuxActionTarget,
   run: TmuxRunner = runTmux,
+  options: KillTmuxSessionOptions = {},
 ): Promise<void> {
   const identity = target.tmux;
+  const listed = await run(['-S', identity.socketPath, 'list-panes', '-s', '-t', identity.sessionId, '-F', '#{pane_id}']);
+  if (listed.code !== 0) {
+    throw new AppError('The selected tmux pane changed; reopen it from the session list.', {
+      code: 'TMUX_PANE_GENERATION_MISMATCH',
+      statusCode: 409,
+      details: listed.output.slice(0, 500),
+    });
+  }
+  const otherPanes = listed.output.split('\n').map((line) => line.trim()).filter((line) => line && line !== identity.paneId);
+  if (otherPanes.length > 0 && options.allowOtherPanes !== true) {
+    throw new AppError(`The tmux session holds ${otherPanes.length} other pane(s). Confirm closing them too, or terminate only this pane.`, {
+      code: 'TMUX_SESSION_HAS_OTHER_PANES',
+      statusCode: 409,
+      details: { otherPanes: otherPanes.length },
+    });
+  }
   await requireTmuxSuccess(identity, ['kill-session', '-t', identity.sessionId], run);
 }
 

--- a/server/modules/providers/tests/process-start-time.test.ts
+++ b/server/modules/providers/tests/process-start-time.test.ts
@@ -2,6 +2,8 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  parseBootTimeMs,
+  parseProcStatStartTicks,
   parseProcessStartTime,
   processStartMs,
 } from '../services/process-start-time.service.js';
@@ -33,4 +35,37 @@ test('parseProcessStartTime reads the portable ps lstart format used on macOS', 
     Date.parse('Wed Jul 22 23:16:35 2026'),
   );
   assert.equal(parseProcessStartTime('not a process time'), null);
+});
+
+test('processStartMs derives the generation from the immutable start tick, not the procfs inode time', async () => {
+  const stat = await import('node:fs/promises').then((fs) => fs.readFile(`/proc/${process.pid}/stat`, 'utf8'));
+  const ticks = parseProcStatStartTicks(stat);
+  assert.ok(ticks !== null && ticks > 0);
+  const derived = await processStartMs(process.pid);
+  const observed = Date.now() - process.uptime() * 1000;
+  assert.ok(derived !== null && Math.abs(derived - observed) < 2_000, `derived ${derived} vs observed ${observed}`);
+
+  // The comm field may contain spaces and parentheses; fields count from the last ')'.
+  const tricky = `1234 (my prog) with) parens) S 1 1 1 0 -1 4194304 0 0 0 0 0 0 0 0 20 0 1 0 987654 0 0 0`;
+  assert.equal(parseProcStatStartTicks(tricky), 987654);
+  assert.equal(parseProcStatStartTicks('garbage'), null);
+  assert.equal(parseBootTimeMs('cpu 1 2 3\nbtime 1788146973\nprocesses 1\n'), 1_788_146_973_000);
+  assert.equal(parseBootTimeMs('cpu 1 2 3\n'), null);
+
+  const injected = await processStartMs(4242, {
+    readFile: async (path) => (path === '/proc/stat' ? 'btime 1000\n' : '4242 (agent) S 1 1 1 0 -1 0 0 0 0 0 0 0 0 0 20 0 1 0 250 0 0 0'),
+    clockTicksPerSecond: async () => 100,
+  });
+  assert.equal(injected, 1_000_000 + 2_500, 'boot time plus ticks over HZ, truncated to an integer');
+});
+
+test('the ps lstart fallback runs in the C locale so a localized ps cannot break it', async () => {
+  const runs: Array<{ command: string; args: readonly string[]; lcAll: string | undefined }> = [];
+  const value = await processStartMs(99, {
+    readFile: async () => { throw new Error('ENOENT'); },
+    run: async (command, args, options) => { runs.push({ command, args, lcAll: options?.env?.LC_ALL }); return 'Wed Jul 22 23:16:35 2026\n'; },
+  });
+  assert.equal(value, Date.parse('Wed Jul 22 23:16:35 2026'));
+  assert.deepEqual(runs.map((run) => [run.command, run.lcAll]), [['ps', 'C']]);
+  assert.equal(parseProcessStartTime('수  9월  2 12:00:21 2026'), null, 'the localized form the default locale produced is unparseable, hence the forced C locale');
 });

--- a/server/modules/providers/tests/tmux-pane-actions.service.test.ts
+++ b/server/modules/providers/tests/tmux-pane-actions.service.test.ts
@@ -199,9 +199,26 @@ test('pane and session termination use distinct immutable ids', async () => {
     '-S', identity.socketPath, 'kill-pane', '-t', identity.paneId,
   ]);
 
-  const session = recordingRunner();
+  const session = recordingRunner([`${identity.paneId}\n`]);
   await killTmuxSession(target, session.run);
   assert.deepEqual(session.calls[0]?.args, [
+    '-S', identity.socketPath, 'list-panes', '-s', '-t', identity.sessionId, '-F', '#{pane_id}',
+  ]);
+  assert.deepEqual(session.calls[1]?.args, [
     '-S', identity.socketPath, 'kill-session', '-t', identity.sessionId,
   ]);
+});
+
+test('session termination refuses to take other panes down without explicit confirmation', async () => {
+  const crowded = recordingRunner([`${identity.paneId}\n%10\n%11\n`]);
+  await assert.rejects(killTmuxSession(target, crowded.run), (error: unknown) => error instanceof AppError && error.code === 'TMUX_SESSION_HAS_OTHER_PANES');
+  assert.equal(crowded.calls.length, 1, 'nothing is killed after the refusal');
+
+  const confirmed = recordingRunner([`${identity.paneId}\n%10\n`]);
+  await killTmuxSession(target, confirmed.run, { allowOtherPanes: true });
+  assert.deepEqual(confirmed.calls[1]?.args, ['-S', identity.socketPath, 'kill-session', '-t', identity.sessionId]);
+
+  const gone = recordingRunner();
+  gone.run = async () => ({ code: 1, output: "can't find session" });
+  await assert.rejects(killTmuxSession(target, gone.run), (error: unknown) => error instanceof AppError && error.code === 'TMUX_PANE_GENERATION_MISMATCH');
 });


### PR DESCRIPTION
## Summary

Fifth Medium batch: the tmux identity boundary.

1. **Process generation from the immutable start tick.** `processStartMs` used the mtime of the `/proc/<pid>` directory, which the kernel stamps when the procfs inode is instantiated and re-stamps after a dentry eviction. Exact-equality comparison in the fresh verifier and lineage gate meant a live pane could start failing every action with 409 until the user reopened it, and a late stamp shifted the transcript-binding lower bound. It now reads field 22 of `/proc/<pid>/stat` (start time in clock ticks since boot, written once for the life of the pid) plus `btime` from `/proc/stat` and `CLK_TCK`, truncated to a safe integer for the fleet wire. The `ps -o lstart=` fallback runs under `LC_ALL=C`; on the reference host the default locale printed `수  9월  2 12:00:21 2026`, which `Date.parse` cannot read.
   One-time effect after upgrade: generation values change once, so panes open in a browser before the restart need to be reopened. That is the fail-closed direction.
2. **Session termination blast radius.** `killTmuxSession` ended the whole tmux session after verifying one pane, so other agents, editors and shells in it died unverified. It now runs `list-panes -s` first and refuses with `TMUX_SESSION_HAS_OTHER_PANES` (409, with the count) unless the caller passes `confirmOtherPanes: true`, which the external and live kill routes accept. The fleet `terminateSession` path passes no confirmation and is therefore refused for multi-pane sessions. The UI does not yet send the confirmation; a session that holds other panes now gets a clear refusal instead of a silent multi-kill, and adding the confirm dialog is a small client follow-up.

## Verification

- `process-start-time.test.ts`: the derived generation matches `Date.now() - process.uptime()` within 2 s; the stat parser handles a comm with spaces and parentheses; boot time and tick arithmetic are pinned with injected reads; the fallback runs `ps` with `LC_ALL=C`
- `tmux-pane-actions.service.test.ts`: single-pane session kill lists then kills; other panes refuse without confirmation and proceed with it; a vanished session is a 409
- Provider route contract, live-sessions, external-cli-sessions, fresh verifier, discovery collector and fleet mutation suites pass
- `eslint` on touched files, `tsc --noEmit -p server/tsconfig.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
