### PR TITLE
chore(release): v1.8.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatmux",
-  "version": "1.8.16",
+  "version": "1.8.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatmux",
-      "version": "1.8.16",
+      "version": "1.8.17",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chatmux",
   "private": true,
-  "version": "1.8.16",
+  "version": "1.8.17",
   "productName": "ChatMux",
   "description": "A self-hosted web interface for coding-agent sessions running in tmux",
   "type": "module",

--- a/packaging/release/update-compatibility.json
+++ b/packaging/release/update-compatibility.json
@@ -191,6 +191,16 @@
           "1.8.15"
         ]
       }
+    },
+    "1.8.17": {
+      "database": {
+        "schemaGeneration": 19,
+        "rollbackCompatibleFrom": [
+          "1.8.14",
+          "1.8.15",
+          "1.8.16"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Version bookkeeping for v1.8.17, the release that carries every September review fix merged after v1.8.16 (#81 through #97): the remaining Medium batches (auth, fleet, updater, tmux, files, cookie-only sessions, watcher resync, binding grade, release asset contract) and the Low batches (tmux, security, fleet, updater, process stop, hub session kill).

- `package.json` / `package-lock.json`: 1.8.16 → 1.8.17
- `packaging/release/update-compatibility.json`: new `1.8.17` entry, `schemaGeneration` 19 (no migration since 1.8.15), `rollbackCompatibleFrom` carries the previous window forward and adds `1.8.16`

## Test plan

- [x] `npm run release:check-metadata`
- [ ] CI
- [ ] After merge: dispatch `release.yml` from `main`, apply on home-server, re-run the Serve probe

🤖 Generated with [Claude Code](https://claude.com/claude-code)