### PR TITLE
fix(fleet): let the confirmed hub session kill take the other panes with it

### DIFF
--- a/server/modules/fleet/rpc/mutations/local-services.ts
+++ b/server/modules/fleet/rpc/mutations/local-services.ts
@@ -84,6 +84,10 @@ export function createLocalFleetMutationServices(localHostId: string, discovery:
     verifySession, verifyPane,
     verifySpawn: async (projectLocalId, cwd) => { if (projectsDb.getProjectById(projectLocalId) === null) throw new FleetMutationRpcError('HOST_NOT_FOUND', 'project was not found'); const resolved = await resolveExternalCliCwd(cwd); if (resolved === null) throw new FleetMutationRpcError('FLEET_UNAUTHORIZED', 'spawn cwd is outside peer home'); return { cwd: resolved }; },
     finalCheck, send: (key, message) => sendToTmuxPane(unwrap(key), message), abort: (key) => sendTmuxProcessAction(unwrap(key), 'interrupt'), interrupt: (key) => sendTmuxProcessAction(unwrap(key), 'interrupt'), escape: (key) => sendTmuxProcessAction(unwrap(key), 'escape'), respondPrompt: prompt,
-    respondApproval: (key, decision) => answerTmuxApproval(unwrap(key), decision), spawn: async (value, name) => spawnLiveSession(name, value.cwd), terminateProcess: (key) => stopAgentProcessInPane(unwrap(key)), terminatePane: (key) => killTmuxPane(unwrap(key)), terminateSession: (key) => killTmuxSession(unwrap(key)),
+    respondApproval: (key, decision) => answerTmuxApproval(unwrap(key), decision), spawn: async (value, name) => spawnLiveSession(name, value.cwd), terminateProcess: (key) => stopAgentProcessInPane(unwrap(key)), terminatePane: (key) => killTmuxPane(unwrap(key)), // The hub UI's session kill is confirmed by the user against the wording
+    // "Destroy this tmux session, all panes, and all processes inside it", so
+    // the wider blast radius is already an explicit choice here; the direct
+    // provider route, which has no such prompt, keeps requiring confirmOtherPanes.
+    terminateSession: (key) => killTmuxSession(unwrap(key), undefined, { allowOtherPanes: true }),
   };
 }


### PR DESCRIPTION
## Summary

Regression fix on main from #86.

#86 made `killTmuxSession` refuse a session that still holds other panes unless the caller passes `allowOtherPanes`, and the direct provider route reads `confirmOtherPanes` for that. The browser, however, kills sessions only through the hub route (`/api/hosts/:hostId/providers/panes/:localId/actions` with `terminate-session`, for the local host as well), and that path never passed the confirmation. Since #86 every session kill on a multi-pane session failed, surfaced as a stale-generation error.

- `local-services.ts` `terminateSession` now passes `allowOtherPanes: true`. The hub UI already requires the user to confirm the wording "Destroy this tmux session, all panes, and all processes inside it", so the wider blast radius is an explicit choice on that path.
- The direct provider route is unchanged and still requires `confirmOtherPanes` for API clients, which have no such prompt.
- No wire change: the fleet `session.terminate` body stays `{ deadlineAtMs }`.

## Test plan

- [x] `task-11-remote-mutations.test.ts`, `tmux-pane-actions.service.test.ts` (the `allowOtherPanes` behaviour itself is covered there), `tsc`, eslint
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)