### PR TITLE
fix(tmux): stop a child agent by verified signal instead of replacing the user's shell

### DIFF
--- a/server/modules/providers/services/process-start-time.service.ts
+++ b/server/modules/providers/services/process-start-time.service.ts
@@ -56,6 +56,26 @@ export function parseProcStatStartTicks(stat: string): number | null {
   return Number.isSafeInteger(ticks) && ticks >= 0 ? ticks : null;
 }
 
+/** Fields after the comm of /proc/<pid>/stat, counted from field 3 (state). */
+function procStatFieldsAfterComm(stat: string): string[] | null {
+  const close = stat.lastIndexOf(')');
+  if (close < 0) return null;
+  return stat.slice(close + 1).trim().split(/\s+/);
+}
+
+/** Field 3 of /proc/<pid>/stat: the one-letter scheduler state ('Z' = zombie). */
+export function parseProcStatState(stat: string): string | null {
+  const fields = procStatFieldsAfterComm(stat);
+  return fields && /^[A-Za-z]$/.test(fields[0] ?? '') ? fields[0] : null;
+}
+
+/** Field 5 of /proc/<pid>/stat: the process group id. */
+export function parseProcStatProcessGroupId(stat: string): number | null {
+  const fields = procStatFieldsAfterComm(stat);
+  const pgid = Number(fields?.[2]);
+  return Number.isSafeInteger(pgid) && pgid > 0 ? pgid : null;
+}
+
 export function parseBootTimeMs(procStat: string): number | null {
   const match = /^btime (\d+)$/m.exec(procStat);
   if (!match) return null;
@@ -86,6 +106,39 @@ async function defaultClockTicksPerSecond(run: NonNullable<ProcessStartTimeDeps[
  * portable `ps lstart` is parsed in the C locale, because the default locale
  * (Korean on the reference host) produced text Date.parse cannot read.
  */
+/**
+ * Process group of a pid. An interactive shell with job control runs each
+ * foreground job in its own group, while a pane whose root *is* the agent
+ * keeps its wrappers and binary in the root's group; that difference decides
+ * whether a shell is there to preserve when an agent is stopped.
+ */
+export async function processGroupId(pid: number, deps: ProcessStartTimeDeps = {}): Promise<number | null> {
+  const read = deps.readFile ?? defaultReadFile;
+  const run = deps.run ?? runCommand;
+  try {
+    const pgid = parseProcStatProcessGroupId(await read(`/proc/${pid}/stat`));
+    if (pgid !== null) return pgid;
+  } catch {
+    // Not Linux, or the pid vanished: fall through to the portable form.
+  }
+  try {
+    const pgid = Number((await run('ps', ['-p', String(pid), '-o', 'pgid='], { env: { ...process.env, LC_ALL: 'C' } })).trim());
+    return Number.isSafeInteger(pgid) && pgid > 0 ? pgid : null;
+  } catch {
+    return null;
+  }
+}
+
+/** True when /proc reports the pid as a zombie: exited, waiting to be reaped, no longer running anything. */
+export async function isZombieProcess(pid: number, deps: ProcessStartTimeDeps = {}): Promise<boolean> {
+  const read = deps.readFile ?? defaultReadFile;
+  try {
+    return parseProcStatState(await read(`/proc/${pid}/stat`)) === 'Z';
+  } catch {
+    return false;
+  }
+}
+
 export async function processStartMs(pid: number, deps: ProcessStartTimeDeps = {}): Promise<number | null> {
   const read = deps.readFile ?? defaultReadFile;
   const run = deps.run ?? runCommand;

--- a/server/modules/providers/services/tmux-pane-actions.service.ts
+++ b/server/modules/providers/services/tmux-pane-actions.service.ts
@@ -5,7 +5,7 @@ import { AppError } from '@/shared/utils.js';
 import type { TmuxPaneIdentity, TmuxProcessGeneration } from '../../../../shared/tmux.js';
 
 import { runTmux, type TmuxRunner } from './builtin-relay.service.js';
-import { processStartMs } from './process-start-time.service.js';
+import { isZombieProcess, processGroupId, processStartMs } from './process-start-time.service.js';
 import type { VerifiedTmuxActionTarget } from './tmux-fresh-verifier.service.js';
 
 const SESSION_ID_RE = /^\$\d+$/;
@@ -300,10 +300,14 @@ export async function killTmuxSession(
 }
 
 export type StopAgentProcessDeps = Readonly<{
-  /** Sends a signal to a pid; defaults to process.kill. */
+  /** Sends a signal to a pid, or to a whole group when pid is negative; defaults to process.kill. */
   readonly kill?: (pid: number, signal: NodeJS.Signals) => void;
   /** Reads a pid's start time; defaults to the /proc-backed processStartMs. */
   readonly startedAtMs?: (pid: number) => Promise<number | null>;
+  /** Reads a pid's process group; defaults to the /proc-backed processGroupId. */
+  readonly processGroupId?: (pid: number) => Promise<number | null>;
+  /** True when the pid is a zombie (exited, unreaped); defaults to /proc. */
+  readonly isZombie?: (pid: number) => Promise<boolean>;
   readonly sleep?: (ms: number) => Promise<void>;
 }>;
 
@@ -314,12 +318,15 @@ const STOP_POLL_MS = 100;
 /**
  * Stops the verified agent process and confirms that it is gone.
  *
- * When the agent is a child of the pane's shell it is signalled directly
- * (SIGTERM, then SIGKILL) and its exit is confirmed against the verified
- * start time, so the user's shell, history, and virtualenv survive. Only when
- * the agent *is* the pane's root process, where its exit would close the
- * pane, is the pane respawned with a shell as before. A pid whose start time
- * no longer matches the verified generation is never signalled.
+ * An interactive shell with job control runs the agent (and any launcher
+ * wrappers around it) in its own process group, distinct from the pane's
+ * root. That group is signalled as a whole (SIGTERM, then SIGKILL) and the
+ * agent's exit is confirmed against its verified start time, so the user's
+ * shell, history, and virtualenv survive. When the agent shares the pane
+ * root's group there is no shell to preserve: the pane command is the agent
+ * or its wrapper, its exit would close the pane, and the pane is respawned
+ * with a shell as before. A pid whose start time no longer matches the
+ * verified generation is never signalled.
  */
 export async function stopAgentProcessInPane(
   target: VerifiedTmuxActionTarget,
@@ -351,12 +358,20 @@ export async function stopAgentProcessInPane(
     });
   }
 
-  if (panePid === target.process.pid) {
+  const readGroup = deps.processGroupId ?? processGroupId;
+  const [paneGroup, agentGroup] = await Promise.all([readGroup(panePid), readGroup(target.process.pid)]);
+  if (agentGroup === null) {
+    throw new AppError('The tmux pane now belongs to a different agent process. Reopen it from the session list.', {
+      code: 'TMUX_PROCESS_GENERATION_MISMATCH',
+      statusCode: 409,
+    });
+  }
+  if (panePid === target.process.pid || paneGroup === agentGroup) {
     await requireTmuxSuccess(identity, [
       'respawn-pane', '-k', '-t', identity.paneId, '-c', cwd, shell,
     ], run);
   } else {
-    await signalVerifiedProcess(target.process, deps);
+    await signalVerifiedProcessGroup(target.process, agentGroup, deps);
   }
 
   for (const option of [
@@ -370,14 +385,18 @@ export async function stopAgentProcessInPane(
   }
 }
 
-async function signalVerifiedProcess(
+async function signalVerifiedProcessGroup(
   generation: Readonly<TmuxProcessGeneration>,
+  group: number,
   deps: StopAgentProcessDeps,
 ): Promise<void> {
   const kill = deps.kill ?? ((pid, signal) => process.kill(pid, signal));
   const startedAtMs = deps.startedAtMs ?? processStartMs;
+  const isZombie = deps.isZombie ?? isZombieProcess;
   const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
-  const stillVerified = async (): Promise<boolean> => (await startedAtMs(generation.pid)) === generation.startedAtMs;
+  // A zombie keeps its /proc entry (and start tick) until its parent reaps it,
+  // but it runs nothing any more, so it counts as exited.
+  const stillVerified = async (): Promise<boolean> => (await startedAtMs(generation.pid)) === generation.startedAtMs && !await isZombie(generation.pid);
   const waitForExit = async (graceMs: number): Promise<boolean> => {
     for (let waited = 0; waited < graceMs; waited += STOP_POLL_MS) {
       await sleep(STOP_POLL_MS);
@@ -393,7 +412,8 @@ async function signalVerifiedProcess(
     });
   }
   const signal = (name: NodeJS.Signals): void => {
-    try { kill(generation.pid, name); } catch (error) {
+    // Negative pid: the whole group, so launcher wrappers go with the binary.
+    try { kill(-group, name); } catch (error) {
       // ESRCH means it exited between the check and the signal; anything else is a real refusal.
       if (!(error && typeof error === 'object' && 'code' in error && error.code === 'ESRCH')) throw error;
     }

--- a/server/modules/providers/services/tmux-pane-actions.service.ts
+++ b/server/modules/providers/services/tmux-pane-actions.service.ts
@@ -358,20 +358,20 @@ export async function stopAgentProcessInPane(
     });
   }
 
-  const readGroup = deps.processGroupId ?? processGroupId;
-  const [paneGroup, agentGroup] = await Promise.all([readGroup(panePid), readGroup(target.process.pid)]);
-  if (agentGroup === null) {
-    throw new AppError('The tmux pane now belongs to a different agent process. Reopen it from the session list.', {
-      code: 'TMUX_PROCESS_GENERATION_MISMATCH',
-      statusCode: 409,
-    });
-  }
-  if (panePid === target.process.pid || paneGroup === agentGroup) {
-    await requireTmuxSuccess(identity, [
-      'respawn-pane', '-k', '-t', identity.paneId, '-c', cwd, shell,
-    ], run);
+  if (panePid === target.process.pid) {
+    // The agent is the pane's root process: nothing else lives in the pane.
+    await respawnPaneShell(identity, cwd, shell, run);
   } else {
-    await signalVerifiedProcessGroup(target.process, agentGroup, deps);
+    const readGroup = deps.processGroupId ?? processGroupId;
+    const [paneGroup, agentGroup] = await Promise.all([readGroup(panePid), readGroup(target.process.pid)]);
+    if (agentGroup === null) {
+      throw new AppError('The tmux pane now belongs to a different agent process. Reopen it from the session list.', {
+        code: 'TMUX_PROCESS_GENERATION_MISMATCH',
+        statusCode: 409,
+      });
+    }
+    if (paneGroup === agentGroup) await respawnPaneShell(identity, cwd, shell, run);
+    else await signalVerifiedProcessGroup(target.process, agentGroup, deps);
   }
 
   for (const option of [
@@ -383,6 +383,12 @@ export async function stopAgentProcessInPane(
       'set-option', '-p', '-t', identity.paneId, option, '',
     ], run);
   }
+}
+
+async function respawnPaneShell(identity: TmuxPaneIdentity, cwd: string, shell: string, run: TmuxRunner): Promise<void> {
+  await requireTmuxSuccess(identity, [
+    'respawn-pane', '-k', '-t', identity.paneId, '-c', cwd, shell,
+  ], run);
 }
 
 async function signalVerifiedProcessGroup(

--- a/server/modules/providers/services/tmux-pane-actions.service.ts
+++ b/server/modules/providers/services/tmux-pane-actions.service.ts
@@ -5,6 +5,7 @@ import { AppError } from '@/shared/utils.js';
 import type { TmuxPaneIdentity, TmuxProcessGeneration } from '../../../../shared/tmux.js';
 
 import { runTmux, type TmuxRunner } from './builtin-relay.service.js';
+import { processStartMs } from './process-start-time.service.js';
 import type { VerifiedTmuxActionTarget } from './tmux-fresh-verifier.service.js';
 
 const SESSION_ID_RE = /^\$\d+$/;
@@ -298,18 +299,42 @@ export async function killTmuxSession(
   await requireTmuxSuccess(identity, ['kill-session', '-t', identity.sessionId], run);
 }
 
+export type StopAgentProcessDeps = Readonly<{
+  /** Sends a signal to a pid; defaults to process.kill. */
+  readonly kill?: (pid: number, signal: NodeJS.Signals) => void;
+  /** Reads a pid's start time; defaults to the /proc-backed processStartMs. */
+  readonly startedAtMs?: (pid: number) => Promise<number | null>;
+  readonly sleep?: (ms: number) => Promise<void>;
+}>;
+
+const STOP_TERM_GRACE_MS = 3_000;
+const STOP_KILL_GRACE_MS = 2_000;
+const STOP_POLL_MS = 100;
+
+/**
+ * Stops the verified agent process and confirms that it is gone.
+ *
+ * When the agent is a child of the pane's shell it is signalled directly
+ * (SIGTERM, then SIGKILL) and its exit is confirmed against the verified
+ * start time, so the user's shell, history, and virtualenv survive. Only when
+ * the agent *is* the pane's root process, where its exit would close the
+ * pane, is the pane respawned with a shell as before. A pid whose start time
+ * no longer matches the verified generation is never signalled.
+ */
 export async function stopAgentProcessInPane(
   target: VerifiedTmuxActionTarget,
   run: TmuxRunner = runTmux,
   shell = process.env.SHELL && isAbsolute(process.env.SHELL) ? process.env.SHELL : '/bin/sh',
+  deps: StopAgentProcessDeps = {},
 ): Promise<void> {
   const identity = target.tmux;
   const inspected = await run([
     '-S', identity.socketPath,
     'display-message', '-p', '-t', identity.paneId,
-    '#{session_id}\t#{window_id}\t#{pane_id}\t#{pane_current_path}',
+    '#{session_id}\t#{window_id}\t#{pane_id}\t#{pane_current_path}\t#{pane_pid}',
   ]);
-  const [sessionId, windowId, paneId, cwd] = inspected.output.trim().split('\t');
+  const [sessionId, windowId, paneId, cwd, panePidText] = inspected.output.trim().split('\t');
+  const panePid = Number(panePidText);
   if (
     inspected.code !== 0
     || sessionId !== identity.sessionId
@@ -317,15 +342,23 @@ export async function stopAgentProcessInPane(
     || paneId !== identity.paneId
     || !cwd
     || !isAbsolute(cwd)
+    || !Number.isSafeInteger(panePid)
+    || panePid <= 1
   ) {
     throw new AppError('The selected tmux pane changed; reopen it from the session list.', {
       code: 'TMUX_PANE_GENERATION_MISMATCH',
       statusCode: 409,
     });
   }
-  await requireTmuxSuccess(identity, [
-    'respawn-pane', '-k', '-t', identity.paneId, '-c', cwd, shell,
-  ], run);
+
+  if (panePid === target.process.pid) {
+    await requireTmuxSuccess(identity, [
+      'respawn-pane', '-k', '-t', identity.paneId, '-c', cwd, shell,
+    ], run);
+  } else {
+    await signalVerifiedProcess(target.process, deps);
+  }
+
   for (const option of [
     '@chatmux_cli_kind',
     '@chatmux_provider_session_id',
@@ -335,4 +368,42 @@ export async function stopAgentProcessInPane(
       'set-option', '-p', '-t', identity.paneId, option, '',
     ], run);
   }
+}
+
+async function signalVerifiedProcess(
+  generation: Readonly<TmuxProcessGeneration>,
+  deps: StopAgentProcessDeps,
+): Promise<void> {
+  const kill = deps.kill ?? ((pid, signal) => process.kill(pid, signal));
+  const startedAtMs = deps.startedAtMs ?? processStartMs;
+  const sleep = deps.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const stillVerified = async (): Promise<boolean> => (await startedAtMs(generation.pid)) === generation.startedAtMs;
+  const waitForExit = async (graceMs: number): Promise<boolean> => {
+    for (let waited = 0; waited < graceMs; waited += STOP_POLL_MS) {
+      await sleep(STOP_POLL_MS);
+      if (!await stillVerified()) return true;
+    }
+    return !await stillVerified();
+  };
+
+  if (!await stillVerified()) {
+    throw new AppError('The tmux pane now belongs to a different agent process. Reopen it from the session list.', {
+      code: 'TMUX_PROCESS_GENERATION_MISMATCH',
+      statusCode: 409,
+    });
+  }
+  const signal = (name: NodeJS.Signals): void => {
+    try { kill(generation.pid, name); } catch (error) {
+      // ESRCH means it exited between the check and the signal; anything else is a real refusal.
+      if (!(error && typeof error === 'object' && 'code' in error && error.code === 'ESRCH')) throw error;
+    }
+  };
+  signal('SIGTERM');
+  if (await waitForExit(STOP_TERM_GRACE_MS)) return;
+  signal('SIGKILL');
+  if (await waitForExit(STOP_KILL_GRACE_MS)) return;
+  throw new AppError('The agent process ignored SIGTERM and SIGKILL; terminate the pane instead.', {
+    code: 'AGENT_PROCESS_STILL_RUNNING',
+    statusCode: 409,
+  });
 }

--- a/server/modules/providers/tests/process-start-time.test.ts
+++ b/server/modules/providers/tests/process-start-time.test.ts
@@ -2,9 +2,13 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  isZombieProcess,
   parseBootTimeMs,
+  parseProcStatProcessGroupId,
   parseProcStatStartTicks,
+  parseProcStatState,
   parseProcessStartTime,
+  processGroupId,
   processStartMs,
 } from '../services/process-start-time.service.js';
 
@@ -68,4 +72,26 @@ test('the ps lstart fallback runs in the C locale so a localized ps cannot break
   assert.equal(value, Date.parse('Wed Jul 22 23:16:35 2026'));
   assert.deepEqual(runs.map((run) => [run.command, run.lcAll]), [['ps', 'C']]);
   assert.equal(parseProcessStartTime('수  9월  2 12:00:21 2026'), null, 'the localized form the default locale produced is unparseable, hence the forced C locale');
+});
+
+test('process group and state come from /proc/<pid>/stat fields 5 and 3, counted from the last parenthesis', async () => {
+  const stat = '4242 (node (wrapped) tui) S 4100 4200 4100 34817 4242 4194560 1 0 0 0 5 1 0 0 20 0 1 0 987654 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23';
+  assert.equal(parseProcStatProcessGroupId(stat), 4200, 'pgid survives spaces and parentheses in comm');
+  assert.equal(parseProcStatState(stat), 'S');
+  assert.equal(parseProcStatState(stat.replace(') S ', ') Z ')), 'Z');
+  assert.equal(parseProcStatProcessGroupId('garbage'), null);
+
+  const read = async (path: string) => { if (path === '/proc/77/stat') return stat; throw new Error('ENOENT'); };
+  assert.equal(await processGroupId(77, { readFile: read, run: async () => { throw new Error('no ps'); } }), 4200);
+  assert.equal(await isZombieProcess(77, { readFile: read }), false);
+  assert.equal(await isZombieProcess(78, { readFile: read }), false, 'a vanished pid is not reported as a zombie');
+  // Portable fallback when /proc is absent.
+  assert.equal(await processGroupId(77, { readFile: async () => { throw new Error('ENOENT'); }, run: async (command, args) => { assert.equal(command, 'ps'); assert.deepEqual(args, ['-p', '77', '-o', 'pgid=']); return ' 4200\n'; } }), 4200);
+});
+
+test('a live process reports the same group through /proc and through ps', async () => {
+  const fromProc = await processGroupId(process.pid);
+  const fromPs = await processGroupId(process.pid, { readFile: async () => { throw new Error('ENOENT'); } });
+  assert.ok(fromProc !== null && fromProc > 0);
+  assert.equal(fromProc, fromPs);
 });

--- a/server/modules/providers/tests/support/provider-routes-contract.support.ts
+++ b/server/modules/providers/tests/support/provider-routes-contract.support.ts
@@ -37,6 +37,8 @@ case "$*" in
     case "$*" in
       *'%2'*socket_path*) printf '/tmp/chatmux-contract.sock\t$2\t@2\t%%2\n' ;;
       *socket_path*) printf '/tmp/chatmux-contract.sock\t$1\t@1\t%%1\n' ;;
+      *'%2'*pane_current_path*pane_pid*) printf '$2\t@2\t%%2\t/tmp\t%s\n' "$PPID" ;;
+      *pane_current_path*pane_pid*) printf '$1\t@1\t%%1\t/tmp\t%s\n' "$PPID" ;;
       *pane_pid*) printf '%s\n' "$PPID" ;;
       *'%2'*pane_current_path*) printf '$2\t@2\t%%2\t/tmp\n' ;;
       *pane_current_path*) printf '$1\t@1\t%%1\t/tmp\n' ;;

--- a/server/modules/providers/tests/tmux-pane-actions.service.test.ts
+++ b/server/modules/providers/tests/tmux-pane-actions.service.test.ts
@@ -191,11 +191,15 @@ test('selector actions reject empty and oversized internally constructed sequenc
   assert.equal(recordingRunner().calls.length, 0);
 });
 
-test('process stop respawns a shell only when the agent is the pane root process', async () => {
-  const { calls, run } = recordingRunner(['$7\t@8\t%9\t/workspace/project\t42\n']);
+test('process stop respawns a shell when the agent shares the pane root process group', async () => {
+  // Pane command is a node launcher (pid 40) whose codex child is the agent (42): one group, no shell to keep.
+  const { calls, run } = recordingRunner(['$7\t@8\t%9\t/workspace/project\t40\n']);
   const signals: string[] = [];
-  await stopAgentProcessInPane(target, run, '/bin/bash', { kill: (_pid, signal) => { signals.push(signal); } });
-  assert.deepEqual(signals, [], 'the pane root is replaced, not signalled');
+  await stopAgentProcessInPane(target, run, '/bin/bash', {
+    kill: (_pid, signal) => { signals.push(signal); },
+    processGroupId: async () => 40,
+  });
+  assert.deepEqual(signals, [], 'the pane root group is replaced, not signalled');
   assert.deepEqual(calls[0]?.args, [
     '-S', identity.socketPath,
     'display-message', '-p', '-t', identity.paneId,
@@ -213,13 +217,16 @@ test('process stop respawns a shell only when the agent is the pane root process
   ]);
 });
 
-test('process stop signals a child agent, confirms its exit against the verified generation, and keeps the shell', async () => {
+test('process stop signals the agent job group, confirms its exit against the verified generation, and keeps the shell', async () => {
+  // Interactive shell (pid 41, its own group) started the agent as a job in group 42.
   const { calls, run } = recordingRunner(['$7\t@8\t%9\t/workspace/project\t41\n']);
   const signals: string[] = [];
   let alive = true;
   await stopAgentProcessInPane(target, run, '/bin/bash', {
-    kill: (pid, signal) => { assert.equal(pid, 42); signals.push(signal); if (signal === 'SIGTERM') alive = false; },
+    kill: (pid, signal) => { assert.equal(pid, -42, 'the whole job group, wrappers included'); signals.push(signal); if (signal === 'SIGTERM') alive = false; },
     startedAtMs: async (pid) => (pid === 42 && alive ? 1234 : null),
+    processGroupId: async (pid) => (pid === 41 ? 41 : 42),
+    isZombie: async () => false,
     sleep: async () => {},
   });
   assert.deepEqual(signals, ['SIGTERM']);
@@ -231,16 +238,28 @@ test('process stop escalates to SIGKILL and reports an agent that will not die',
   const stubborn = recordingRunner(['$7\t@8\t%9\t/workspace/project\t41\n']);
   const signals: string[] = [];
   let alive = true;
+  const group = { processGroupId: async (pid: number) => (pid === 41 ? 41 : 42), isZombie: async () => false, sleep: async () => {} };
   await stopAgentProcessInPane(target, stubborn.run, '/bin/bash', {
+    ...group,
     kill: (_pid, signal) => { signals.push(signal); if (signal === 'SIGKILL') alive = false; },
     startedAtMs: async () => (alive ? 1234 : null),
-    sleep: async () => {},
   });
   assert.deepEqual(signals, ['SIGTERM', 'SIGKILL']);
 
+  // A zombie still has its /proc entry and start tick, but it has exited.
+  const reaped = recordingRunner(['$7\t@8\t%9\t/workspace/project\t41\n']);
+  const zombieSignals: string[] = [];
+  await stopAgentProcessInPane(target, reaped.run, '/bin/bash', {
+    ...group,
+    kill: (_pid, signal) => { zombieSignals.push(signal); },
+    startedAtMs: async () => 1234,
+    isZombie: async () => zombieSignals.length > 0,
+  });
+  assert.deepEqual(zombieSignals, ['SIGTERM']);
+
   const immortal = recordingRunner(['$7\t@8\t%9\t/workspace/project\t41\n']);
   await assert.rejects(
-    stopAgentProcessInPane(target, immortal.run, '/bin/bash', { kill: () => {}, startedAtMs: async () => 1234, sleep: async () => {} }),
+    stopAgentProcessInPane(target, immortal.run, '/bin/bash', { ...group, kill: () => {}, startedAtMs: async () => 1234 }),
     (error: unknown) => error instanceof AppError && error.code === 'AGENT_PROCESS_STILL_RUNNING',
   );
   assert.equal(immortal.calls.some(({ args }) => args.includes('set-option')), false, 'tags stay while the agent is still there');
@@ -250,7 +269,13 @@ test('process stop never signals a pid whose start time no longer matches the ve
   const { run } = recordingRunner(['$7\t@8\t%9\t/workspace/project\t41\n']);
   const signals: string[] = [];
   await assert.rejects(
-    stopAgentProcessInPane(target, run, '/bin/bash', { kill: (_pid, signal) => { signals.push(signal); }, startedAtMs: async () => 9999, sleep: async () => {} }),
+    stopAgentProcessInPane(target, run, '/bin/bash', {
+      kill: (_pid, signal) => { signals.push(signal); },
+      startedAtMs: async () => 9999,
+      processGroupId: async (pid) => (pid === 41 ? 41 : 42),
+      isZombie: async () => false,
+      sleep: async () => {},
+    }),
     (error: unknown) => error instanceof AppError && error.code === 'TMUX_PROCESS_GENERATION_MISMATCH',
   );
   assert.deepEqual(signals, []);

--- a/server/modules/providers/tests/tmux-pane-actions.service.test.ts
+++ b/server/modules/providers/tests/tmux-pane-actions.service.test.ts
@@ -191,13 +191,15 @@ test('selector actions reject empty and oversized internally constructed sequenc
   assert.equal(recordingRunner().calls.length, 0);
 });
 
-test('default process stop respawns a shell in the same pane', async () => {
-  const { calls, run } = recordingRunner(['$7\t@8\t%9\t/workspace/project\n']);
-  await stopAgentProcessInPane(target, run, '/bin/bash');
+test('process stop respawns a shell only when the agent is the pane root process', async () => {
+  const { calls, run } = recordingRunner(['$7\t@8\t%9\t/workspace/project\t42\n']);
+  const signals: string[] = [];
+  await stopAgentProcessInPane(target, run, '/bin/bash', { kill: (_pid, signal) => { signals.push(signal); } });
+  assert.deepEqual(signals, [], 'the pane root is replaced, not signalled');
   assert.deepEqual(calls[0]?.args, [
     '-S', identity.socketPath,
     'display-message', '-p', '-t', identity.paneId,
-    '#{session_id}\t#{window_id}\t#{pane_id}\t#{pane_current_path}',
+    '#{session_id}\t#{window_id}\t#{pane_id}\t#{pane_current_path}\t#{pane_pid}',
   ]);
   assert.deepEqual(calls[1]?.args, [
     '-S', identity.socketPath,
@@ -209,6 +211,49 @@ test('default process stop respawns a shell in the same pane', async () => {
     ['set-option', '-p', '-t', identity.paneId, '@chatmux_provider_session_id', ''],
     ['set-option', '-p', '-t', identity.paneId, '@chatmux_codex_thread_id', ''],
   ]);
+});
+
+test('process stop signals a child agent, confirms its exit against the verified generation, and keeps the shell', async () => {
+  const { calls, run } = recordingRunner(['$7\t@8\t%9\t/workspace/project\t41\n']);
+  const signals: string[] = [];
+  let alive = true;
+  await stopAgentProcessInPane(target, run, '/bin/bash', {
+    kill: (pid, signal) => { assert.equal(pid, 42); signals.push(signal); if (signal === 'SIGTERM') alive = false; },
+    startedAtMs: async (pid) => (pid === 42 && alive ? 1234 : null),
+    sleep: async () => {},
+  });
+  assert.deepEqual(signals, ['SIGTERM']);
+  assert.equal(calls.some(({ args }) => args.includes('respawn-pane')), false, 'the user shell in the pane survives');
+  assert.deepEqual(calls.slice(1).map(({ args }) => args[2]), ['set-option', 'set-option', 'set-option']);
+});
+
+test('process stop escalates to SIGKILL and reports an agent that will not die', async () => {
+  const stubborn = recordingRunner(['$7\t@8\t%9\t/workspace/project\t41\n']);
+  const signals: string[] = [];
+  let alive = true;
+  await stopAgentProcessInPane(target, stubborn.run, '/bin/bash', {
+    kill: (_pid, signal) => { signals.push(signal); if (signal === 'SIGKILL') alive = false; },
+    startedAtMs: async () => (alive ? 1234 : null),
+    sleep: async () => {},
+  });
+  assert.deepEqual(signals, ['SIGTERM', 'SIGKILL']);
+
+  const immortal = recordingRunner(['$7\t@8\t%9\t/workspace/project\t41\n']);
+  await assert.rejects(
+    stopAgentProcessInPane(target, immortal.run, '/bin/bash', { kill: () => {}, startedAtMs: async () => 1234, sleep: async () => {} }),
+    (error: unknown) => error instanceof AppError && error.code === 'AGENT_PROCESS_STILL_RUNNING',
+  );
+  assert.equal(immortal.calls.some(({ args }) => args.includes('set-option')), false, 'tags stay while the agent is still there');
+});
+
+test('process stop never signals a pid whose start time no longer matches the verified generation', async () => {
+  const { run } = recordingRunner(['$7\t@8\t%9\t/workspace/project\t41\n']);
+  const signals: string[] = [];
+  await assert.rejects(
+    stopAgentProcessInPane(target, run, '/bin/bash', { kill: (_pid, signal) => { signals.push(signal); }, startedAtMs: async () => 9999, sleep: async () => {} }),
+    (error: unknown) => error instanceof AppError && error.code === 'TMUX_PROCESS_GENERATION_MISMATCH',
+  );
+  assert.deepEqual(signals, []);
 });
 
 test('pane and session termination recheck the exact pane, then use distinct immutable ids', async () => {


### PR DESCRIPTION
## Summary

Correctness Low from the September review: "process stop" was `respawn-pane -k`, which replaced the user's shell (history, virtualenv) and never checked that the agent had exited.

- `stopAgentProcessInPane` reads `#{pane_pid}` with the identity recheck and compares the **process group** of the pane root with that of the verified agent pid (`/proc/<pid>/stat` field 5, `ps -o pgid=` fallback in the C locale).
  - Different groups (an interactive shell started the agent as a job): the whole job group is sent `SIGTERM`, then `SIGKILL` after 3 s, so launcher wrappers go with the binary; the agent's exit is confirmed against its verified `startedAtMs` before the ChatMux pane tags are cleared. The shell in the pane is untouched.
  - Same group (the pane command is the agent or its wrapper): its exit would close the pane, so that case keeps `respawn-pane -k` with a shell.
- A zombie still has its `/proc` start tick until reaped; it now counts as exited rather than forcing an escalation.
- A pid whose start time no longer matches the verified generation is never signalled (`TMUX_PROCESS_GENERATION_MISMATCH`). An agent that survives both signals yields `AGENT_PROCESS_STILL_RUNNING` (409) with a hint to terminate the pane. Worst case 5 s stays inside the fleet's 10 s request deadline.
- Signal, start time, group, zombie check, and sleep are injectable for tests.

Verified on this host: `zsh → claude` panes show the agent in its own group (pgid ≠ pane pid); a pane rooted at `npm run dev` keeps its `sh` child in the root's group.

Not in this PR: the attach `select-window` side effect on other tmux clients. A grouped session fixes the current-window part but makes every shared pane appear twice in `list-panes -a`, which the discovery lanes would have to filter; that needs its own change.

## Test plan

- [x] `tmux-pane-actions.service.test.ts`: same-group respawn, separate job group signalled as `-pgid` and shell kept, SIGKILL escalation, zombie counted as exited, still-running refusal, stale generation never signalled
- [x] `process-start-time.test.ts`: field parsing with spaces and parentheses in comm, `/proc` and `ps` agreement on a live pid
- [x] Fleet `task-11` mutations and `task-12` terminal protection suites, `tsc`, eslint
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
