### PR TITLE
fix(update): tolerate archive-derived release assets and share the checksum parser

### DIFF
--- a/server/release-update-contract.ts
+++ b/server/release-update-contract.ts
@@ -194,3 +194,38 @@ export function sanitizePublicUpdateError(value: unknown): string | undefined {
   if (!normalized) return undefined;
   return normalized.replace(/(?:\/[^\s]+|[A-Za-z]:\\[^\s]+|https?:\/\/[^\s]+|\b(?:token|secret|password)=\S+)/gi, '[redacted]').slice(0, 240);
 }
+
+/**
+ * The three assets the updater consumes must each be present exactly once.
+ * Additional assets are tolerated only when derived from the archive name
+ * (`<archive>.sha256.sig`, an attestation, …): a future release can ship a
+ * signature without stranding installs on this version, while an asset with an
+ * unrelated name still fails closed. The updater never downloads an extra asset.
+ */
+export function hasCanonicalReleaseAssetSet(names: readonly string[], archiveName: string): boolean {
+  const required = [archiveName, `${archiveName}.sha256`, 'install.sh'];
+  if (new Set(names).size !== names.length) return false;
+  if (required.some((name) => !names.includes(name))) return false;
+  return names.every((name) => required.includes(name) || name.startsWith(`${archiveName}.`));
+}
+
+/**
+ * Parses a `sha256sum`-style checksum file and returns the archive's digest.
+ * Every non-empty line must be `<64 hex><spaces>[*]<name>`, and exactly one
+ * line may name the archive; further lines (a bootstrap script hash, for
+ * instance) are allowed but never consumed. Shared with the update worker so
+ * discovery and apply cannot disagree about what a valid file looks like.
+ */
+export function parseReleaseChecksumFile(text: string, archiveName: string): string | null {
+  const lines = text.split(/\r?\n/).map((line) => line.trim()).filter((line) => line.length > 0);
+  if (lines.length === 0) return null;
+  let digest: string | null = null;
+  for (const line of lines) {
+    const entry = /^([a-f0-9]{64})\s+\*?(\S.*)$/.exec(line);
+    if (!entry) return null;
+    if (entry[2] !== archiveName) continue;
+    if (digest !== null) return null;
+    digest = entry[1];
+  }
+  return digest;
+}

--- a/server/release-update-worker.test.ts
+++ b/server/release-update-worker.test.ts
@@ -251,6 +251,30 @@ test('worker persists durable archive download progress with and without a decla
   } finally { await unsized.cleanup(); }
 });
 
+test('worker accepts a multi-line checksum file and rejects one that names the archive twice', async () => {
+  const twoLine = await workerFixture({
+    fetch: (url) => (async function* () {
+      if (url.endsWith('.sha256')) { yield Buffer.from(`${'b'.repeat(64)}  install.sh\n${archiveHash} *chatmux-server-1.2.3-linux-x64-node22.tar.gz\n`); return; }
+      yield archive;
+    })(),
+  });
+  try {
+    await twoLine.worker.run(jobId);
+    assert.equal(twoLine.state.get(jobId)?.phase, 'succeeded');
+  } finally { await twoLine.cleanup(); }
+
+  const ambiguous = await workerFixture({
+    fetch: (url) => (async function* () {
+      if (url.endsWith('.sha256')) { yield Buffer.from(`${archiveHash}  chatmux-server-1.2.3-linux-x64-node22.tar.gz\n${'c'.repeat(64)}  chatmux-server-1.2.3-linux-x64-node22.tar.gz\n`); return; }
+      yield archive;
+    })(),
+  });
+  try {
+    await ambiguous.worker.run(jobId);
+    assert.equal(ambiguous.state.get(jobId)?.phase, 'failed');
+  } finally { await ambiguous.cleanup(); }
+});
+
 test('worker preserves native Response status, headers, and body across its bounded timer wrapper', async () => {
   const fixture = await workerFixture({ nativeResponse: true });
   try {

--- a/server/release-update-worker.ts
+++ b/server/release-update-worker.ts
@@ -15,6 +15,7 @@ import {
   type ReleaseUpdatePhase,
   formatHealthProbeHost,
   isHealthProbeHost,
+  parseReleaseChecksumFile,
   resolveHealthProbeHost,
 } from './release-update-contract.js';
 import { ReleaseUpdateStateStore } from './release-update-state.js';
@@ -117,9 +118,9 @@ export function validateTarListing(listing: string): void {
   if (!count) throw new ReleaseUpdateWorkerError('Archive is empty.');
 }
 function parseChecksum(text: string, expectedName: string): string {
-  const match = new RegExp(`^([a-f0-9]{64})\\s+\\*?${expectedName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'm').exec(text.trim());
-  if (!match || text.trim().split(/\r?\n/).length !== 1) throw new ReleaseUpdateWorkerError('Release checksum is malformed.');
-  return match[1];
+  const digest = parseReleaseChecksumFile(text, expectedName);
+  if (digest === null) throw new ReleaseUpdateWorkerError('Release checksum is malformed.');
+  return digest;
 }
 function isJsonObject(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);

--- a/server/self-update.test.ts
+++ b/server/self-update.test.ts
@@ -773,30 +773,55 @@ test('release updates fail closed without a strict installed version before stat
     await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
   }
 });
-test('canonical release discovery accepts only exact three-asset stable contract', async () => {
+test('canonical release discovery requires the three consumed assets once each and tolerates only archive-derived extras', async () => {
   const version = '1.2.3';
   const archive = `chatmux-server-${version}-linux-x64-node22.tar.gz`;
   const checksum = 'a'.repeat(64);
-  const fetcher = async (url: string) => ({
+  const asset = (name: string) => ({ name, browser_download_url: `https://github.com/devswha/chatmux/releases/download/v${version}/${name}` });
+  const canonical = [asset(archive), asset(`${archive}.sha256`), asset('install.sh')];
+  const fetcherFor = (assets: unknown[], checksumBody = `${checksum}  ${archive}\n`) => (async (url: string) => ({
     ok: true,
     json: async () => url.includes('/releases/latest')
-      ? { tag_name: `v${version}`, published_at: '2026-01-02T03:04:05.000Z', assets: [
-        { name: archive, browser_download_url: `https://github.com/devswha/chatmux/releases/download/v${version}/${archive}` },
-        { name: `${archive}.sha256`, browser_download_url: `https://github.com/devswha/chatmux/releases/download/v${version}/${archive}.sha256` },
-        { name: 'install.sh', browser_download_url: `https://github.com/devswha/chatmux/releases/download/v${version}/install.sh` }
-      ] }
+      ? { tag_name: `v${version}`, published_at: '2026-01-02T03:04:05.000Z', assets }
       : { schema: 1, releases: { [version]: { database: { rollbackCompatibleFrom: ['1.2.2'], schemaGeneration: 19 } } } },
-    text: async () => `${checksum}  ${archive}\n`,
+    text: async () => checksumBody,
     status: 200,
     headers: new Headers(),
-  }) as any;
-  const release = await discoverCanonicalRelease(fetcher);
+  })) as any;
+
+  const release = await discoverCanonicalRelease(fetcherFor(canonical));
   assert.equal(release.release.archiveName, archive);
+  assert.equal(release.release.archiveSha256, checksum);
   assert.deepEqual(
     release.compatibility,
     { database: { rollbackCompatibleFrom: ['1.2.2'] } },
     'a governed release declaring schemaGeneration stays discoverable and the field is stripped',
   );
+
+  // A future signature or attestation of the archive must not strand this version.
+  const signed = await discoverCanonicalRelease(fetcherFor([...canonical, asset(`${archive}.sha256.sig`), asset(`${archive}.sigstore.json`)]));
+  assert.equal(signed.release.archiveSha256, checksum);
+
+  for (const [label, assets] of [
+    ['an unrelated extra asset', [...canonical, asset('notes.txt')]],
+    ['a duplicated required asset', [...canonical, asset('install.sh')]],
+    ['a missing checksum asset', [asset(archive), asset('install.sh')]],
+    ['a checksum for a different archive', [asset(archive), asset(`chatmux-server-9.9.9-linux-x64-node22.tar.gz.sha256`), asset('install.sh')]],
+  ] as const) {
+    await assert.rejects(discoverCanonicalRelease(fetcherFor([...assets])), /assets are incomplete/, label);
+  }
+
+  // sha256sum-style bodies may carry further lines, but the archive appears exactly once.
+  const multi = await discoverCanonicalRelease(fetcherFor(canonical, `${'b'.repeat(64)}  install.sh\n${checksum} *${archive}\n`));
+  assert.equal(multi.release.archiveSha256, checksum);
+  for (const [label, body] of [
+    ['the archive named twice', `${checksum}  ${archive}\n${'c'.repeat(64)}  ${archive}\n`],
+    ['a malformed extra line', `${checksum}  ${archive}\nnot a checksum line\n`],
+    ['no line for the archive', `${'b'.repeat(64)}  install.sh\n`],
+    ['a short digest', `${'a'.repeat(63)}  ${archive}\n`],
+  ] as const) {
+    await assert.rejects(discoverCanonicalRelease(fetcherFor(canonical, body)), /checksum is invalid/, label);
+  }
 });
 function canonicalDiscoveryFetcher(checksumResponse: (url: string) => any, checksumUrl?: string, onRequest?: (url: string, init?: RequestInit) => void) {
   const version = '1.2.3';

--- a/server/self-update.ts
+++ b/server/self-update.ts
@@ -9,7 +9,7 @@ import express, { type NextFunction, type Request, type Response as ExpressRespo
 
 import { getTailscaleAccessInfo, type TailscaleAccessInfo } from './tailscale-access.js';
 import { ReleaseUpdateStateError, ReleaseUpdateStateStore } from './release-update-state.js';
-import { archiveNameForVersion, compareStrictSemVer, formatHealthProbeHost, parseStrictSemVer, resolveHealthProbeHost, validateCompatibilityMetadata, type CompatibilityMetadata, type ImmutableUpdateJobDescriptor, type ReleaseDescriptor } from './release-update-contract.js';
+import { archiveNameForVersion, compareStrictSemVer, formatHealthProbeHost, hasCanonicalReleaseAssetSet, parseReleaseChecksumFile, parseStrictSemVer, resolveHealthProbeHost, validateCompatibilityMetadata, type CompatibilityMetadata, type ImmutableUpdateJobDescriptor, type ReleaseDescriptor } from './release-update-contract.js';
 
 export type InstallMode = 'source' | 'release' | 'unknown';
 export function detectInstallMode(appRoot: string, home: string = homedir()): InstallMode {
@@ -434,20 +434,19 @@ export async function discoverCanonicalRelease(fetcher: FetchLike = fetch): Prom
   const latest = await readJson(await discoveryFetch(fetcher, 'https://api.github.com/repos/devswha/chatmux/releases/latest')) as { tag_name?: unknown; published_at?: unknown; prerelease?: unknown; draft?: unknown; assets?: unknown; body?: unknown; html_url?: unknown };
   if (latest.prerelease || latest.draft || typeof latest.tag_name !== 'string' || !latest.tag_name.startsWith('v') || !parseStrictSemVer(latest.tag_name.slice(1)) || typeof latest.published_at !== 'string' || !Array.isArray(latest.assets)) throw new Error('Canonical stable release is invalid.');
   const version = latest.tag_name.slice(1); const archiveName = archiveNameForVersion(version)!; const checksumName = `${archiveName}.sha256`;
-  const expectedNames = [archiveName, checksumName, 'install.sh'];
-  if (latest.assets.length !== expectedNames.length || latest.assets.some((asset) => !asset || typeof asset !== 'object' || typeof (asset as { name?: unknown }).name !== 'string' || typeof (asset as { browser_download_url?: unknown }).browser_download_url !== 'string')) throw new Error('Canonical release assets are incomplete.');
+  if (latest.assets.some((asset) => !asset || typeof asset !== 'object' || typeof (asset as { name?: unknown }).name !== 'string' || typeof (asset as { browser_download_url?: unknown }).browser_download_url !== 'string')) throw new Error('Canonical release assets are incomplete.');
   const names = latest.assets.map((asset) => (asset as { name: string }).name);
-  if (new Set(names).size !== names.length || names.some((name) => !expectedNames.includes(name))) throw new Error('Canonical release assets are incomplete.');
+  if (!hasCanonicalReleaseAssetSet(names, archiveName)) throw new Error('Canonical release assets are incomplete.');
   const assets = new Map(latest.assets.map((asset) => [((asset as { name: string }).name), ((asset as { browser_download_url: string }).browser_download_url)]));
   const checksumUrl = assets.get(checksumName)!;
   if (!isCanonicalChecksumAssetUrl(checksumUrl, latest.tag_name, checksumName)) throw new Error('Canonical release checksum asset is invalid.');
   const checksum = await downloadCanonicalChecksum(fetcher, checksumUrl);
-  const match = new RegExp(`^([a-f0-9]{64})  ${archiveName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}$`, 'm').exec(checksum);
-  if (!match || checksum.trim().split(/\r?\n/).length !== 1) throw new Error('Canonical release checksum is invalid.');
+  const archiveSha256 = parseReleaseChecksumFile(checksum, archiveName);
+  if (archiveSha256 === null) throw new Error('Canonical release checksum is invalid.');
   const metadata = await readJson(await discoveryFetch(fetcher, `https://raw.githubusercontent.com/devswha/chatmux/${latest.tag_name}/packaging/release/update-compatibility.json`)) as { schema?: unknown; releases?: Record<string, unknown> };
   const compatibility = metadata.schema === 1 ? validateCompatibilityMetadata(metadata.releases?.[version]) : null;
   if (!compatibility) throw new Error('Canonical release compatibility metadata is invalid.');
-  return { release: { repository: 'devswha/chatmux', tag: latest.tag_name, version, archiveName, checksumName, bootstrapName: 'install.sh', archiveSha256: match[1], publishedAt: latest.published_at }, compatibility, notes: releaseNotesFromLatest(latest, latest.tag_name) };
+  return { release: { repository: 'devswha/chatmux', tag: latest.tag_name, version, archiveName, checksumName, bootstrapName: 'install.sh', archiveSha256, publishedAt: latest.published_at }, compatibility, notes: releaseNotesFromLatest(latest, latest.tag_name) };
 }
 
 export interface SystemRouterOptions {


### PR DESCRIPTION
## Summary

First step of R14 from the September review: unblock a future signed release without changing what the updater downloads or verifies today.

- `release-update-contract.ts`: `hasCanonicalReleaseAssetSet` requires the archive, its `.sha256`, and `install.sh` exactly once each. Extra assets pass only when their name starts with `<archive>.` (a `.sha256.sig`, an attestation); anything else still fails closed. `parseReleaseChecksumFile` accepts sha256sum-style bodies where every non-empty line is `<64 hex> [*]<name>` and exactly one line names the archive.
- `self-update.ts` discovery and `release-update-worker.ts` apply both use those helpers, so the two paths can no longer disagree (discovery required two spaces, the worker allowed `\s+\*?`).
- No behaviour change for the releases published so far: three assets, one checksum line.

The signing key, `.sha256.sig` publication, and `crypto.verify` in discovery and the worker are the next release's work; this PR only makes that release installable from here.

## Test plan

- [x] `self-update.test.ts`: signed-extra accepted; unrelated extra, duplicated required, missing checksum, wrong-archive checksum rejected; multi-line body accepted; archive named twice, malformed line, missing archive line, short digest rejected
- [x] `release-update-worker.test.ts`: multi-line checksum succeeds end to end; archive named twice fails the job before apply
- [x] `release-update-contract.test.ts`, `tsc --noEmit -p server/tsconfig.json`, eslint (59 tests pass)
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)