### PR TITLE
fix(native-core): coalesce watcher events and resync on overflow instead of exiting

### DIFF
--- a/native/chatmux-core/src/watcher.rs
+++ b/native/chatmux-core/src/watcher.rs
@@ -1,18 +1,25 @@
+use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::io::{self, Read, Write};
 use std::path::{Component, Path, PathBuf};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{self, RecvTimeoutError, TrySendError};
+use std::sync::mpsc;
+use std::sync::{Arc, Condvar, Mutex, MutexGuard, PoisonError};
 use std::thread;
 use std::time::Duration;
 
+use notify::event::{ModifyKind, RenameMode};
 use notify::{Config, ErrorKind, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 
 const READY_FRAME: &[u8] = b"{\"protocolVersion\":1,\"kind\":\"ready\"}\n";
+const RESYNC_FRAME: &[u8] = b"{\"protocolVersion\":1,\"kind\":\"resync\"}\n";
 const WATCH_ERROR: &[u8] = b"chatmux-core: watcher failed\n";
 const MAX_FRAME_BYTES: usize = 64 * 1024;
-const EVENT_CHANNEL_CAPACITY: usize = 256;
+// Distinct paths the drain loop may fall behind by before the queue stops
+// remembering individual events. Past this the host is asked to rescan instead
+// of the watcher dying: a burst (a bulk checkout, a cache purge under a root)
+// is a gap to reconcile, not a reason to restart and lose live tracking.
+const MAX_PENDING_PATHS: usize = 4096;
+const DRAIN_IDLE_WAIT: Duration = Duration::from_millis(100);
 
 // inotify has no kernel-side recursion: every watched directory costs one
 // entry in the per-user watch table (fs.inotify.max_user_watches, 65536 by
@@ -24,7 +31,7 @@ const EVENT_CHANNEL_CAPACITY: usize = 256;
 // whole user and starved other watchers on the machine.
 const MAX_WATCH_DIR_DEPTH: usize = 2;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum OutputEvent {
     Add,
     Change,
@@ -39,18 +46,117 @@ impl OutputEvent {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct PendingPath {
+    /// Latest event kind to report for the path; none when only the watch set
+    /// may need extending.
+    output: Option<OutputEvent>,
+    /// The path may be a directory that appeared at an observable depth.
+    may_be_directory: bool,
+}
+
+/// Path-keyed coalescing queue between the notify callback and the drain loop.
+/// The callback only records; every blocking filesystem call (canonicalize,
+/// read_dir, watch installation) happens on the drain side, so a slow drain
+/// can never stall the notify thread or lose events to a full channel.
+#[derive(Debug, Default)]
+struct PendingEvents {
+    order: Vec<PathBuf>,
+    paths: HashMap<PathBuf, PendingPath>,
+    /// More than `MAX_PENDING_PATHS` distinct paths were pending: the backlog
+    /// was dropped and the host must rescan.
+    overflowed: bool,
+    /// The backend reported an error; the watch set can no longer be trusted.
+    failed: bool,
+}
+
+impl PendingEvents {
+    fn is_idle(&self) -> bool {
+        self.order.is_empty() && !self.overflowed && !self.failed
+    }
+
+    fn push(&mut self, event: Event) {
+        let may_be_directory = matches!(
+            event.kind,
+            EventKind::Create(_)
+                | EventKind::Modify(ModifyKind::Name(RenameMode::Both | RenameMode::To))
+        );
+        let output = output_event(event.kind);
+        if output.is_none() && !may_be_directory {
+            return;
+        }
+        let destination_only = output.is_some_and(|(_, destination_only)| destination_only);
+        let last = event.paths.len().saturating_sub(1);
+        for (index, path) in event.paths.into_iter().enumerate() {
+            let kind =
+                output.and_then(|(kind, _)| (!destination_only || index == last).then_some(kind));
+            self.record(path, kind, may_be_directory);
+        }
+    }
+
+    fn record(&mut self, path: PathBuf, output: Option<OutputEvent>, may_be_directory: bool) {
+        if self.overflowed {
+            // The rescan the host performs after the resync frame covers this.
+            return;
+        }
+        if !self.paths.contains_key(&path) {
+            if self.paths.len() >= MAX_PENDING_PATHS {
+                self.order.clear();
+                self.paths.clear();
+                self.overflowed = true;
+                return;
+            }
+            self.order.push(path.clone());
+        }
+        let entry = self.paths.entry(path).or_default();
+        if output.is_some() {
+            entry.output = output;
+        }
+        entry.may_be_directory |= may_be_directory;
+    }
+}
+
+#[derive(Default)]
+struct EventQueue {
+    pending: Mutex<PendingEvents>,
+    wake: Condvar,
+}
+
+impl EventQueue {
+    fn lock(&self) -> MutexGuard<'_, PendingEvents> {
+        self.pending.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    fn record(&self, result: notify::Result<Event>) {
+        let mut pending = self.lock();
+        match result {
+            Ok(event) => pending.push(event),
+            Err(_) => pending.failed = true,
+        }
+        drop(pending);
+        self.wake.notify_one();
+    }
+
+    /// Takes everything recorded so far, waiting briefly first when idle.
+    fn take(&self) -> PendingEvents {
+        let mut pending = self.lock();
+        if pending.is_idle() {
+            pending = self
+                .wake
+                .wait_timeout(pending, DRAIN_IDLE_WAIT)
+                .unwrap_or_else(PoisonError::into_inner)
+                .0;
+        }
+        std::mem::take(&mut *pending)
+    }
+}
+
 /// Runs a parent-owned depth-bounded watcher until stdin reaches EOF.
 pub fn run(roots: Vec<PathBuf>) -> bool {
-    let (events_tx, events_rx) = mpsc::sync_channel(EVENT_CHANNEL_CAPACITY);
-    let failed = Arc::new(AtomicBool::new(false));
-    let callback_failed = Arc::clone(&failed);
+    let queue = Arc::new(EventQueue::default());
+    let callback_queue = Arc::clone(&queue);
     let mut watcher = match RecommendedWatcher::new(
-        move |result: notify::Result<Event>| match events_tx.try_send(result.map_err(|_| ())) {
-            Ok(()) => {}
-            Err(TrySendError::Full(_)) | Err(TrySendError::Disconnected(_)) => {
-                callback_failed.store(true, Ordering::Release);
-            }
-        },
+        move |result: notify::Result<Event>| callback_queue.record(result),
         Config::default(),
     ) {
         Ok(watcher) => watcher,
@@ -85,9 +191,6 @@ pub fn run(roots: Vec<PathBuf>) -> bool {
     }
 
     loop {
-        if failed.load(Ordering::Acquire) {
-            return fail();
-        }
         match shutdown_rx.try_recv() {
             Ok(true) => return true,
             Ok(false) => return fail(),
@@ -95,19 +198,43 @@ pub fn run(roots: Vec<PathBuf>) -> bool {
             Err(mpsc::TryRecvError::Empty) => {}
         }
 
-        match events_rx.recv_timeout(Duration::from_millis(100)) {
-            Ok(Ok(event)) => {
-                if !watch_created_directories(&mut stdout, &mut watcher, &roots, &event) {
-                    return fail();
-                }
-                if !write_event_frames(&mut stdout, &roots, event) {
-                    return fail();
+        let batch = queue.take();
+        if batch.failed {
+            return fail();
+        }
+        if batch.overflowed && !resync(&mut stdout, &mut watcher, &roots) {
+            return fail();
+        }
+        for path in &batch.order {
+            let Some(entry) = batch.paths.get(path) else {
+                continue;
+            };
+            if entry.may_be_directory
+                && !watch_created_directory(&mut stdout, &mut watcher, &roots, path)
+            {
+                return fail();
+            }
+            if let Some(kind) = entry.output {
+                if let Some(frame) = frame_for_path(kind, path, &roots) {
+                    if stdout.write_all(&frame).is_err() || stdout.flush().is_err() {
+                        return fail();
+                    }
                 }
             }
-            Ok(Err(())) | Err(RecvTimeoutError::Disconnected) => return fail(),
-            Err(RecvTimeoutError::Timeout) => {}
         }
     }
+}
+
+/// The queue dropped events. Directories created meanwhile may lack watches,
+/// so re-walk the roots (claiming watches only), then tell the host to rescan:
+/// it owns the transcript index and reconciles far cheaper than a restart.
+fn resync<W: Watcher>(stdout: &mut impl Write, watcher: &mut W, roots: &[PathBuf]) -> bool {
+    for root in roots {
+        if !watch_directory_tree(watcher, stdout, roots, root, 0, false) {
+            return false;
+        }
+    }
+    stdout.write_all(RESYNC_FRAME).is_ok() && stdout.flush().is_ok()
 }
 
 fn wait_for_stdin_eof() -> bool {
@@ -184,41 +311,25 @@ fn is_vanished_directory_error(error: &notify::Error) -> bool {
 
 /// Extends the watch set when a directory appears inside a root at an
 /// observable depth, whether freshly created or moved in.
-fn watch_created_directories<W: Watcher>(
+fn watch_created_directory<W: Watcher>(
     stdout: &mut impl Write,
     watcher: &mut W,
     roots: &[PathBuf],
-    event: &Event,
+    path: &Path,
 ) -> bool {
-    let relevant = matches!(
-        event.kind,
-        EventKind::Create(_)
-            | EventKind::Modify(notify::event::ModifyKind::Name(
-                notify::event::RenameMode::Both | notify::event::RenameMode::To
-            ))
-    );
-    if !relevant {
+    let Ok(resolved) = std::fs::canonicalize(path) else {
+        return true;
+    };
+    if !resolved.is_dir() {
         return true;
     }
-
-    for path in &event.paths {
-        let Ok(resolved) = std::fs::canonicalize(path) else {
-            continue;
-        };
-        if !resolved.is_dir() {
-            continue;
-        }
-        let Some(depth) = directory_depth(&resolved, roots) else {
-            continue;
-        };
-        if depth == 0 || depth > MAX_WATCH_DIR_DEPTH {
-            continue;
-        }
-        if !watch_directory_tree(watcher, stdout, roots, &resolved, depth, true) {
-            return false;
-        }
+    let Some(depth) = directory_depth(&resolved, roots) else {
+        return true;
+    };
+    if depth == 0 || depth > MAX_WATCH_DIR_DEPTH {
+        return true;
     }
-    true
+    watch_directory_tree(watcher, stdout, roots, &resolved, depth, true)
 }
 
 /// Depth of `path` below the closest containing root (the root itself is 0).
@@ -238,33 +349,13 @@ fn directory_depth(path: &Path, roots: &[PathBuf]) -> Option<usize> {
         .min()
 }
 
-fn write_event_frames(stdout: &mut impl Write, roots: &[PathBuf], event: Event) -> bool {
-    let Some((kind, destination_only)) = output_event(event.kind) else {
-        return true;
-    };
-
-    let paths: &[PathBuf] = if destination_only {
-        event.paths.last().map_or(&[], std::slice::from_ref)
-    } else {
-        &event.paths
-    };
-    for path in paths {
-        if let Some(frame) = frame_for_path(kind, path, roots) {
-            if stdout.write_all(&frame).is_err() || stdout.flush().is_err() {
-                return false;
-            }
-        }
-    }
-    true
-}
-
+/// Frame kind for an event, and whether only the last (destination) path of
+/// the event names the file to report.
 fn output_event(kind: EventKind) -> Option<(OutputEvent, bool)> {
     match kind {
         EventKind::Create(_) => Some((OutputEvent::Add, false)),
-        EventKind::Modify(notify::event::ModifyKind::Name(notify::event::RenameMode::From)) => None,
-        EventKind::Modify(notify::event::ModifyKind::Name(notify::event::RenameMode::Both)) => {
-            Some((OutputEvent::Change, true))
-        }
+        EventKind::Modify(ModifyKind::Name(RenameMode::From)) => None,
+        EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => Some((OutputEvent::Change, true)),
         EventKind::Modify(_) => Some((OutputEvent::Change, false)),
         _ => None,
     }
@@ -341,11 +432,130 @@ fn fail() -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        OutputEvent, directory_depth, frame_for_path, frame_for_resolved_path, watch_directory_tree,
+        EventQueue, MAX_PENDING_PATHS, OutputEvent, PendingEvents, PendingPath, directory_depth,
+        frame_for_path, frame_for_resolved_path, watch_directory_tree,
     };
-    use notify::{Config, EventHandler, RecursiveMode, Watcher, WatcherKind};
+    use notify::event::{CreateKind, DataChange, ModifyKind, RemoveKind, RenameMode};
+    use notify::{Config, Event, EventHandler, EventKind, RecursiveMode, Watcher, WatcherKind};
     use std::fs;
     use std::path::{Path, PathBuf};
+
+    fn event(kind: EventKind, paths: &[&str]) -> Event {
+        paths.iter().fold(Event::new(kind), |event, path| {
+            event.add_path(PathBuf::from(path))
+        })
+    }
+
+    fn change(path: &str) -> Event {
+        event(
+            EventKind::Modify(ModifyKind::Data(DataChange::Any)),
+            &[path],
+        )
+    }
+
+    #[test]
+    fn coalesces_events_per_path_in_arrival_order_keeping_the_latest_kind() {
+        let mut pending = PendingEvents::default();
+        pending.push(event(EventKind::Create(CreateKind::File), &["/r/a.jsonl"]));
+        pending.push(change("/r/b.jsonl"));
+        pending.push(change("/r/a.jsonl"));
+        assert_eq!(
+            pending.order,
+            [PathBuf::from("/r/a.jsonl"), PathBuf::from("/r/b.jsonl")]
+        );
+        assert_eq!(
+            pending.paths[Path::new("/r/a.jsonl")],
+            PendingPath {
+                output: Some(OutputEvent::Change),
+                may_be_directory: true,
+            }
+        );
+        assert_eq!(
+            pending.paths[Path::new("/r/b.jsonl")],
+            PendingPath {
+                output: Some(OutputEvent::Change),
+                may_be_directory: false,
+            }
+        );
+
+        // A rename reports only its destination, but either side may be a
+        // directory the watch set has to follow.
+        pending.push(event(
+            EventKind::Modify(ModifyKind::Name(RenameMode::Both)),
+            &["/r/old", "/r/new"],
+        ));
+        assert_eq!(
+            pending.paths[Path::new("/r/old")],
+            PendingPath {
+                output: None,
+                may_be_directory: true,
+            }
+        );
+        assert_eq!(
+            pending.paths[Path::new("/r/new")],
+            PendingPath {
+                output: Some(OutputEvent::Change),
+                may_be_directory: true,
+            }
+        );
+
+        // Removals and rename sources carry nothing the host acts on.
+        pending.push(event(EventKind::Remove(RemoveKind::File), &["/r/gone"]));
+        pending.push(event(
+            EventKind::Modify(ModifyKind::Name(RenameMode::From)),
+            &["/r/moved-away"],
+        ));
+        assert!(!pending.paths.contains_key(Path::new("/r/gone")));
+        assert!(!pending.paths.contains_key(Path::new("/r/moved-away")));
+        assert!(!pending.overflowed);
+    }
+
+    #[test]
+    fn overflow_drops_the_backlog_and_asks_for_a_resync_instead_of_failing() {
+        let mut pending = PendingEvents::default();
+        for index in 0..MAX_PENDING_PATHS {
+            pending.push(change(&format!("/r/{index}.jsonl")));
+        }
+        assert!(!pending.overflowed);
+        assert_eq!(pending.paths.len(), MAX_PENDING_PATHS);
+
+        // Re-touching a known path is coalesced, never counted again.
+        pending.push(change("/r/0.jsonl"));
+        assert!(!pending.overflowed);
+
+        pending.push(change("/r/one-too-many.jsonl"));
+        assert!(pending.overflowed);
+        assert!(!pending.failed);
+        assert!(pending.order.is_empty());
+        assert!(pending.paths.is_empty());
+
+        // Until the drain takes the batch, later events are not remembered:
+        // the rescan the resync frame triggers covers them.
+        pending.push(change("/r/later.jsonl"));
+        assert!(pending.paths.is_empty());
+
+        let taken = std::mem::take(&mut pending);
+        assert!(taken.overflowed);
+        assert!(pending.is_idle());
+    }
+
+    #[test]
+    fn queue_hands_over_batches_and_flags_backend_errors() {
+        let queue = EventQueue::default();
+        queue.record(Ok(event(
+            EventKind::Create(CreateKind::File),
+            &["/r/a.jsonl"],
+        )));
+        let batch = queue.take();
+        assert_eq!(batch.order, [PathBuf::from("/r/a.jsonl")]);
+        assert!(!batch.failed);
+
+        queue.record(Err(notify::Error::generic("backend")));
+        assert!(queue.take().failed);
+
+        // An idle queue yields an empty batch after the bounded wait.
+        assert!(queue.take().is_idle());
+    }
     struct FailingWatcher {
         error: Option<notify::Error>,
     }

--- a/native/chatmux-core/src/watcher.rs
+++ b/native/chatmux-core/src/watcher.rs
@@ -76,6 +76,15 @@ impl PendingEvents {
     }
 
     fn push(&mut self, event: Event) {
+        if event.need_rescan() {
+            // The kernel queue itself overflowed (IN_Q_OVERFLOW): notify
+            // reports it as an event, not an error, and nothing after it can
+            // be trusted. Same remedy as our own overflow: drop and rescan.
+            self.order.clear();
+            self.paths.clear();
+            self.overflowed = true;
+            return;
+        }
         let may_be_directory = matches!(
             event.kind,
             EventKind::Create(_)
@@ -435,7 +444,7 @@ mod tests {
         EventQueue, MAX_PENDING_PATHS, OutputEvent, PendingEvents, PendingPath, directory_depth,
         frame_for_path, frame_for_resolved_path, watch_directory_tree,
     };
-    use notify::event::{CreateKind, DataChange, ModifyKind, RemoveKind, RenameMode};
+    use notify::event::{CreateKind, DataChange, Flag, ModifyKind, RemoveKind, RenameMode};
     use notify::{Config, Event, EventHandler, EventKind, RecursiveMode, Watcher, WatcherKind};
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -537,6 +546,21 @@ mod tests {
         let taken = std::mem::take(&mut pending);
         assert!(taken.overflowed);
         assert!(pending.is_idle());
+    }
+
+    #[test]
+    fn a_kernel_rescan_notice_is_treated_as_an_overflow() {
+        let mut pending = PendingEvents::default();
+        pending.push(change("/r/a.jsonl"));
+        pending.push(Event::new(EventKind::Other).set_flag(Flag::Rescan));
+        assert!(pending.overflowed);
+        assert!(!pending.failed);
+        assert!(pending.paths.is_empty());
+
+        // A plain "other" event without the flag stays ignorable.
+        let mut quiet = PendingEvents::default();
+        quiet.push(Event::new(EventKind::Other));
+        assert!(quiet.is_idle());
     }
 
     #[test]

--- a/server/modules/providers/services/gjc-session-watcher.service.ts
+++ b/server/modules/providers/services/gjc-session-watcher.service.ts
@@ -5,6 +5,8 @@ const MAX_FRAME_BYTES = 64 * 1024;
 const MAX_QUEUED_PATHS = 4096;
 const FAILURE_MESSAGE = 'GJC session watcher failed.';
 const CALLBACK_FAILURE_MESSAGE = 'GJC session watcher callback failed.';
+const RESYNC_FAILURE_MESSAGE = 'GJC session watcher resync failed.';
+const QUEUE_OVERFLOW_MESSAGE = 'GJC session watcher queue overflowed; rescanning transcripts.';
 const STDERR_MESSAGE = 'GJC session watcher emitted diagnostics.';
 
 /**
@@ -23,8 +25,7 @@ export type GjcSessionWatcherFailureReason =
   | 'oversized-frame'
   | 'invalid-utf8'
   | 'malformed-json'
-  | 'protocol-violation'
-  | 'queue-overflow';
+  | 'protocol-violation';
 
 /** Exit status is numeric/signal-name only, so it is safe to attach to a reason. */
 function exitDetail(code: unknown, signal: unknown): string {
@@ -65,6 +66,13 @@ type Spawn = (
 export type GjcSessionWatcherOptions = {
   roots: readonly string[];
   onEvent: (event: GjcSessionWatchEvent, signal: AbortSignal) => unknown;
+  /**
+   * Individual events were lost, either because the native watcher's queue
+   * overflowed (it then emits a resync frame) or because this client's own
+   * queue did. The owner rescans the roots; events queued before the gap are
+   * dropped because the rescan supersedes them.
+   */
+  onResync?: (signal: AbortSignal) => unknown;
   onFailure: (error: Error) => unknown;
   corePath?: string;
   spawn?: Spawn;
@@ -104,7 +112,7 @@ function safeCall(callback: () => unknown): void {
 
 /** Watches GJC transcript files through the mandatory native Protocol v1 host. */
 export class GjcSessionWatcher {
-  private readonly options: Required<Pick<GjcSessionWatcherOptions, 'spawn' | 'platform' | 'environment' | 'readyTimeoutMs' | 'closeDrainTimeoutMs' | 'closeExitTimeoutMs' | 'diagnostic'>> & Pick<GjcSessionWatcherOptions, 'corePath' | 'compiled' | 'roots' | 'onEvent' | 'onFailure'>;
+  private readonly options: Required<Pick<GjcSessionWatcherOptions, 'spawn' | 'platform' | 'environment' | 'readyTimeoutMs' | 'closeDrainTimeoutMs' | 'closeExitTimeoutMs' | 'diagnostic'>> & Pick<GjcSessionWatcherOptions, 'corePath' | 'compiled' | 'roots' | 'onEvent' | 'onResync' | 'onFailure'>;
   private child?: Child;
   private starting?: Promise<void>;
   private closing?: Promise<void>;
@@ -117,6 +125,7 @@ export class GjcSessionWatcher {
   private exitedOnce = false;
   private input = Buffer.alloc(0);
   private readonly pending = new Map<string, GjcSessionWatchEvent>();
+  private resyncRequested = false;
   private draining = false;
   private drainDone = deferred();
   private drainCancelled = false;
@@ -126,6 +135,7 @@ export class GjcSessionWatcher {
     this.options = {
       roots: options.roots,
       onEvent: options.onEvent,
+      onResync: options.onResync,
       onFailure: options.onFailure,
       corePath: options.corePath,
       compiled: options.compiled,
@@ -228,6 +238,11 @@ export class GjcSessionWatcher {
       this.started.resolve();
       return;
     }
+    if (record.kind === 'resync') {
+      if (!this.ready || keys.length !== 2 || !keys.includes('protocolVersion') || !keys.includes('kind')) return this.fail('protocol-violation');
+      this.requestResync();
+      return;
+    }
     if (
       record.kind !== 'event' ||
       (record.event !== 'add' && record.event !== 'change') ||
@@ -243,8 +258,20 @@ export class GjcSessionWatcher {
     ) {
       return this.fail('protocol-violation');
     }
-    if (!this.pending.has(record.path) && this.pending.size >= MAX_QUEUED_PATHS) return this.fail('queue-overflow');
+    if (!this.pending.has(record.path) && this.pending.size >= MAX_QUEUED_PATHS) {
+      // Same shape as the native side's overflow: a burst is a gap for the
+      // owner to reconcile, not a reason to restart and lose live tracking.
+      this.diagnose(QUEUE_OVERFLOW_MESSAGE);
+      this.requestResync();
+      return;
+    }
     this.pending.set(record.path, { kind: record.event, path: record.path });
+    void this.drain();
+  }
+
+  private requestResync(): void {
+    this.pending.clear();
+    this.resyncRequested = true;
     void this.drain();
   }
 
@@ -253,7 +280,16 @@ export class GjcSessionWatcher {
     this.drainDone = deferred();
     this.draining = true;
     try {
-      while (!this.failed && !this.drainCancelled && this.pending.size > 0) {
+      while (!this.failed && !this.drainCancelled && (this.resyncRequested || this.pending.size > 0)) {
+        if (this.resyncRequested) {
+          this.resyncRequested = false;
+          try {
+            await this.options.onResync?.(this.drainAbort.signal);
+          } catch {
+            if (!this.drainCancelled) this.diagnose(RESYNC_FAILURE_MESSAGE);
+          }
+          continue;
+        }
         const event = this.pending.values().next().value as GjcSessionWatchEvent;
         this.pending.delete(event.path);
         try {
@@ -264,7 +300,7 @@ export class GjcSessionWatcher {
       }
     } finally {
       this.draining = false;
-      if (this.pending.size === 0 || this.drainCancelled) this.drainDone.resolve();
+      if ((this.pending.size === 0 && !this.resyncRequested) || this.drainCancelled) this.drainDone.resolve();
     }
   }
 
@@ -282,6 +318,7 @@ export class GjcSessionWatcher {
     this.failed = true;
     this.drainCancelled = true;
     this.pending.clear();
+    this.resyncRequested = false;
     this.drainAbort.abort();
     this.drainDone.resolve();
     const cause = detail === undefined ? reason : `${reason} ${detail}`;

--- a/server/modules/providers/services/sessions-watcher.service.ts
+++ b/server/modules/providers/services/sessions-watcher.service.ts
@@ -478,6 +478,17 @@ function scheduleGjcWatcherRestart(): void {
   gjcWatcherRestartTimer.unref?.();
 }
 
+/** Rescans the GJC roots after the watcher lost events, as the startup reconcile does. */
+async function reconcileGjcTranscriptsAfterGap(signal: AbortSignal): Promise<void> {
+  if (signal.aborted || sessionWatchersClosing) return;
+  const reconciliation = await sessionSynchronizerService.reconcileProvider('gjc', signal);
+  if (signal.aborted || sessionWatchersClosing) return;
+  for (const sessionId of reconciliation.sessionIds) {
+    markTranscriptChanged('gjc', providerSessionIdForIndexed('gjc', sessionId));
+    queuePendingWatcherUpdate('change', 'gjc', sessionId);
+  }
+}
+
 async function runGjcSessionWatcherStart(
   reconcileAfterStart: boolean,
   controller: AbortController
@@ -519,6 +530,9 @@ async function runGjcSessionWatcherStart(
   const watcher = new GjcSessionWatcher({
     roots: GJC_WATCH_PATHS,
     onEvent: (event, signal) => queueFileUpdate(event.kind, event.path, 'gjc', signal),
+    // The native watcher (or this client) dropped events under a burst. One
+    // provider-wide reconcile closes the gap; the watcher keeps running.
+    onResync: (signal) => reconcileGjcTranscriptsAfterGap(signal),
     onFailure: reportFailure,
     diagnostic: (message) => console.error(message),
   });

--- a/server/modules/providers/tests/gjc-session-watcher.test.ts
+++ b/server/modules/providers/tests/gjc-session-watcher.test.ts
@@ -35,14 +35,16 @@ class FakeChild extends EventEmitter {
 
 type SpawnCall = { command: string; args: string[]; options: unknown };
 
-function setup(overrides: Partial<GjcSessionWatcherOptions> = {}): { watcher: GjcSessionWatcher; child: FakeChild; calls: SpawnCall[]; events: { kind: 'add' | 'change'; path: string }[]; failures: Error[] } {
+function setup(overrides: Partial<GjcSessionWatcherOptions> = {}): { watcher: GjcSessionWatcher; child: FakeChild; calls: SpawnCall[]; events: { kind: 'add' | 'change'; path: string }[]; resyncs: number[]; failures: Error[] } {
   const child = new FakeChild();
   const calls: SpawnCall[] = [];
   const events: { kind: 'add' | 'change'; path: string }[] = [];
+  const resyncs: number[] = [];
   const failures: Error[] = [];
   const watcher = new GjcSessionWatcher({
     roots: ['/one', '/two'],
     onEvent: (event) => events.push(event),
+    onResync: () => resyncs.push(events.length),
     onFailure: (error) => failures.push(error),
     spawn: ((command: string, args: string[], options: unknown) => {
       calls.push({ command, args, options });
@@ -53,7 +55,7 @@ function setup(overrides: Partial<GjcSessionWatcherOptions> = {}): { watcher: Gj
     closeExitTimeoutMs: 10,
     ...overrides,
   });
-  return { watcher, child, calls, events, failures };
+  return { watcher, child, calls, events, resyncs, failures };
 }
 
 async function ready(watcher: GjcSessionWatcher, child: FakeChild): Promise<void> {
@@ -151,10 +153,16 @@ test('contains callback diagnostics and continues without exposing event paths',
   assert.doesNotMatch(diagnostics.join(' '), /secret-path|sensitive/u);
 });
 
-test('fails closed when distinct queued paths exceed the fixed bound', async () => {
+test('degrades to one resync when distinct queued paths exceed the fixed bound, without failing or naming paths', async () => {
   let release!: () => void;
   const hold = new Promise<void>((resolve) => { release = resolve; });
-  const { watcher, child, failures } = setup({ onEvent: () => hold });
+  const diagnostics: string[] = [];
+  const events: string[] = [];
+  const { watcher, child, failures } = setup({
+    onEvent: async (event) => { events.push(event.path); if (event.path === 'blocking') await hold; },
+    onResync: () => { events.push('<rescan>'); },
+    diagnostic: (message) => diagnostics.push(message),
+  });
   await ready(watcher, child);
   child.output('{"protocolVersion":1,"kind":"event","event":"add","path":"blocking"}\n');
   await Promise.resolve();
@@ -162,10 +170,53 @@ test('fails closed when distinct queued paths exceed the fixed bound', async () 
   child.output(Array.from({ length: 4097 }, (_, index) => (
     `{"protocolVersion":1,"kind":"event","event":"change","path":"queued-${index}"}\n`
   )).join(''));
-
-  assert.equal(failures.length, 1);
-  assert.doesNotMatch(failures[0].message, /queued-/u);
+  // Events after the overflow are queued behind the rescan and still delivered.
+  child.output('{"protocolVersion":1,"kind":"event","event":"add","path":"after-gap"}\n');
   release();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(failures, []);
+  assert.deepEqual(events, ['blocking', '<rescan>', 'after-gap'], 'one rescan after the blocking callback; the superseded backlog is dropped');
+  assert.ok(diagnostics.some((message) => /overflowed/u.test(message)));
+  assert.ok(diagnostics.every((message) => !/queued-|blocking|after-gap/u.test(message)));
+});
+
+test('a native resync frame drops the queued backlog, rescans once, then resumes ordinary events', async () => {
+  let release!: () => void;
+  const hold = new Promise<void>((resolve) => { release = resolve; });
+  const events: string[] = [];
+  const { watcher, child, failures } = setup({
+    onEvent: async (event) => { events.push(event.path); if (event.path === 'blocking') await hold; },
+    onResync: () => { events.push('<rescan>'); },
+  });
+  await ready(watcher, child);
+  child.output('{"protocolVersion":1,"kind":"event","event":"add","path":"blocking"}\n');
+  await Promise.resolve();
+  child.output('{"protocolVersion":1,"kind":"event","event":"change","path":"stale"}\n');
+  child.output('{"protocolVersion":1,"kind":"resync"}\n{"protocolVersion":1,"kind":"resync"}\n');
+  child.output('{"protocolVersion":1,"kind":"event","event":"add","path":"fresh"}\n');
+  release();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(failures, []);
+  assert.deepEqual(events, ['blocking', '<rescan>', 'fresh'], 'back-to-back resync frames collapse into one rescan');
+});
+
+test('a resync frame before readiness or with extra keys is a protocol violation', async () => {
+  for (const [frame, primeReady] of [
+    ['{"protocolVersion":1,"kind":"resync"}\n', false],
+    ['{"protocolVersion":1,"kind":"resync","path":"secret-path"}\n', true],
+  ] as const) {
+    const { watcher, child, resyncs, failures } = setup();
+    if (primeReady) await ready(watcher, child);
+    else void watcher.start().catch(() => {});
+    child.output(frame);
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(failures.length, 1, frame);
+    assert.equal(failures[0].cause, 'protocol-violation');
+    assert.doesNotMatch(failures[0].message, /secret-path/u);
+    assert.deepEqual(resyncs, []);
+  }
 });
 
 test('close cancels queued callbacks at its deadline and reaps a non-exiting child', async () => {


### PR DESCRIPTION
## Summary

Medium batch 8 from the September review (finding R13).

- `native/chatmux-core/src/watcher.rs`: the notify callback records into a path-keyed coalescing queue (latest kind wins, insertion order kept) instead of a 256-slot channel whose overflow was fatal. All blocking filesystem work (canonicalize, read_dir, watch installation) moves to the drain side, so the notify thread never stalls.
- Past 4096 distinct pending paths the backlog is dropped, the roots are re-walked to claim watches for directories created during the gap, and a `{"protocolVersion":1,"kind":"resync"}` frame asks the host to rescan. Backend errors still fail the watcher as before.
- `gjc-session-watcher.service.ts`: accepts the resync frame (ready required, exact keys), exposes `onResync`, and applies the same degrade-to-rescan rule to its own 4096-path queue instead of failing with `queue-overflow`. Back-to-back resyncs collapse into one rescan; events after the gap are delivered after it.
- `sessions-watcher.service.ts`: a resync runs one `reconcileProvider('gjc')` pass and marks the returned sessions changed, the same as the startup reconcile; the watcher keeps running.

Hosts that predate this change never see a resync frame unless paired with the new binary, and the frame is rejected as a protocol violation there, which is the pre-existing fail-closed behaviour.

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets -D warnings`, `cargo test` (22 pass; 3 new: coalescing, overflow, queue handover)
- [x] `server/modules/providers/tests/gjc-session-watcher.test.ts` (15 pass; overflow test rewritten, 2 resync tests added)
- [x] `tsc --noEmit -p server/tsconfig.json`, eslint on touched files
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)