### PR TITLE
fix(tmux): strip paste control characters, recheck panes before kills, refuse dotted session names

### DIFF
--- a/server/modules/providers/services/builtin-relay.service.ts
+++ b/server/modules/providers/services/builtin-relay.service.ts
@@ -85,7 +85,10 @@ function runCollected(command: string, args: string[], stdin?: string): Promise<
   });
 }
 
-const NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+// tmux rewrites '.' and ':' in a session name to '_' (session_check_name), so
+// a name with a dot would be created under a different name than the one the
+// duplicate check and the returned tmuxName refer to. Refuse it up front.
+const NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
 
 async function hasSession(name: string, run: TmuxRunner): Promise<boolean> {
   try {
@@ -130,7 +133,7 @@ export async function builtinSpawn(
   const spawnRun = deps.spawnRun ?? (deps.run === undefined ? runTmuxSpawn : deps.run);
   const fail = (detail: string): LiveSpawnResult => ({ ok: false, reachable: true, conflict: false, detail });
   if (!NAME_RE.test(name) || name.toLowerCase().startsWith('company')) {
-    return fail('잘못된 세션명 (company*는 예약됨)');
+    return fail('잘못된 세션명 (영문·숫자·_·- 만, company*는 예약됨)');
   }
   const resolvedCwd = await resolveSpawnCwd(cwd, deps.home);
   if (!resolvedCwd) {

--- a/server/modules/providers/services/live-send.service.ts
+++ b/server/modules/providers/services/live-send.service.ts
@@ -10,7 +10,9 @@ export function towerUrl(): string {
 
 // tmux session names are simple tokens; reject anything that could be an argv/shell
 // surprise before it reaches the tower (the tower validates too — defence in depth).
-const TMUX_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+// '.' and ':' are excluded because tmux silently rewrites them to '_', which
+// would leave every later lookup pointing at a name that does not exist.
+const TMUX_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
 
 export function isValidTmuxName(name: unknown): name is string {
   return typeof name === 'string' && TMUX_NAME_RE.test(name);

--- a/server/modules/providers/services/tmux-pane-actions.service.ts
+++ b/server/modules/providers/services/tmux-pane-actions.service.ts
@@ -130,17 +130,35 @@ export async function assertTmuxPaneIdentity(
   }
 }
 
+/**
+ * Text pasted into a pane travels inside a bracketed paste (`paste-buffer -p`),
+ * which the application reads as literal input only until it sees the end
+ * marker ESC [ 201 ~. A message carrying that sequence would end the paste
+ * early and turn the remainder into key input. No chat message needs terminal
+ * control characters, so every C0 control except tab and newline, DEL, and the
+ * C1 range (0x9B is an 8-bit CSI) are removed; CR and CRLF become LF.
+ */
+export function sanitizeTmuxPasteText(message: string): string {
+  return message
+    .replace(/\r\n?/g, '\n')
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F\u0080-\u009F]/g, '');
+}
+
 export async function pasteToTmuxPane(
   target: VerifiedTmuxActionTarget,
   message: string,
   run: TmuxRunner = runTmux,
 ): Promise<void> {
+  const text = sanitizeTmuxPasteText(message);
+  if (!text.trim()) {
+    throw new AppError('message is required.', { code: 'EMPTY_MESSAGE', statusCode: 400 });
+  }
   const identity = target.tmux;
   const bufferName = `chatmux-pane-${process.pid}-${++pasteBufferSequence}`;
   // Recheck before the first write so a stale pane receives no bytes. tmux cannot
   // make load/paste/Enter atomic, so replacement after this point is accepted TOCTOU.
   await assertTmuxPaneIdentity(identity, run);
-  const load = await run(['-S', identity.socketPath, 'load-buffer', '-b', bufferName, '-'], message);
+  const load = await run(['-S', identity.socketPath, 'load-buffer', '-b', bufferName, '-'], text);
   if (load.code !== 0) {
     throw new AppError('tmux could not stage the message.', {
       code: 'TMUX_PANE_SEND_FAILED',
@@ -228,11 +246,18 @@ export async function captureTmuxPane(
   return result.output;
 }
 
+/**
+ * Pane ids never repeat within a tmux server, so `%N` cannot name a different
+ * pane later; it can only have moved (join-pane, break-pane) out of the
+ * verified window or session. Recheck all four coordinates right before the
+ * kill, as the send path does, so a moved pane is refused rather than killed.
+ */
 export async function killTmuxPane(
   target: VerifiedTmuxActionTarget,
   run: TmuxRunner = runTmux,
 ): Promise<void> {
   const identity = target.tmux;
+  await assertTmuxPaneIdentity(identity, run);
   await requireTmuxSuccess(identity, ['kill-pane', '-t', identity.paneId], run);
 }
 
@@ -252,6 +277,8 @@ export async function killTmuxSession(
   options: KillTmuxSessionOptions = {},
 ): Promise<void> {
   const identity = target.tmux;
+  // The verified pane must still live in this session before the session dies.
+  await assertTmuxPaneIdentity(identity, run);
   const listed = await run(['-S', identity.socketPath, 'list-panes', '-s', '-t', identity.sessionId, '-F', '#{pane_id}']);
   if (listed.code !== 0) {
     throw new AppError('The selected tmux pane changed; reopen it from the session list.', {

--- a/server/modules/providers/tests/live-send.service.test.ts
+++ b/server/modules/providers/tests/live-send.service.test.ts
@@ -9,20 +9,22 @@ import {
 } from '@/modules/providers/services/live-send.service.js';
 
 test('isValidTmuxName accepts simple session tokens, rejects unsafe ones', () => {
-  for (const ok of ['omg', 'magi-stock', 'flask', 'company-gjc', 'a.b_c-1']) {
+  for (const ok of ['omg', 'magi-stock', 'flask', 'company-gjc', 'ab_c-1']) {
     assert.equal(isValidTmuxName(ok), true, ok);
   }
-  for (const bad of ['', ' omg', 'a b', 'a;b', 'a/b', '$(x)', '-lead', 42, null, undefined]) {
+  // tmux rewrites '.' and ':' to '_' when creating a session, so such a name
+  // would never match the session that actually exists.
+  for (const bad of ['', ' omg', 'a b', 'a;b', 'a/b', '$(x)', '-lead', 'my.proj', 'a:b', 42, null, undefined]) {
     assert.equal(isValidTmuxName(bad as unknown), false, String(bad));
   }
 });
 
 
 test('isValidSpawnName accepts safe names but rejects the reserved "company"', () => {
-  for (const ok of ['patina', 'magi-stock', 'feat_x', 'a.b_c-1']) {
+  for (const ok of ['patina', 'magi-stock', 'feat_x', 'ab_c-1']) {
     assert.equal(isValidSpawnName(ok), true, ok);
   }
-  for (const bad of ['company', 'Company', 'COMPANY', '', ' x', 'a b', 'a/b', 42, null]) {
+  for (const bad of ['company', 'Company', 'COMPANY', '', ' x', 'a b', 'a/b', 'my.proj', 42, null]) {
     assert.equal(isValidSpawnName(bad as unknown), false, String(bad));
   }
 });

--- a/server/modules/providers/tests/support/tmux-harness-utils.ts
+++ b/server/modules/providers/tests/support/tmux-harness-utils.ts
@@ -11,7 +11,7 @@ import type { FakeTmuxAgent, FakeTranscriptTmuxAgent } from './tmux-e2e-types.js
 const execFileAsync = promisify(execFile);
 const REPOSITORY_ROOT = path.resolve(fileURLToPath(new URL('../../../../../', import.meta.url)));
 const DISCOVERY_MARKER = '__CHATMUX_TMUX_E2E_SESSIONS__=';
-const SESSION_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
+const SESSION_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$/;
 const SESSION_ID_RE = /^[0-9a-fA-F][0-9a-fA-F-]{7,}$/;
 
 export class TmuxHarnessContractError extends Error {

--- a/server/modules/providers/tests/tmux-pane-actions.service.test.ts
+++ b/server/modules/providers/tests/tmux-pane-actions.service.test.ts
@@ -9,6 +9,7 @@ import {
   pasteToTmuxPane,
   readTmuxPaneIdentity,
   readTmuxProcessGeneration,
+  sanitizeTmuxPasteText,
   sendTmuxProcessAction,
   sendTmuxSelectionKeys,
   sendToTmuxPane,
@@ -102,6 +103,24 @@ test('send targets one pane and preserves literal input', async () => {
   ]);
 });
 
+test('paste strips terminal control characters so a message cannot end the bracketed paste early', async () => {
+  const { calls, run } = recordingRunner(['$7\t@8\t%9\n']);
+  const hostile = 'hello\u001b[201~rm -rf /\u001b[200~\r\nworld\u009bA\ttab\u0000\u0007\u007f';
+  await pasteToTmuxPane(target, hostile, run);
+  const staged = calls.find(({ args }) => args.includes('load-buffer'));
+  assert.equal(staged?.stdin, 'hello[201~rm -rf /[200~\nworldA\ttab', 'ESC, C1, NUL, BEL, DEL gone; tab and newline kept');
+  assert.equal(sanitizeTmuxPasteText('a\rb\r\nc\n'), 'a\nb\nc\n');
+});
+
+test('paste rejects a message that is empty once control characters are removed, before touching tmux', async () => {
+  const { calls, run } = recordingRunner(['$7\t@8\t%9\n']);
+  await assert.rejects(
+    pasteToTmuxPane(target, '\u001b\u0007 \u000b\r\n\u009b', run),
+    (error) => error instanceof AppError && error.code === 'EMPTY_MESSAGE',
+  );
+  assert.equal(calls.length, 0);
+});
+
 test('paste can stage native prompt feedback without submitting Enter', async () => {
   const { calls, run } = recordingRunner(['$7\t@8\t%9\n']);
   await pasteToTmuxPane(target, 'change the plan', run);
@@ -192,31 +211,48 @@ test('default process stop respawns a shell in the same pane', async () => {
   ]);
 });
 
-test('pane and session termination use distinct immutable ids', async () => {
-  const pane = recordingRunner();
+test('pane and session termination recheck the exact pane, then use distinct immutable ids', async () => {
+  const recheck = [
+    '-S', identity.socketPath,
+    'display-message', '-p', '-t', identity.paneId,
+    '#{session_id}\t#{window_id}\t#{pane_id}',
+  ];
+  const pane = recordingRunner(['$7\t@8\t%9\n']);
   await killTmuxPane(target, pane.run);
-  assert.deepEqual(pane.calls[0]?.args, [
+  assert.deepEqual(pane.calls[0]?.args, recheck);
+  assert.deepEqual(pane.calls[1]?.args, [
     '-S', identity.socketPath, 'kill-pane', '-t', identity.paneId,
   ]);
 
-  const session = recordingRunner([`${identity.paneId}\n`]);
+  const session = recordingRunner(['$7\t@8\t%9\n', `${identity.paneId}\n`]);
   await killTmuxSession(target, session.run);
-  assert.deepEqual(session.calls[0]?.args, [
+  assert.deepEqual(session.calls[0]?.args, recheck);
+  assert.deepEqual(session.calls[1]?.args, [
     '-S', identity.socketPath, 'list-panes', '-s', '-t', identity.sessionId, '-F', '#{pane_id}',
   ]);
-  assert.deepEqual(session.calls[1]?.args, [
+  assert.deepEqual(session.calls[2]?.args, [
     '-S', identity.socketPath, 'kill-session', '-t', identity.sessionId,
   ]);
 });
 
-test('session termination refuses to take other panes down without explicit confirmation', async () => {
-  const crowded = recordingRunner([`${identity.paneId}\n%10\n%11\n`]);
-  await assert.rejects(killTmuxSession(target, crowded.run), (error: unknown) => error instanceof AppError && error.code === 'TMUX_SESSION_HAS_OTHER_PANES');
-  assert.equal(crowded.calls.length, 1, 'nothing is killed after the refusal');
+test('termination refuses a pane that moved to another window or session', async () => {
+  const moved = recordingRunner(['$7\t@12\t%9\n']);
+  await assert.rejects(killTmuxPane(target, moved.run), (error: unknown) => error instanceof AppError && error.code === 'TMUX_PANE_GENERATION_MISMATCH');
+  assert.equal(moved.calls.some(({ args }) => args.includes('kill-pane')), false);
 
-  const confirmed = recordingRunner([`${identity.paneId}\n%10\n`]);
+  const rehomed = recordingRunner(['$30\t@8\t%9\n']);
+  await assert.rejects(killTmuxSession(target, rehomed.run, { allowOtherPanes: true }), (error: unknown) => error instanceof AppError && error.code === 'TMUX_PANE_GENERATION_MISMATCH');
+  assert.equal(rehomed.calls.some(({ args }) => args.includes('kill-session')), false);
+});
+
+test('session termination refuses to take other panes down without explicit confirmation', async () => {
+  const crowded = recordingRunner(['$7\t@8\t%9\n', `${identity.paneId}\n%10\n%11\n`]);
+  await assert.rejects(killTmuxSession(target, crowded.run), (error: unknown) => error instanceof AppError && error.code === 'TMUX_SESSION_HAS_OTHER_PANES');
+  assert.equal(crowded.calls.length, 2, 'nothing is killed after the refusal');
+
+  const confirmed = recordingRunner(['$7\t@8\t%9\n', `${identity.paneId}\n%10\n`]);
   await killTmuxSession(target, confirmed.run, { allowOtherPanes: true });
-  assert.deepEqual(confirmed.calls[1]?.args, ['-S', identity.socketPath, 'kill-session', '-t', identity.sessionId]);
+  assert.deepEqual(confirmed.calls[2]?.args, ['-S', identity.socketPath, 'kill-session', '-t', identity.sessionId]);
 
   const gone = recordingRunner();
   gone.run = async () => ({ code: 1, output: "can't find session" });


### PR DESCRIPTION
## Summary

Low batch (tmux area) from the September review: bracketed-paste escape, kill-path recheck, dotted session names.

- `tmux-pane-actions.service.ts`: new `sanitizeTmuxPasteText` runs before every paste. C0 controls except tab and newline, DEL, and C1 (0x80–0x9F, which includes the 8-bit CSI) are removed; CR and CRLF become LF. A message that is empty afterwards is rejected with `EMPTY_MESSAGE` before any tmux call. ESC is stripped rather than whole sequences, so leftover text like `[201~` is inert.
- `killTmuxPane` and `killTmuxSession` call `assertTmuxPaneIdentity` first. Pane ids never repeat within a server, so the only way `%N` can be wrong is that it moved (join-pane, break-pane); that case now returns `TMUX_PANE_GENERATION_MISMATCH` instead of killing.
- Session-name validators in `builtin-relay.service.ts`, `live-send.service.ts`, and the test harness no longer accept `.`; tmux rewrites `.` and `:` to `_` on creation, so such names never matched the session that actually existed.

Not in this batch: the `respawn-pane -k` process-stop semantics and the attach `select-window` side effect; both are larger and belong to their own PRs.

## Test plan

- [x] `tmux-pane-actions.service.test.ts` (paste sanitising, empty-after-sanitise, kill recheck and moved-pane refusal), `live-send.service.test.ts`, `builtin-relay.service.test.ts` (26 pass)
- [x] `tmux-interactive-prompt*` and `tmux-ask-selection*` tests (19 pass), since they paste through the same choke point
- [x] `tsc --noEmit -p server/tsconfig.json`, eslint on touched files
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)