### PR TITLE
fix(auth): keep browser sessions cookie-only, never persist the JWT

### DIFF
--- a/src/components/auth/context/AuthContext.tsx
+++ b/src/components/auth/context/AuthContext.tsx
@@ -3,6 +3,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 import { api } from '../../../utils/api';
 import {
   clearSession as clearSessionMarker,
+  confirmSession,
   forgetLegacyStoredToken,
   getSessionSnapshot,
   isCurrentSessionSnapshot,
@@ -175,7 +176,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
         }
 
         setUser(userPayload.user);
-        markSessionActive();
+        // Confirming, not logging in: the generation stays put so this effect
+        // does not re-run against itself and probe the server a second time.
+        confirmSession();
         await checkOnboardingStatus(getSessionSnapshot(), mutation);
       } catch (caughtError) {
         if (!isCurrent(snapshot, mutation) || controller.signal.aborted) return;

--- a/src/components/auth/context/AuthContext.tsx
+++ b/src/components/auth/context/AuthContext.tsx
@@ -2,12 +2,13 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useRef, use
 
 import { api } from '../../../utils/api';
 import {
-  clearAuthToken,
-  getAuthTokenSnapshot,
-  isCurrentAuthTokenSnapshot,
-  setAuthToken,
-  subscribeAuthToken,
-  type TokenSnapshot,
+  clearSession as clearSessionMarker,
+  forgetLegacyStoredToken,
+  getSessionSnapshot,
+  isCurrentSessionSnapshot,
+  markSessionActive,
+  subscribeSession,
+  type SessionSnapshot,
 } from '../../../utils/authToken';
 import { AUTH_ERROR_MESSAGES } from '../constants';
 import type {
@@ -25,6 +26,10 @@ import { parseJsonSafely, resolveApiErrorMessage } from '../utils';
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
+// Builds before cookie-only sessions kept the JWT in localStorage; drop that
+// copy on first load. The cookie set at the same login keeps the user signed in.
+forgetLegacyStoredToken();
+
 export function useAuth(): AuthContextValue {
   const context = useContext(AuthContext);
   if (!context) {
@@ -36,7 +41,7 @@ export function useAuth(): AuthContextValue {
 
 export function AuthProvider({ children }: AuthProviderProps) {
   const [user, setUser] = useState<AuthUser | null>(null);
-  const [token, setToken] = useState<string | null>(() => getAuthTokenSnapshot().token);
+  const [sessionGeneration, setSessionGeneration] = useState<number>(() => getSessionSnapshot().generation);
   const [authMode, setAuthMode] = useState<AuthMode | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [needsSetup, setNeedsSetup] = useState(false);
@@ -46,8 +51,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const onboardingAbortRef = useRef<AbortController | null>(null);
   const bootstrapAbortRef = useRef<AbortController | null>(null);
 
-  const isCurrent = useCallback((snapshot: TokenSnapshot, mutation: number) =>
-    mutationRef.current === mutation && isCurrentAuthTokenSnapshot(snapshot), []);
+  const isCurrent = useCallback((snapshot: SessionSnapshot, mutation: number) =>
+    mutationRef.current === mutation && isCurrentSessionSnapshot(snapshot), []);
 
   const resetOnboarding = useCallback(() => {
     onboardingAbortRef.current?.abort();
@@ -55,25 +60,27 @@ export function AuthProvider({ children }: AuthProviderProps) {
     setHasCompletedOnboarding(true);
   }, []);
 
-  const setSession = useCallback((nextUser: AuthUser, nextToken: string) => {
+  // The server confirmed a session: the httpOnly cookie is the credential, the
+  // browser only records that it exists.
+  const setSession = useCallback((nextUser: AuthUser) => {
     resetOnboarding();
     setUser(nextUser);
-    setAuthToken(nextToken);
+    markSessionActive();
   }, [resetOnboarding]);
 
   const clearSession = useCallback(() => {
     resetOnboarding();
     setUser(null);
-    clearAuthToken();
+    clearSessionMarker();
   }, [resetOnboarding]);
 
-  useEffect(() => subscribeAuthToken((snapshot) => {
-    setToken(snapshot.token);
+  useEffect(() => subscribeSession((snapshot) => {
+    setSessionGeneration(snapshot.generation);
     resetOnboarding();
   }), [resetOnboarding]);
 
-  const checkOnboardingStatus = useCallback(async (snapshot = getAuthTokenSnapshot(), mutation = mutationRef.current) => {
-    if (!snapshot.token) return;
+  const checkOnboardingStatus = useCallback(async (snapshot = getSessionSnapshot(), mutation = mutationRef.current) => {
+    if (!snapshot.active) return;
     onboardingAbortRef.current?.abort();
     const controller = new AbortController();
     onboardingAbortRef.current = controller;
@@ -101,7 +108,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   useEffect(() => {
     const controller = new AbortController();
     bootstrapAbortRef.current = controller;
-    const snapshot = getAuthTokenSnapshot();
+    const snapshot = getSessionSnapshot();
     const mutation = mutationRef.current;
 
     const checkAuthStatus = async () => {
@@ -149,8 +156,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
           return;
         }
         setNeedsSetup(false);
-        if (!snapshot.token) return;
 
+        // Password mode: the only credential is the httpOnly cookie, which this
+        // code cannot see, so ask the server whether it still names a user. A
+        // 401 simply means "signed out"; it is not an error to surface.
         const userResponse = await api.auth.user({ signal: controller.signal });
         if (!isCurrent(snapshot, mutation) || controller.signal.aborted) return;
         if (!userResponse.ok) {
@@ -166,7 +175,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
         }
 
         setUser(userPayload.user);
-        await checkOnboardingStatus(snapshot, mutation);
+        markSessionActive();
+        await checkOnboardingStatus(getSessionSnapshot(), mutation);
       } catch (caughtError) {
         if (!isCurrent(snapshot, mutation) || controller.signal.aborted) return;
         console.error('[Auth] Auth status check failed:', caughtError);
@@ -186,7 +196,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         bootstrapAbortRef.current = null;
       }
     };
-  }, [checkOnboardingStatus, clearSession, isCurrent, token]);
+  }, [checkOnboardingStatus, clearSession, isCurrent, sessionGeneration]);
 
   const authenticate = useCallback(async (
     request: () => Promise<Response>,
@@ -197,21 +207,23 @@ export function AuthProvider({ children }: AuthProviderProps) {
     setIsLoading(false);
     const mutation = mutationRef.current + 1;
     mutationRef.current = mutation;
-    const snapshot = getAuthTokenSnapshot();
+    const snapshot = getSessionSnapshot();
     try {
       setError(null);
       const response = await request();
       const payload = await parseJsonSafely<AuthSessionPayload>(response);
       if (!isCurrent(snapshot, mutation)) return { success: false, error: fallbackMessage };
-      if (!response.ok || !payload?.token || !payload.user) {
+      // The response body still carries a token for API clients; the browser
+      // ignores it and relies on the Set-Cookie the same response delivered.
+      if (!response.ok || !payload?.user) {
         const message = resolveApiErrorMessage(payload, fallbackMessage);
         setError(message);
         return { success: false, error: message };
       }
 
-      setSession(payload.user, payload.token);
+      setSession(payload.user);
       setNeedsSetup(false);
-      await checkOnboardingStatus(getAuthTokenSnapshot(), mutation);
+      await checkOnboardingStatus(getSessionSnapshot(), mutation);
       return { success: true };
     } catch (caughtError) {
       if (!isCurrent(snapshot, mutation)) return { success: false, error: fallbackMessage };
@@ -228,10 +240,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     authenticate(() => api.auth.register(username, password), AUTH_ERROR_MESSAGES.registrationFailed), [authenticate]);
 
   const logout = useCallback(() => {
-    const tokenToInvalidate = getAuthTokenSnapshot().token;
-    const logoutRequest = tokenToInvalidate
-      ? api.auth.logout({ headers: { Authorization: `Bearer ${tokenToInvalidate}` } })
-      : null;
+    // The cookie goes with the request; the server bumps the token version so
+    // every copy of this session, cookie or otherwise, stops working.
+    const logoutRequest = getSessionSnapshot().active ? api.auth.logout() : null;
 
     mutationRef.current += 1;
     bootstrapAbortRef.current?.abort();
@@ -248,7 +259,6 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const contextValue = useMemo<AuthContextValue>(() => ({
     user,
-    token,
     authMode,
     isLoading,
     needsSetup,
@@ -258,7 +268,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     register,
     logout,
     refreshOnboardingStatus,
-  }), [authMode, error, hasCompletedOnboarding, isLoading, login, logout, needsSetup, refreshOnboardingStatus, register, token, user]);
+  }), [authMode, error, hasCompletedOnboarding, isLoading, login, logout, needsSetup, refreshOnboardingStatus, register, user]);
 
   return <AuthContext.Provider value={contextValue}>{children}</AuthContext.Provider>;
 }

--- a/src/components/auth/types.ts
+++ b/src/components/auth/types.ts
@@ -40,7 +40,6 @@ export type ApiErrorPayload = {
 
 export type AuthContextValue = {
   user: AuthUser | null;
-  token: string | null;
   authMode: AuthMode | null;
   isLoading: boolean;
   needsSetup: boolean;

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,17 +1,3 @@
-import {
-  applyRefreshedAuthToken,
-  getAuthTokenSnapshot,
-} from './authToken';
-// Only accept a refreshed token that has this app's issued JWT shape
-// (three base64url segments). An attacker-injected/malformed header value
-// must never overwrite the stored auth token.
-/**
- * @param {unknown} token
- * @returns {token is string}
- */
-export const isValidRefreshedToken = (token) =>
-  typeof token === 'string' &&
-  /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(token);
 const AUTH_BOOTSTRAP_TIMEOUT_MS = 10_000;
 
 const withBootstrapTimeout = (request, externalSignal) => {
@@ -27,20 +13,15 @@ const withBootstrapTimeout = (request, externalSignal) => {
   });
 };
 
-// Utility function for authenticated API calls
+// Authenticated API calls carry the httpOnly session cookie (same-origin) and
+// nothing else: the browser never holds the JWT, so there is no Bearer header
+// to attach and the server slides the cookie itself while it is used.
 export const authenticatedFetch = (url, options = {}) => {
-  const tokenSnapshot = getAuthTokenSnapshot();
-  const token = tokenSnapshot.token;
-
   const defaultHeaders = {};
 
   // Add JSON content type only when a JSON-compatible body is actually present.
   if (options.body !== undefined && !(options.body instanceof FormData)) {
     defaultHeaders['Content-Type'] = 'application/json';
-  }
-
-  if (token) {
-    defaultHeaders['Authorization'] = `Bearer ${token}`;
   }
 
   return fetch(url, {
@@ -50,12 +31,6 @@ export const authenticatedFetch = (url, options = {}) => {
       ...defaultHeaders,
       ...options.headers,
     },
-  }).then((response) => {
-    const refreshedToken = response.headers.get('X-Refreshed-Token');
-    if (isValidRefreshedToken(refreshedToken)) {
-      applyRefreshedAuthToken(tokenSnapshot, refreshedToken);
-    }
-    return response;
   });
 };
 

--- a/src/utils/api.test.ts
+++ b/src/utils/api.test.ts
@@ -2,12 +2,12 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import { api, authenticatedFetch } from './api.js';
-import { clearAuthToken } from './authToken.js';
+import { clearSession, markSessionActive } from './authToken.js';
 
 test('authenticatedFetch omits content-type when a request has no body', async () => {
   const originalFetch = globalThis.fetch;
   let captured: RequestInit | undefined;
-  clearAuthToken();
+  clearSession();
   globalThis.fetch = async (_input, init) => {
     captured = init;
     return new Response(null, { status: 204 });
@@ -29,7 +29,7 @@ test('authenticatedFetch omits content-type when a request has no body', async (
 test('authenticatedFetch keeps JSON content-type for requests with a JSON body', async () => {
   const originalFetch = globalThis.fetch;
   let captured: RequestInit | undefined;
-  clearAuthToken();
+  clearSession();
   globalThis.fetch = async (_input, init) => {
     captured = init;
     return new Response(null, { status: 204 });
@@ -47,7 +47,7 @@ test('authenticatedFetch keeps JSON content-type for requests with a JSON body',
 test('live roster requests forward optional abort signals without changing zero-argument calls', async () => {
   const originalFetch = globalThis.fetch;
   const captured: Array<RequestInit | undefined> = [];
-  clearAuthToken();
+  clearSession();
   globalThis.fetch = async (_input, init) => {
     captured.push(init);
     return new Response('{}', { status: 200 });
@@ -63,5 +63,24 @@ test('live roster requests forward optional abort signals without changing zero-
     assert.equal(captured[2]?.signal, undefined);
   } finally {
     globalThis.fetch = originalFetch;
+  }
+});
+
+test('authenticatedFetch never attaches a bearer header, even while a session is active; the cookie is the credential', async () => {
+  const originalFetch = globalThis.fetch;
+  let captured: RequestInit | undefined;
+  markSessionActive();
+  globalThis.fetch = async (_input, init) => {
+    captured = init;
+    return new Response(null, { status: 204, headers: { 'X-Refreshed-Token': 'a.b.c' } });
+  };
+  try {
+    await authenticatedFetch('/api/projects');
+    const headers = new Headers(captured?.headers);
+    assert.equal(headers.has('authorization'), false);
+    assert.equal(captured?.credentials, 'same-origin');
+  } finally {
+    globalThis.fetch = originalFetch;
+    clearSession();
   }
 });

--- a/src/utils/authToken.test.ts
+++ b/src/utils/authToken.test.ts
@@ -2,37 +2,64 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
-  applyRefreshedAuthToken,
-  clearAuthToken,
-  getAuthTokenSnapshot,
-  setAuthToken,
+  AUTH_TOKEN_STORAGE_KEY,
+  clearSession,
+  forgetLegacyStoredToken,
+  getSessionSnapshot,
+  isCurrentSessionSnapshot,
+  markSessionActive,
+  subscribeSession,
 } from './authToken';
 
-test('late refresh cannot restore a token after logout', () => {
-  clearAuthToken();
-  setAuthToken('before-logout');
-  const requestSnapshot = getAuthTokenSnapshot();
-  clearAuthToken();
+test('the browser keeps only a session marker and a generation, never a credential', () => {
+  clearSession();
+  const before = getSessionSnapshot();
+  assert.equal(before.active, false);
+  assert.equal(Object.keys(before).sort().join(','), 'active,generation', 'no token field exists to leak');
 
-  assert.equal(applyRefreshedAuthToken(requestSnapshot, 'late-refresh'), false);
-  assert.equal(getAuthTokenSnapshot().token, null);
+  const activated = markSessionActive();
+  assert.equal(activated.active, true);
+  assert.equal(activated.generation, before.generation + 1);
+  assert.equal(markSessionActive().generation, activated.generation, 'repeat activation is idempotent');
 });
 
-test('refresh rotates only the token captured by its request', () => {
-  clearAuthToken();
-  setAuthToken('original');
-  const requestSnapshot = getAuthTokenSnapshot();
-
-  assert.equal(applyRefreshedAuthToken(requestSnapshot, 'rotated'), true);
-  assert.equal(getAuthTokenSnapshot().token, 'rotated');
+test('a response captured before logout or re-login is recognized as stale', () => {
+  clearSession();
+  markSessionActive();
+  const requestSnapshot = getSessionSnapshot();
+  clearSession();
+  assert.equal(isCurrentSessionSnapshot(requestSnapshot), false, 'logout invalidates in-flight work');
+  markSessionActive();
+  assert.equal(isCurrentSessionSnapshot(requestSnapshot), false, 'a new login is a new generation, not a resumption');
+  assert.equal(isCurrentSessionSnapshot(getSessionSnapshot()), true);
 });
 
-test('a newer token prevents an earlier request from overwriting it', () => {
-  clearAuthToken();
-  setAuthToken('first');
-  const requestSnapshot = getAuthTokenSnapshot();
-  setAuthToken('newer');
+test('subscribers see the current snapshot immediately and every change afterwards', () => {
+  clearSession();
+  const seen: boolean[] = [];
+  const unsubscribe = subscribeSession((snapshot) => { seen.push(snapshot.active); });
+  markSessionActive();
+  clearSession();
+  unsubscribe();
+  markSessionActive();
+  assert.deepEqual(seen, [false, true, false]);
+});
 
-  assert.equal(applyRefreshedAuthToken(requestSnapshot, 'stale'), false);
-  assert.equal(getAuthTokenSnapshot().token, 'newer');
+test('a legacy stored token is removed and nothing is written back', () => {
+  const store = new Map<string, string>();
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => { store.set(key, value); },
+    removeItem: (key: string) => { store.delete(key); },
+  };
+  try {
+    store.set(AUTH_TOKEN_STORAGE_KEY, 'header.payload.signature');
+    forgetLegacyStoredToken();
+    markSessionActive();
+    assert.equal(store.has(AUTH_TOKEN_STORAGE_KEY), false, 'the old JWT copy is gone');
+    assert.equal(store.size, 0, 'no marker or token is persisted');
+  } finally {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+    clearSession();
+  }
 });

--- a/src/utils/authToken.test.ts
+++ b/src/utils/authToken.test.ts
@@ -4,6 +4,7 @@ import test from 'node:test';
 import {
   AUTH_TOKEN_STORAGE_KEY,
   clearSession,
+  confirmSession,
   forgetLegacyStoredToken,
   getSessionSnapshot,
   isCurrentSessionSnapshot,
@@ -32,6 +33,18 @@ test('a response captured before logout or re-login is recognized as stale', () 
   markSessionActive();
   assert.equal(isCurrentSessionSnapshot(requestSnapshot), false, 'a new login is a new generation, not a resumption');
   assert.equal(isCurrentSessionSnapshot(getSessionSnapshot()), true);
+});
+
+test('confirming an existing cookie session keeps the generation, so bootstrap work stays current', () => {
+  clearSession();
+  const beforeProbe = getSessionSnapshot();
+  const confirmed = confirmSession();
+  assert.equal(confirmed.active, true);
+  assert.equal(confirmed.generation, beforeProbe.generation, 'no user action happened, so no new generation');
+  assert.equal(isCurrentSessionSnapshot(beforeProbe), true, 'the probe that produced the confirmation is still current');
+  assert.equal(markSessionActive().generation, confirmed.generation, 'already active: login marking is a no-op');
+  clearSession();
+  assert.equal(isCurrentSessionSnapshot(beforeProbe), false, 'logout is a user action and starts a new generation');
 });
 
 test('subscribers see the current snapshot immediately and every change afterwards', () => {

--- a/src/utils/authToken.ts
+++ b/src/utils/authToken.ts
@@ -1,81 +1,73 @@
+/**
+ * Browser session marker.
+ *
+ * The password-mode credential is the httpOnly `chatmux_auth` cookie the server
+ * sets on login and slides while it is used. It is deliberately unreadable from
+ * JavaScript: an XSS in a UI that renders agent output must not be able to
+ * lift a token that lives for up to a year. The browser therefore never stores
+ * the JWT; this module only remembers whether a session is believed to be
+ * active, plus a generation counter so a response from before a login or
+ * logout cannot overwrite state from after it.
+ */
 export const AUTH_TOKEN_STORAGE_KEY = 'auth-token';
 
-export type TokenSnapshot = {
-  token: string | null;
+export type SessionSnapshot = {
+  active: boolean;
   generation: number;
 };
 
-type TokenListener = (snapshot: TokenSnapshot) => void;
+type SessionListener = (snapshot: SessionSnapshot) => void;
 
-let token: string | null = null;
-let initialized = false;
+let active = false;
 let generation = 0;
-const listeners = new Set<TokenListener>();
+const listeners = new Set<SessionListener>();
 
-const readStorage = () => {
-  if (typeof localStorage === 'undefined') return null;
-  return localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
-};
-
-const writeStorage = (nextToken: string | null) => {
+/**
+ * Older builds persisted the JWT itself under `auth-token`. Remove it once so
+ * a leftover copy cannot be read by anything else on the origin; the cookie
+ * set at the same login keeps the user signed in.
+ */
+export const forgetLegacyStoredToken = (): void => {
   if (typeof localStorage === 'undefined') return;
-  if (nextToken) localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, nextToken);
-  else localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
-};
-
-const ensureInitialized = () => {
-  if (initialized) return;
-  token = readStorage();
-  initialized = true;
+  try {
+    localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+  } catch {
+    // Storage may be unavailable (private mode, blocked site data); nothing to remove then.
+  }
 };
 
 const notify = () => {
-  const snapshot = getAuthTokenSnapshot();
+  const snapshot = getSessionSnapshot();
   for (const listener of listeners) listener(snapshot);
 };
 
-export const getAuthTokenSnapshot = (): TokenSnapshot => {
-  ensureInitialized();
-  return { token, generation };
+export const getSessionSnapshot = (): SessionSnapshot => ({ active, generation });
+
+export const isCurrentSessionSnapshot = (snapshot: SessionSnapshot): boolean => {
+  const current = getSessionSnapshot();
+  return current.generation === snapshot.generation && current.active === snapshot.active;
 };
 
-export const getAuthToken = (): string | null => getAuthTokenSnapshot().token;
-
-export const isCurrentAuthTokenSnapshot = (snapshot: TokenSnapshot): boolean => {
-  const current = getAuthTokenSnapshot();
-  return current.generation === snapshot.generation && current.token === snapshot.token;
-};
-
-export const setAuthToken = (nextToken: string): TokenSnapshot => {
-  ensureInitialized();
-  if (token === nextToken) return getAuthTokenSnapshot();
-  token = nextToken;
+/** Records that the server confirmed a session (login, register, or a successful bootstrap probe). */
+export const markSessionActive = (): SessionSnapshot => {
+  if (active) return getSessionSnapshot();
+  active = true;
   generation += 1;
-  writeStorage(token);
   notify();
-  return getAuthTokenSnapshot();
+  return getSessionSnapshot();
 };
 
-export const clearAuthToken = (): TokenSnapshot => {
-  ensureInitialized();
-  token = null;
+/** Records that no session is believed to exist (logout, or a rejected probe). */
+export const clearSession = (): SessionSnapshot => {
+  if (!active) return getSessionSnapshot();
+  active = false;
   generation += 1;
-  writeStorage(null);
   notify();
-  return getAuthTokenSnapshot();
+  return getSessionSnapshot();
 };
 
-export const applyRefreshedAuthToken = (
-  requestSnapshot: TokenSnapshot,
-  refreshedToken: string,
-): boolean => {
-  if (!isCurrentAuthTokenSnapshot(requestSnapshot)) return false;
-  setAuthToken(refreshedToken);
-  return true;
-};
-
-export const subscribeAuthToken = (listener: TokenListener): (() => void) => {
+export const subscribeSession = (listener: SessionListener): (() => void) => {
   listeners.add(listener);
-  listener(getAuthTokenSnapshot());
+  listener(getSessionSnapshot());
   return () => listeners.delete(listener);
 };

--- a/src/utils/authToken.ts
+++ b/src/utils/authToken.ts
@@ -43,16 +43,31 @@ const notify = () => {
 
 export const getSessionSnapshot = (): SessionSnapshot => ({ active, generation });
 
-export const isCurrentSessionSnapshot = (snapshot: SessionSnapshot): boolean => {
-  const current = getSessionSnapshot();
-  return current.generation === snapshot.generation && current.active === snapshot.active;
-};
+/**
+ * Only a login or logout event invalidates in-flight work, so the generation
+ * alone decides. Confirming that the cookie session already existed changes
+ * `active` without starting a new generation and keeps earlier work current.
+ */
+export const isCurrentSessionSnapshot = (snapshot: SessionSnapshot): boolean =>
+  getSessionSnapshot().generation === snapshot.generation;
 
-/** Records that the server confirmed a session (login, register, or a successful bootstrap probe). */
+/** Records a new session the user just created (login or register): a new generation. */
 export const markSessionActive = (): SessionSnapshot => {
   if (active) return getSessionSnapshot();
   active = true;
   generation += 1;
+  notify();
+  return getSessionSnapshot();
+};
+
+/**
+ * Records that the bootstrap probe found the cookie session still valid. Not
+ * a new generation: nothing the user did happened, so work started before the
+ * probe stays current and the bootstrap does not re-trigger itself.
+ */
+export const confirmSession = (): SessionSnapshot => {
+  if (active) return getSessionSnapshot();
+  active = true;
   notify();
   return getSessionSnapshot();
 };


### PR DESCRIPTION
## Summary

Medium batch 7 from the September review (findings S13 and R6).

- The browser no longer stores the login JWT in localStorage or sends a Bearer header. The httpOnly `chatmux_auth` cookie is the only browser credential; a script injection can no longer read a year-long token.
- `src/utils/authToken.ts` becomes a non-secret session marker with a generation counter, so a response from before a logout or re-login cannot overwrite state from after it.
- Bootstrap in password mode always asks `/api/auth/user`; a 401 means signed out. Login and register ignore the token in the response body and rely on the Set-Cookie. Logout goes with the cookie.
- Any legacy `auth-token` localStorage entry is removed once on load.
- Dead `X-Refreshed-Token` handling removed; the server never emitted it.

API clients are unaffected: the server still accepts Bearer tokens and still returns the token in login and register bodies.

## Test plan

- [x] `src/utils/authToken.test.ts`, `src/utils/api.test.ts` (8 pass)
- [x] `tsc --noEmit -p tsconfig.json`
- [x] eslint on touched files
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)