### PR TITLE
fix(files): type-safe asset names, no .git through the file API, validated project roots

### DIFF
--- a/server/modules/assets/assets.routes.ts
+++ b/server/modules/assets/assets.routes.ts
@@ -1,14 +1,16 @@
 import fsSync, { promises as fs } from 'node:fs';
 
 import express from 'express';
-import mime from 'mime-types';
 import multer from 'multer';
 
 import {
   buildStoredImageRecords,
   ensureImageAssetsDir,
+  imageContentTypeForStoredName,
   isAllowedImageMimeType,
   resolveImageAssetFile,
+  sanitizedImageBaseName,
+  storedImageExtension,
 } from '@/modules/assets/services/image-assets.service.js';
 
 const router = express.Router();
@@ -23,8 +25,13 @@ const storage = multer.diskStorage({
   },
   filename: (req, file, cb) => {
     const uniqueSuffix = `${Date.now()}-${Math.round(Math.random() * 1e9)}`;
-    const sanitizedName = file.originalname.replace(/[^a-zA-Z0-9.-]/g, '_');
-    cb(null, `${uniqueSuffix}-${sanitizedName}`);
+    // The extension comes from the accepted mime type, never from the upload name.
+    const extension = storedImageExtension(file.mimetype);
+    if (extension === null) {
+      cb(new Error('Invalid file type. Only JPEG, PNG, GIF, WebP, and SVG are allowed.'), '');
+      return;
+    }
+    cb(null, `${uniqueSuffix}-${sanitizedImageBaseName(file.originalname)}${extension}`);
   },
 });
 
@@ -79,7 +86,12 @@ router.get('/images/:filename', async (req, res) => {
     return res.status(404).json({ error: 'Asset not found' });
   }
 
-  const contentType = mime.lookup(resolved) || 'application/octet-stream';
+  // Only the allowlisted image types are ever served inline; a stored name
+  // with any other extension (legacy uploads kept their original names) is
+  // handed over as an opaque download so nothing renders as a document on
+  // the app origin.
+  const imageType = imageContentTypeForStoredName(resolved);
+  const contentType = imageType ?? 'application/octet-stream';
   res.setHeader('Content-Type', contentType);
   // Stored-XSS hardening: never let the browser sniff a different type, and
   // force SVGs (which can carry scripts when rendered as a document) to
@@ -87,7 +99,7 @@ router.get('/images/:filename', async (req, res) => {
   // fetches assets as blobs and shows them through <img>, where SVG scripts
   // never execute.
   res.setHeader('X-Content-Type-Options', 'nosniff');
-  if (contentType === 'image/svg+xml') {
+  if (imageType === null || contentType === 'image/svg+xml') {
     res.setHeader('Content-Disposition', 'attachment');
   }
   const fileStream = fsSync.createReadStream(resolved);

--- a/server/modules/assets/services/image-assets.service.ts
+++ b/server/modules/assets/services/image-assets.service.ts
@@ -38,6 +38,42 @@ export function isAllowedImageMimeType(mimeType: string): boolean {
   return ALLOWED_IMAGE_MIME_TYPES.has(mimeType);
 }
 
+/**
+ * Stored extension for an accepted mime type. The upload's original extension
+ * is never trusted: multer's `mimetype` is the client-declared part header,
+ * and a `.html` name behind an `image/png` declaration would otherwise be
+ * served back as text/html on the app origin.
+ */
+const STORED_IMAGE_EXTENSIONS: Readonly<Record<string, string>> = {
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/gif': '.gif',
+  'image/webp': '.webp',
+  'image/svg+xml': '.svg',
+};
+
+export function storedImageExtension(mimeType: string): string | null {
+  return STORED_IMAGE_EXTENSIONS[mimeType] ?? null;
+}
+
+/** Content type to serve a stored asset with, from its stored extension only; null for anything else. */
+export function imageContentTypeForStoredName(filename: string): string | null {
+  const extension = path.extname(filename).toLowerCase();
+  const entry = Object.entries(STORED_IMAGE_EXTENSIONS).find(([, storedExtension]) => storedExtension === extension);
+  return entry?.[0] ?? null;
+}
+
+/** Display-safe base name: the original name without its extension, sanitized. */
+export function sanitizedImageBaseName(originalName: string): string {
+  const raw = path.basename(originalName);
+  const extension = path.extname(raw);
+  // A name that is only an extension (".html") has no base; basename() would keep it whole.
+  // extname() reports no extension for a bare ".html", so a leading-dot-only name is also extension-only.
+  const stem = extension ? raw.slice(0, -extension.length) : (raw.startsWith('.') ? '' : raw);
+  const base = stem.replace(/[^a-zA-Z0-9.-]/g, '_');
+  return base || 'image';
+}
+
 /** Creates the global `~/.chatmux/assets` folder if needed and returns it. */
 export async function ensureImageAssetsDir(): Promise<string> {
   const assetsDir = getGlobalImageAssetsDir();

--- a/server/modules/assets/tests/image-assets.service.test.ts
+++ b/server/modules/assets/tests/image-assets.service.test.ts
@@ -5,8 +5,11 @@ import test from 'node:test';
 
 import {
   buildStoredImageRecords,
+  imageContentTypeForStoredName,
   isAllowedImageMimeType,
   resolveImageAssetFile,
+  sanitizedImageBaseName,
+  storedImageExtension,
 } from '@/modules/assets/services/image-assets.service.js';
 
 const ASSETS_DIR = path.join(os.homedir(), '.chatmux', 'assets');
@@ -43,4 +46,21 @@ test('resolveImageAssetFile rejects traversal and separator attempts', () => {
   assert.equal(resolveImageAssetFile('sub/dir.png'), null);
   assert.equal(resolveImageAssetFile('sub\\dir.png'), null);
   assert.equal(resolveImageAssetFile('a..b/../c.png'), null);
+});
+
+test('stored image names take their extension from the accepted mime type, never from the upload name', () => {
+  assert.equal(storedImageExtension('image/png'), '.png');
+  assert.equal(storedImageExtension('image/jpeg'), '.jpg');
+  assert.equal(storedImageExtension('image/svg+xml'), '.svg');
+  assert.equal(storedImageExtension('text/html'), null);
+  assert.equal(sanitizedImageBaseName('evil<script>.html'), 'evil_script_', 'the original extension is dropped and unsafe characters neutralized');
+  assert.equal(sanitizedImageBaseName('.html'), 'image');
+});
+
+test('only allowlisted stored extensions are served as images; anything else is an opaque download', () => {
+  assert.equal(imageContentTypeForStoredName('/assets/123-shot.png'), 'image/png');
+  assert.equal(imageContentTypeForStoredName('/assets/123-shot.JPG'), 'image/jpeg');
+  assert.equal(imageContentTypeForStoredName('/assets/123-shot.svg'), 'image/svg+xml');
+  assert.equal(imageContentTypeForStoredName('/assets/123-page.html'), null, 'a legacy upload that kept an html name never renders as a document');
+  assert.equal(imageContentTypeForStoredName('/assets/123-noext'), null);
 });

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -847,7 +847,7 @@ router.post(
     const body = (req.body ?? {}) as Record<string, unknown>;
     const provider = parseProvider(body.provider);
     const projectPath = typeof body.projectPath === 'string' ? body.projectPath : '';
-    const result = sessionsService.createAppSession(provider, projectPath);
+    const result = await sessionsService.createAppSession(provider, projectPath);
     res.status(201).json(createApiSuccessResponse(result));
   }),
 );

--- a/server/modules/providers/services/sessions.service.ts
+++ b/server/modules/providers/services/sessions.service.ts
@@ -11,7 +11,7 @@ import type {
   LLMProvider,
   NormalizedMessage,
 } from '@/shared/types.js';
-import { AppError } from '@/shared/utils.js';
+import { AppError, validateWorkspacePath } from '@/shared/utils.js';
 
 type CreateAppSessionResult = {
   sessionId: string;
@@ -188,11 +188,32 @@ export const sessionsService = {
    * for the lifetime of the conversation. The provider-native id is mapped to
    * this row later, when the provider runtime announces it mid-run.
    */
-  createAppSession(provider: LLMProvider, projectPath: string): CreateAppSessionResult {
+  async createAppSession(
+    provider: LLMProvider,
+    projectPath: string,
+    deps: { validate?: typeof validateWorkspacePath; isDirectory?: (candidate: string) => Promise<boolean> } = {},
+  ): Promise<CreateAppSessionResult> {
     const normalizedProjectPath = projectPath.trim();
     if (!normalizedProjectPath) {
       throw new AppError('projectPath is required.', {
         code: 'PROJECT_PATH_REQUIRED',
+        statusCode: 400,
+      });
+    }
+    // Registering a directory as a project hands every file and git route its
+    // root, so the browser only gets to register existing directories that the
+    // workspace policy allows (under WORKSPACES_ROOT, never a system path).
+    const validation = await (deps.validate ?? validateWorkspacePath)(normalizedProjectPath);
+    if (!validation.valid) {
+      throw new AppError(validation.error ?? 'projectPath is not allowed.', {
+        code: 'INVALID_PROJECT_PATH',
+        statusCode: 400,
+      });
+    }
+    const isDirectory = deps.isDirectory ?? (async (candidate: string) => { try { return (await fsp.stat(candidate)).isDirectory(); } catch { return false; } });
+    if (!(await isDirectory(normalizedProjectPath))) {
+      throw new AppError('projectPath must be an existing directory.', {
+        code: 'PROJECT_PATH_NOT_FOUND',
         statusCode: 400,
       });
     }

--- a/server/modules/providers/tests/create-app-session-validation.test.ts
+++ b/server/modules/providers/tests/create-app-session-validation.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { sessionsService } from '@/modules/providers/services/sessions.service.js';
+import { AppError } from '@/shared/utils.js';
+
+test('browser-initiated project registration is refused outside the workspace policy or for missing directories', async () => {
+  const rejectedByPolicy = await sessionsService.createAppSession('claude', '/etc', {
+    validate: async () => ({ valid: false, error: 'Cannot use system-critical directories as workspace locations' }),
+    isDirectory: async () => true,
+  }).then(() => null, (error: unknown) => error);
+  assert.ok(rejectedByPolicy instanceof AppError && rejectedByPolicy.code === 'INVALID_PROJECT_PATH' && rejectedByPolicy.statusCode === 400);
+
+  const missing = await sessionsService.createAppSession('claude', '/home/owner/workspace/gone', {
+    validate: async () => ({ valid: true }),
+    isDirectory: async () => false,
+  }).then(() => null, (error: unknown) => error);
+  assert.ok(missing instanceof AppError && missing.code === 'PROJECT_PATH_NOT_FOUND');
+
+  const empty = await sessionsService.createAppSession('claude', '   ').then(() => null, (error: unknown) => error);
+  assert.ok(empty instanceof AppError && empty.code === 'PROJECT_PATH_REQUIRED', 'the existing empty-path contract is unchanged');
+});

--- a/server/shared/project-file-containment.ts
+++ b/server/shared/project-file-containment.ts
@@ -9,6 +9,23 @@ function isWithinProjectRoot(projectRootRealPath: string, candidateRealPath: str
   );
 }
 
+/**
+ * `.git` under the project root is repository metadata, not project content.
+ * Writing `.git/config` (core.fsmonitor, diff.external) or a hook turns the
+ * app's own git calls into command execution, and `.git/config` can carry
+ * credentials in remote URLs, so the file API neither reads nor writes there.
+ */
+export function isGitMetadataPath(projectRootRealPath: string, candidateRealPath: string): boolean {
+  if (!isWithinProjectRoot(projectRootRealPath, candidateRealPath) || candidateRealPath === projectRootRealPath) return false;
+  const relative = candidateRealPath.slice(projectRootRealPath.length + 1);
+  const [head] = relative.split(path.sep);
+  return head === '.git';
+}
+
+function isAccessibleProjectPath(projectRootRealPath: string, candidateRealPath: string): boolean {
+  return isWithinProjectRoot(projectRootRealPath, candidateRealPath) && !isGitMetadataPath(projectRootRealPath, candidateRealPath);
+}
+
 async function resolveNearestExistingAncestor(filePath: string): Promise<{
   path: string;
   missingPathSegments: string[];
@@ -52,7 +69,7 @@ export async function resolveProjectFileForRead(
   ]);
   const fileRealPath = await realpath(filePath);
 
-  return isWithinProjectRoot(projectRootRealPath, fileRealPath) ? fileRealPath : null;
+  return isAccessibleProjectPath(projectRootRealPath, fileRealPath) ? fileRealPath : null;
 }
 
 /**
@@ -83,7 +100,7 @@ export async function resolveProjectFileForWrite(
   }
 
   const fileRealPath = path.join(ancestorRealPath, ...ancestor.missingPathSegments);
-  return isWithinProjectRoot(projectRootRealPath, fileRealPath) ? fileRealPath : null;
+  return isAccessibleProjectPath(projectRootRealPath, fileRealPath) ? fileRealPath : null;
 }
 
 /**
@@ -104,7 +121,8 @@ export async function resolveProjectEntryForMutation(
     return null;
   }
 
-  return path.join(parentRealPath, path.basename(absoluteEntryPath));
+  const entryRealPath = path.join(parentRealPath, path.basename(absoluteEntryPath));
+  return isGitMetadataPath(projectRootRealPath, entryRealPath) ? null : entryRealPath;
 }
 
 export async function openProjectFileForWrite(

--- a/server/shared/tests/project-file-containment.test.ts
+++ b/server/shared/tests/project-file-containment.test.ts
@@ -1,10 +1,12 @@
 import assert from 'node:assert/strict';
+import { promises as fsPromises } from 'node:fs';
 import { lstat, mkdtemp, mkdir, readFile, realpath, rm, symlink, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
 import {
+  isGitMetadataPath,
   openProjectFileForWrite,
   resolveProjectEntryForMutation,
   resolveProjectFileForRead,
@@ -126,5 +128,27 @@ test('project file writes use the same regular file object that passed validatio
     assert.equal(await readFile(outsideFile, 'utf8'), 'outside');
   } finally {
     await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test('project file containment keeps .git metadata out of reach for reads, writes, and mutations', async () => {
+  const root = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'containment-git-'));
+  try {
+    await fsPromises.mkdir(path.join(root, '.git', 'hooks'), { recursive: true });
+    await fsPromises.writeFile(path.join(root, '.git', 'config'), '[core]\n');
+    await fsPromises.writeFile(path.join(root, '.gitignore'), 'node_modules\n');
+    await fsPromises.writeFile(path.join(root, 'notes.md'), '# notes\n');
+
+    assert.equal(await resolveProjectFileForRead(root, path.join(root, '.git', 'config')), null, 'git config can carry remote credentials and fsmonitor commands');
+    assert.equal(await resolveProjectFileForWrite(root, path.join(root, '.git', 'config')), null);
+    assert.equal(await resolveProjectFileForWrite(root, path.join(root, '.git', 'hooks', 'pre-commit')), null, 'a hook written here would run on the app\'s next git commit');
+    assert.equal(await resolveProjectEntryForMutation(root, path.join(root, '.git')), null);
+    assert.equal(await openProjectFileForWrite(root, path.join(root, '.git', 'config')), null);
+    assert.equal(isGitMetadataPath(root, path.join(root, '.git')), true);
+
+    assert.equal(await resolveProjectFileForRead(root, path.join(root, '.gitignore')), path.join(await fsPromises.realpath(root), '.gitignore'), 'dotfiles that merely start with .git stay editable');
+    assert.ok(await resolveProjectFileForWrite(root, path.join(root, 'notes.md')));
+  } finally {
+    await fsPromises.rm(root, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary

Sixth Medium batch: the file surfaces.

1. **Image asset names and types.** `assets.routes.ts` accepted the client-declared multipart `mimetype`, kept the upload's original extension, and served the stored file by that extension, so `x.html` declared as `image/png` came back as `text/html` on the app origin (stored XSS; with the JWT in localStorage that is token theft). The stored name now takes its extension from the accepted mime type (`.jpg`, `.png`, `.gif`, `.webp`, `.svg`) with the original extension dropped, and the serving route recognizes only those stored extensions; anything else, including legacy uploads that kept an html name, is served as `application/octet-stream` with `Content-Disposition: attachment`. `nosniff` stays.
2. **`.git` is off limits to the file API.** `resolveProjectFileForRead`, `resolveProjectFileForWrite` and `resolveProjectEntryForMutation` now refuse paths whose first segment under the project root is `.git`. Writing `.git/config` (`core.fsmonitor`, `diff.external`) or a hook turns the app's own `git status`/`git commit` into command execution, and `.git/config` can carry credentials in remote URLs. `.gitignore` and other dotfiles that merely start with `.git` stay editable.
3. **Browser-registered project roots are validated.** `POST /api/providers/sessions` registered any directory after a `trim()`, and every file and git route trusted that root; `validateWorkspacePath` existed but had no caller. `sessionsService.createAppSession` now requires the workspace policy to accept the path (under `WORKSPACES_ROOT`, never a system directory, symlinks resolved) and the path to be an existing directory, with `INVALID_PROJECT_PATH` / `PROJECT_PATH_NOT_FOUND` as 400s. Server-side synchronizers that register projects from discovered transcripts are unchanged.

## Verification

- `image-assets.service.test.ts`: extension from mime, original extension dropped and sanitized, only allowlisted stored extensions map to an image type
- `project-file-containment.test.ts`: `.git/config`, a hook path and `.git` itself are refused for read, write and mutation; `.gitignore` remains readable and writable
- `create-app-session-validation.test.ts` (new): policy rejection, missing directory, and the unchanged empty-path contract
- Files route contract and provider route contract suites pass; `tsc --noEmit -p server/tsconfig.json`; `eslint` on touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
