### PR TITLE
fix(chat, sessions): autoscroll follow-tail, missing-cwd creation, fail-closed resume guard

### DIFF
--- a/native/chatmux-core/Cargo.lock
+++ b/native/chatmux-core/Cargo.lock
@@ -49,15 +49,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
 name = "chatmux-core"
 version = "0.2.0"
 dependencies = [
  "base64",
+ "nix 0.31.3",
  "notify",
  "portable-pty",
  "rusqlite",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -82,6 +90,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +110,12 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "filedescriptor"
@@ -133,6 +157,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -223,6 +258,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,7 +295,19 @@ checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
  "bitflags 2.13.1",
  "cfg-if",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases 0.2.2",
  "libc",
 ]
 
@@ -278,6 +331,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,7 +355,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix",
+ "nix 0.28.0",
  "serial2",
  "shared_library",
  "shell-words",
@@ -323,6 +382,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rusqlite"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -334,6 +399,19 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -436,6 +514,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/native/chatmux-core/Cargo.toml
+++ b/native/chatmux-core/Cargo.toml
@@ -8,9 +8,13 @@ rust-version = "1.85"
 base64 = "0.22.1"
 portable-pty = "0.9.0"
 notify = "6.1.1"
+nix = { version = "0.31.3", features = ["fs"] }
 rusqlite = { version = "0.37.0", features = ["bundled"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[dev-dependencies]
+tempfile = "3.20.0"
 
 [lib]
 name = "chatmux_core"

--- a/native/chatmux-core/src/lib.rs
+++ b/native/chatmux-core/src/lib.rs
@@ -22,8 +22,8 @@ pub enum Command {
         database: PathBuf,
     },
     MkdirUnder {
-        root: PathBuf,
-        relative: Vec<OsString>,
+        home: PathBuf,
+        components: Vec<OsString>,
     },
     Pty {
         program: OsString,
@@ -86,16 +86,16 @@ where
     I: IntoIterator<Item = OsString>,
 {
     let mut args = args.into_iter();
-    if args.next().as_deref() != Some(std::ffi::OsStr::new("--root")) {
+    if args.next().as_deref() != Some(std::ffi::OsStr::new("--home")) {
         return Err(ParseError);
     }
-    let root = args.next().map(PathBuf::from).ok_or(ParseError)?;
-    if !root.is_absolute() || args.next().as_deref() != Some(std::ffi::OsStr::new("--")) {
+    let home = args.next().map(PathBuf::from).ok_or(ParseError)?;
+    if !home.is_absolute() || args.next().as_deref() != Some(std::ffi::OsStr::new("--")) {
         return Err(ParseError);
     }
     Ok(Command::MkdirUnder {
-        root,
-        relative: args.collect(),
+        home,
+        components: args.collect(),
     })
 }
 
@@ -202,23 +202,23 @@ mod tests {
     }
 
     #[test]
-    fn parses_mkdir_under_root_and_opaque_components() {
+    fn parses_mkdir_under_home_and_opaque_components() {
         assert_eq!(
             parse_args([
                 os("mkdir-under"),
-                os("--root"),
+                os("--home"),
                 os("/home/user"),
                 os("--"),
                 os("project name"),
                 os("child"),
             ]),
             Ok(Command::MkdirUnder {
-                root: "/home/user".into(),
-                relative: vec![os("project name"), os("child")],
+                home: "/home/user".into(),
+                components: vec![os("project name"), os("child")],
             })
         );
         assert_eq!(
-            parse_args([os("mkdir-under"), os("--root"), os("relative"), os("--")]),
+            parse_args([os("mkdir-under"), os("--home"), os("relative"), os("--")]),
             Err(ParseError)
         );
     }

--- a/native/chatmux-core/src/lib.rs
+++ b/native/chatmux-core/src/lib.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 pub mod jobs;
+pub mod mkdir_under;
 pub mod pty;
 pub mod watcher;
 
@@ -19,6 +20,10 @@ pub enum Command {
     },
     Jobs {
         database: PathBuf,
+    },
+    MkdirUnder {
+        root: PathBuf,
+        relative: Vec<OsString>,
     },
     Pty {
         program: OsString,
@@ -55,6 +60,7 @@ where
         },
         Some(command) if command == "watch" => parse_watch_args(args),
         Some(command) if command == "jobs" => parse_jobs_args(args),
+        Some(command) if command == "mkdir-under" => parse_mkdir_under_args(args),
         Some(command) if command == "pty" => parse_pty_args(args),
         _ => Err(ParseError),
     }
@@ -73,6 +79,24 @@ where
         return Err(ParseError);
     }
     Ok(Command::Jobs { database })
+}
+
+fn parse_mkdir_under_args<I>(args: I) -> Result<Command, ParseError>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let mut args = args.into_iter();
+    if args.next().as_deref() != Some(std::ffi::OsStr::new("--root")) {
+        return Err(ParseError);
+    }
+    let root = args.next().map(PathBuf::from).ok_or(ParseError)?;
+    if !root.is_absolute() || args.next().as_deref() != Some(std::ffi::OsStr::new("--")) {
+        return Err(ParseError);
+    }
+    Ok(Command::MkdirUnder {
+        root,
+        relative: args.collect(),
+    })
 }
 
 fn parse_pty_args<I>(args: I) -> Result<Command, ParseError>
@@ -174,6 +198,28 @@ mod tests {
                 program: os("program name"),
                 args: vec![os("$not-expanded")],
             })
+        );
+    }
+
+    #[test]
+    fn parses_mkdir_under_root_and_opaque_components() {
+        assert_eq!(
+            parse_args([
+                os("mkdir-under"),
+                os("--root"),
+                os("/home/user"),
+                os("--"),
+                os("project name"),
+                os("child"),
+            ]),
+            Ok(Command::MkdirUnder {
+                root: "/home/user".into(),
+                relative: vec![os("project name"), os("child")],
+            })
+        );
+        assert_eq!(
+            parse_args([os("mkdir-under"), os("--root"), os("relative"), os("--")]),
+            Err(ParseError)
         );
     }
 

--- a/native/chatmux-core/src/main.rs
+++ b/native/chatmux-core/src/main.rs
@@ -35,7 +35,7 @@ fn main() -> ExitCode {
                 fail(JOBS_ERROR)
             }
         }
-        Ok(CliCommand::MkdirUnder { root, relative }) => run_mkdir_under(root, relative),
+        Ok(CliCommand::MkdirUnder { home, components }) => run_mkdir_under(home, components),
         Ok(CliCommand::Pty { program, args }) => {
             if pty::run(program, args) {
                 ExitCode::SUCCESS
@@ -47,8 +47,8 @@ fn main() -> ExitCode {
     }
 }
 
-fn run_mkdir_under(root: std::path::PathBuf, relative: Vec<std::ffi::OsString>) -> ExitCode {
-    let (output, exit_code) = match mkdir_under::mkdir_under(&root, &relative) {
+fn run_mkdir_under(home: std::path::PathBuf, components: Vec<std::ffi::OsString>) -> ExitCode {
+    let (output, exit_code) = match mkdir_under::mkdir_under(&home, &components) {
         Ok(path) => (
             serde_json::json!({ "ok": true, "path": path.to_string_lossy() }),
             ExitCode::SUCCESS,

--- a/native/chatmux-core/src/main.rs
+++ b/native/chatmux-core/src/main.rs
@@ -4,7 +4,9 @@ use std::io::{self, Read, Write};
 use std::process::{Child, Command, ExitCode, ExitStatus, Stdio};
 use std::thread;
 
-use chatmux_core::{Command as CliCommand, jobs, map_exit_status, parse_args, pty, watcher};
+use chatmux_core::{
+    Command as CliCommand, jobs, map_exit_status, mkdir_under, parse_args, pty, watcher,
+};
 
 const USAGE_ERROR: &[u8] = b"chatmux-core: usage error\n";
 const SPAWN_ERROR: &[u8] = b"chatmux-core: spawn failed\n";
@@ -33,6 +35,7 @@ fn main() -> ExitCode {
                 fail(JOBS_ERROR)
             }
         }
+        Ok(CliCommand::MkdirUnder { root, relative }) => run_mkdir_under(root, relative),
         Ok(CliCommand::Pty { program, args }) => {
             if pty::run(program, args) {
                 ExitCode::SUCCESS
@@ -42,6 +45,32 @@ fn main() -> ExitCode {
         }
         Err(_) => fail(USAGE_ERROR),
     }
+}
+
+fn run_mkdir_under(root: std::path::PathBuf, relative: Vec<std::ffi::OsString>) -> ExitCode {
+    let (output, exit_code) = match mkdir_under::mkdir_under(&root, &relative) {
+        Ok(path) => (
+            serde_json::json!({ "ok": true, "path": path.to_string_lossy() }),
+            ExitCode::SUCCESS,
+        ),
+        Err(error) => {
+            #[cfg(not(windows))]
+            let output = serde_json::json!({
+                "ok": false,
+                "code": format!("{:?}", error.errno()),
+                "component": error.component().to_string_lossy(),
+            });
+            #[cfg(windows)]
+            let output = serde_json::json!({ "ok": false, "code": "UNSUPPORTED" });
+            (output, ExitCode::FAILURE)
+        }
+    };
+    if serde_json::to_writer(io::stdout().lock(), &output).is_err()
+        || io::stdout().write_all(b"\n").is_err()
+    {
+        return ExitCode::FAILURE;
+    }
+    exit_code
 }
 
 fn run_proxy(program: std::ffi::OsString, args: Vec<std::ffi::OsString>) -> ExitCode {

--- a/native/chatmux-core/src/mkdir_under.rs
+++ b/native/chatmux-core/src/mkdir_under.rs
@@ -1,0 +1,227 @@
+use std::ffi::{OsStr, OsString};
+use std::path::{Component, Path, PathBuf};
+
+#[cfg(not(windows))]
+use nix::errno::Errno;
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum MkdirUnderError {
+    #[cfg(not(windows))]
+    Root { root: PathBuf, errno: Errno },
+    #[cfg(not(windows))]
+    Component { component: OsString, errno: Errno },
+    #[cfg(windows)]
+    Unsupported,
+}
+
+#[cfg(not(windows))]
+impl MkdirUnderError {
+    pub fn errno(&self) -> Errno {
+        match self {
+            Self::Root { errno, .. } | Self::Component { errno, .. } => *errno,
+        }
+    }
+
+    pub fn component(&self) -> &OsStr {
+        match self {
+            Self::Root { root, .. } => root.as_os_str(),
+            Self::Component { component, .. } => component,
+        }
+    }
+}
+
+/// Creates `components` below an already-canonical directory without resolving
+/// any pathname after the root has been opened.
+#[cfg(not(windows))]
+pub fn mkdir_under(
+    canonical_root: &Path,
+    components: &[OsString],
+) -> Result<PathBuf, MkdirUnderError> {
+    use nix::fcntl::{AtFlags, OFlag, open, openat};
+    use nix::sys::stat::{Mode, SFlag, fstatat, mkdirat};
+
+    let directory_flags = OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW;
+    let mut directory = open(canonical_root, directory_flags, Mode::empty()).map_err(|errno| {
+        MkdirUnderError::Root {
+            root: canonical_root.to_path_buf(),
+            errno,
+        }
+    })?;
+    let mut result = canonical_root.to_path_buf();
+
+    for component in components {
+        if !is_single_normal_component(component) {
+            return Err(MkdirUnderError::Component {
+                component: component.clone(),
+                errno: Errno::EINVAL,
+            });
+        }
+
+        match mkdirat(
+            &directory,
+            component.as_os_str(),
+            Mode::from_bits_truncate(0o755),
+        ) {
+            Ok(()) => {}
+            Err(Errno::EEXIST) => {
+                let metadata = fstatat(
+                    &directory,
+                    component.as_os_str(),
+                    AtFlags::AT_SYMLINK_NOFOLLOW,
+                )
+                .map_err(|errno| MkdirUnderError::Component {
+                    component: component.clone(),
+                    errno,
+                })?;
+                if SFlag::from_bits_truncate(metadata.st_mode) & SFlag::S_IFMT != SFlag::S_IFDIR {
+                    return Err(MkdirUnderError::Component {
+                        component: component.clone(),
+                        errno: Errno::ENOTDIR,
+                    });
+                }
+            }
+            Err(errno) => {
+                return Err(MkdirUnderError::Component {
+                    component: component.clone(),
+                    errno,
+                });
+            }
+        }
+
+        directory = openat(
+            &directory,
+            component.as_os_str(),
+            directory_flags,
+            Mode::empty(),
+        )
+        .map_err(|errno| MkdirUnderError::Component {
+            component: component.clone(),
+            errno,
+        })?;
+        result.push(component);
+    }
+
+    Ok(result)
+}
+
+#[cfg(windows)]
+pub fn mkdir_under(
+    _canonical_root: &Path,
+    _components: &[OsString],
+) -> Result<PathBuf, MkdirUnderError> {
+    Err(MkdirUnderError::Unsupported)
+}
+
+fn is_single_normal_component(component: &OsStr) -> bool {
+    let mut parts = Path::new(component).components();
+    matches!(parts.next(), Some(Component::Normal(part)) if part == component)
+        && parts.next().is_none()
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::{MkdirUnderError, mkdir_under};
+    use nix::errno::Errno;
+    use std::ffi::OsString;
+    use std::fs;
+    use std::os::unix::fs::symlink;
+    use tempfile::tempdir;
+
+    fn components(values: &[&str]) -> Vec<OsString> {
+        values.iter().map(OsString::from).collect()
+    }
+
+    #[test]
+    fn creates_nested_directories_on_disk() {
+        let temporary = tempdir().unwrap();
+        let root = fs::canonicalize(temporary.path()).unwrap();
+        let result = mkdir_under(&root, &components(&["one", "two", "three"])).unwrap();
+
+        assert_eq!(result, root.join("one/two/three"));
+        assert!(fs::symlink_metadata(root.join("one")).unwrap().is_dir());
+        assert!(fs::symlink_metadata(root.join("one/two")).unwrap().is_dir());
+        assert!(fs::symlink_metadata(&result).unwrap().is_dir());
+    }
+
+    #[test]
+    fn refuses_a_symlink_component_without_creating_through_it() {
+        let temporary = tempdir().unwrap();
+        let root = temporary.path().join("root");
+        let outside = temporary.path().join("outside");
+        fs::create_dir(&root).unwrap();
+        fs::create_dir(&outside).unwrap();
+        symlink(&outside, root.join("link")).unwrap();
+        let root = fs::canonicalize(root).unwrap();
+
+        let error = mkdir_under(&root, &components(&["link", "child"])).unwrap_err();
+
+        assert_eq!(
+            error,
+            MkdirUnderError::Component {
+                component: OsString::from("link"),
+                errno: Errno::ENOTDIR,
+            }
+        );
+        assert!(
+            fs::symlink_metadata(root.join("link"))
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(
+            fs::symlink_metadata(outside.join("child"))
+                .unwrap_err()
+                .kind(),
+            std::io::ErrorKind::NotFound
+        );
+    }
+
+    #[test]
+    fn refuses_a_symlink_root() {
+        let temporary = tempdir().unwrap();
+        let actual = temporary.path().join("actual");
+        let link = temporary.path().join("link");
+        fs::create_dir(&actual).unwrap();
+        symlink(&actual, &link).unwrap();
+
+        let error = mkdir_under(&link, &components(&["child"])).unwrap_err();
+
+        assert!(matches!(error, MkdirUnderError::Root { .. }));
+        assert!(
+            fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(
+            fs::symlink_metadata(actual.join("child"))
+                .unwrap_err()
+                .kind(),
+            std::io::ErrorKind::NotFound
+        );
+    }
+
+    #[test]
+    fn refuses_an_existing_regular_file() {
+        let temporary = tempdir().unwrap();
+        let root = fs::canonicalize(temporary.path()).unwrap();
+        fs::write(root.join("file"), b"contents").unwrap();
+
+        let error = mkdir_under(&root, &components(&["file", "child"])).unwrap_err();
+
+        assert_eq!(
+            error,
+            MkdirUnderError::Component {
+                component: OsString::from("file"),
+                errno: Errno::ENOTDIR,
+            }
+        );
+        assert_eq!(fs::read(root.join("file")).unwrap(), b"contents");
+        assert_eq!(
+            fs::symlink_metadata(root.join("file/child"))
+                .unwrap_err()
+                .kind(),
+            std::io::ErrorKind::NotADirectory
+        );
+    }
+}

--- a/native/chatmux-core/src/mkdir_under.rs
+++ b/native/chatmux-core/src/mkdir_under.rs
@@ -30,24 +30,24 @@ impl MkdirUnderError {
     }
 }
 
-/// Creates `components` below an already-canonical directory without resolving
-/// any pathname after the root has been opened.
+/// Creates `components` below canonical HOME. After HOME is opened, every
+/// component is inspected and opened relative to the preceding directory.
 #[cfg(not(windows))]
 pub fn mkdir_under(
-    canonical_root: &Path,
+    canonical_home: &Path,
     components: &[OsString],
 ) -> Result<PathBuf, MkdirUnderError> {
     use nix::fcntl::{AtFlags, OFlag, open, openat};
     use nix::sys::stat::{Mode, SFlag, fstatat, mkdirat};
 
     let directory_flags = OFlag::O_RDONLY | OFlag::O_DIRECTORY | OFlag::O_NOFOLLOW;
-    let mut directory = open(canonical_root, directory_flags, Mode::empty()).map_err(|errno| {
+    let mut directory = open(canonical_home, directory_flags, Mode::empty()).map_err(|errno| {
         MkdirUnderError::Root {
-            root: canonical_root.to_path_buf(),
+            root: canonical_home.to_path_buf(),
             errno,
         }
     })?;
-    let mut result = canonical_root.to_path_buf();
+    let mut result = canonical_home.to_path_buf();
 
     for component in components {
         if !is_single_normal_component(component) {
@@ -57,14 +57,27 @@ pub fn mkdir_under(
             });
         }
 
-        match mkdirat(
+        let metadata = match fstatat(
             &directory,
             component.as_os_str(),
-            Mode::from_bits_truncate(0o755),
+            AtFlags::AT_SYMLINK_NOFOLLOW,
         ) {
-            Ok(()) => {}
-            Err(Errno::EEXIST) => {
-                let metadata = fstatat(
+            Ok(metadata) => metadata,
+            Err(Errno::ENOENT) => {
+                match mkdirat(
+                    &directory,
+                    component.as_os_str(),
+                    Mode::from_bits_truncate(0o755),
+                ) {
+                    Ok(()) | Err(Errno::EEXIST) => {}
+                    Err(errno) => {
+                        return Err(MkdirUnderError::Component {
+                            component: component.clone(),
+                            errno,
+                        });
+                    }
+                }
+                fstatat(
                     &directory,
                     component.as_os_str(),
                     AtFlags::AT_SYMLINK_NOFOLLOW,
@@ -72,13 +85,7 @@ pub fn mkdir_under(
                 .map_err(|errno| MkdirUnderError::Component {
                     component: component.clone(),
                     errno,
-                })?;
-                if SFlag::from_bits_truncate(metadata.st_mode) & SFlag::S_IFMT != SFlag::S_IFDIR {
-                    return Err(MkdirUnderError::Component {
-                        component: component.clone(),
-                        errno: Errno::ENOTDIR,
-                    });
-                }
+                })?
             }
             Err(errno) => {
                 return Err(MkdirUnderError::Component {
@@ -86,6 +93,12 @@ pub fn mkdir_under(
                     errno,
                 });
             }
+        };
+        if SFlag::from_bits_truncate(metadata.st_mode) & SFlag::S_IFMT != SFlag::S_IFDIR {
+            return Err(MkdirUnderError::Component {
+                component: component.clone(),
+                errno: Errno::ENOTDIR,
+            });
         }
 
         directory = openat(
@@ -106,7 +119,7 @@ pub fn mkdir_under(
 
 #[cfg(windows)]
 pub fn mkdir_under(
-    _canonical_root: &Path,
+    _canonical_home: &Path,
     _components: &[OsString],
 ) -> Result<PathBuf, MkdirUnderError> {
     Err(MkdirUnderError::Unsupported)
@@ -144,16 +157,16 @@ mod tests {
     }
 
     #[test]
-    fn refuses_a_symlink_component_without_creating_through_it() {
+    fn refuses_a_mid_path_symlink_without_creating_through_it() {
         let temporary = tempdir().unwrap();
-        let root = temporary.path().join("root");
+        let home = temporary.path().join("home");
         let outside = temporary.path().join("outside");
-        fs::create_dir(&root).unwrap();
+        fs::create_dir_all(home.join("first")).unwrap();
         fs::create_dir(&outside).unwrap();
-        symlink(&outside, root.join("link")).unwrap();
-        let root = fs::canonicalize(root).unwrap();
+        symlink(&outside, home.join("first/link")).unwrap();
+        let home = fs::canonicalize(home).unwrap();
 
-        let error = mkdir_under(&root, &components(&["link", "child"])).unwrap_err();
+        let error = mkdir_under(&home, &components(&["first", "link", "child"])).unwrap_err();
 
         assert_eq!(
             error,
@@ -163,13 +176,52 @@ mod tests {
             }
         );
         assert!(
-            fs::symlink_metadata(root.join("link"))
+            fs::symlink_metadata(home.join("first/link"))
                 .unwrap()
                 .file_type()
                 .is_symlink()
         );
         assert_eq!(
             fs::symlink_metadata(outside.join("child"))
+                .unwrap_err()
+                .kind(),
+            std::io::ErrorKind::NotFound
+        );
+    }
+
+    #[test]
+    fn refuses_a_leading_symlink_before_an_existing_component() {
+        let temporary = tempdir().unwrap();
+        let home = temporary.path().join("home");
+        let target = temporary.path().join("target");
+        fs::create_dir(&home).unwrap();
+        fs::create_dir_all(target.join("existing")).unwrap();
+        symlink(&target, home.join("link")).unwrap();
+        let home = fs::canonicalize(home).unwrap();
+
+        let error =
+            mkdir_under(&home, &components(&["link", "existing", "must-not-exist"])).unwrap_err();
+
+        assert_eq!(
+            error,
+            MkdirUnderError::Component {
+                component: OsString::from("link"),
+                errno: Errno::ENOTDIR,
+            }
+        );
+        assert!(
+            fs::symlink_metadata(home.join("link"))
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert!(
+            fs::symlink_metadata(target.join("existing"))
+                .unwrap()
+                .is_dir()
+        );
+        assert_eq!(
+            fs::symlink_metadata(target.join("existing/must-not-exist"))
                 .unwrap_err()
                 .kind(),
             std::io::ErrorKind::NotFound

--- a/server/modules/providers/provider.routes.ts
+++ b/server/modules/providers/provider.routes.ts
@@ -20,7 +20,6 @@ import {
   getCurrentTmuxPaneIdentityState,
   getExternalCliSessionsDetailed,
   normalizeExternalPaneOutput,
-  resolveExternalCliCwd,
   spawnExternalCliSession,
   type ExternalCliSession,
   type ExternalSpawnCli,
@@ -35,6 +34,7 @@ import {
   toExternalSessionDisplayActivity,
 } from '@/modules/providers/services/external-session-activity.service.js';
 import { getHomeDir, getHomeDirSuggestions } from '@/modules/providers/services/home-dirs.service.js';
+import { ensureExternalCliCwd } from '@/modules/providers/services/external-cli-sessions/inference-and-spawn.js';
 import { isValidSpawnName, spawnLiveSession } from '@/modules/providers/services/live-send.service.js';
 import { listLiveGjcCommands } from '@/modules/providers/services/live-commands.service.js';
 import { assertLineageTmuxTarget } from '@/modules/providers/services/tmux-target-guard.service.js';
@@ -999,9 +999,9 @@ router.post(
     if (!cwdInput) {
       throw new AppError('cwd is required.', { code: 'EMPTY_CWD', statusCode: 400 });
     }
-    const cwd = await resolveExternalCliCwd(cwdInput);
+    const cwd = await ensureExternalCliCwd(cwdInput);
     if (!cwd) {
-      throw new AppError('cwd must be an existing directory under HOME.', {
+      throw new AppError('cwd must be a directory under HOME that can be created.', {
         code: 'INVALID_CWD',
         statusCode: 400,
       });
@@ -1376,9 +1376,9 @@ router.post(
     if (!cwdInput) {
       throw new AppError('cwd is required.', { code: 'EMPTY_CWD', statusCode: 400 });
     }
-    const cwd = await resolveExternalCliCwd(cwdInput);
+    const cwd = await ensureExternalCliCwd(cwdInput);
     if (!cwd) {
-      throw new AppError('cwd must be an existing directory under HOME.', {
+      throw new AppError('cwd must be a directory under HOME that can be created.', {
         code: 'INVALID_CWD',
         statusCode: 400,
       });

--- a/server/modules/providers/services/builtin-relay.service.ts
+++ b/server/modules/providers/services/builtin-relay.service.ts
@@ -1,8 +1,8 @@
 import { spawn } from 'node:child_process';
-import { stat, realpath } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import path from 'node:path';
 
+import { ensureHomeCwd } from './external-cli-sessions/inference-and-spawn.js';
 import { recordHostCommand } from './host-command-metrics.service.js';
 import type { LiveSpawnResult } from './live-send.service.js';
 import { resolveTmuxSpawnLaunch } from './tmux-spawn-scope.service.js';
@@ -99,7 +99,7 @@ async function hasSession(name: string, run: TmuxRunner): Promise<boolean> {
 }
 
 
-/** Mirrors the tower's cwd contract: expanduser, must be an existing dir under $HOME. */
+/** Mirrors the tower's cwd contract: expanduser and create a missing directory under $HOME. */
 export async function resolveSpawnCwd(cwd: string, home: string = homedir()): Promise<string | null> {
   const trimmed = cwd.trim();
   const expanded = trimmed === '~'
@@ -107,18 +107,7 @@ export async function resolveSpawnCwd(cwd: string, home: string = homedir()): Pr
     : trimmed.startsWith('~/')
       ? path.join(home, trimmed.slice(2))
       : trimmed;
-  if (!path.isAbsolute(expanded)) {
-    return null;
-  }
-  try {
-    const [real, homeReal] = await Promise.all([realpath(expanded), realpath(home)]);
-    if (real !== homeReal && !real.startsWith(`${homeReal}${path.sep}`)) {
-      return null;
-    }
-    return (await stat(real)).isDirectory() ? real : null;
-  } catch {
-    return null;
-  }
+  return ensureHomeCwd(expanded, home);
 }
 
 /** Direct spawn: new detached tmux session at the validated cwd, then boot gjc in it. */
@@ -137,7 +126,7 @@ export async function builtinSpawn(
   }
   const resolvedCwd = await resolveSpawnCwd(cwd, deps.home);
   if (!resolvedCwd) {
-    return fail('작업 폴더는 홈 아래 실존 디렉터리만');
+    return fail('작업 폴더는 홈 아래 생성 가능한 디렉터리만');
   }
   try {
     if (await hasSession(name, run)) {

--- a/server/modules/providers/services/external-cli-sessions/inference-and-spawn.ts
+++ b/server/modules/providers/services/external-cli-sessions/inference-and-spawn.ts
@@ -1,7 +1,7 @@
 import { constants as fsConstants } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, isAbsolute, relative, sep, delimiter, dirname } from 'node:path';
-import { mkdir, realpath, stat, access } from 'node:fs/promises';
+import { mkdir, realpath, stat, lstat, access } from 'node:fs/promises';
 
 import { CURSOR_CLI_COMMAND_CANDIDATES } from '@/modules/providers/list/cursor/cursor-cli-command.js';
 
@@ -98,12 +98,29 @@ function expandExternalCliCwd(input: string, home: string): string | null {
   return isAbsolute(trimmed) ? trimmed : join(home, trimmed);
 }
 
-async function realpathExistingAncestor(target: string): Promise<string | null> {
+type EnsureHomeCwdIo = {
+  realpath(pathname: string): Promise<string>;
+  lstat(pathname: string): Promise<{ isDirectory(): boolean }>;
+  mkdir(pathname: string): Promise<unknown>;
+  stat(pathname: string): Promise<{ isDirectory(): boolean }>;
+};
+
+const defaultEnsureHomeCwdIo: EnsureHomeCwdIo = { realpath, lstat, mkdir, stat };
+
+function hasFsErrorCode(error: unknown, code: string): boolean {
+  return error instanceof Error && 'code' in error && error.code === code;
+}
+
+async function realpathExistingAncestor(
+  target: string,
+  io: EnsureHomeCwdIo,
+): Promise<{ path: string; realpath: string } | null> {
   let ancestor = target;
   while (true) {
     try {
-      return await realpath(ancestor);
-    } catch {
+      return { path: ancestor, realpath: await io.realpath(ancestor) };
+    } catch (error) {
+      if (!hasFsErrorCode(error, 'ENOENT')) return null;
       const parent = dirname(ancestor);
       if (parent === ancestor) return null;
       ancestor = parent;
@@ -112,19 +129,43 @@ async function realpathExistingAncestor(target: string): Promise<string | null> 
 }
 
 /** Creates a missing absolute cwd only after its existing ancestor is proven inside HOME. */
-export async function ensureHomeCwd(cwd: string, home = homedir()): Promise<string | null> {
+export async function ensureHomeCwd(
+  cwd: string,
+  home = homedir(),
+  io: EnsureHomeCwdIo = defaultEnsureHomeCwdIo,
+): Promise<string | null> {
   if (cwd.includes('\0') || !isAbsolute(cwd)) return null;
   try {
-    const [homeReal, ancestorReal] = await Promise.all([
-      realpath(home),
-      realpathExistingAncestor(cwd),
+    const [homeReal, ancestor] = await Promise.all([
+      io.realpath(home),
+      realpathExistingAncestor(cwd, io),
     ]);
-    if (!ancestorReal || !isWithinHome(homeReal, ancestorReal)) return null;
+    if (!ancestor || !isWithinHome(homeReal, ancestor.realpath)) return null;
 
-    await mkdir(cwd, { recursive: true });
-    const resolved = await realpath(cwd);
-    if (!isWithinHome(homeReal, resolved)) return null;
-    return (await stat(resolved)).isDirectory() ? resolved : null;
+    const suffix = relative(ancestor.path, cwd).split(sep).filter(Boolean);
+    let canonicalPath = ancestor.realpath;
+    for (const component of suffix) {
+      const expectedPath = join(canonicalPath, component);
+      try {
+        const entry = await io.lstat(expectedPath);
+        if (!entry.isDirectory()) return null;
+      } catch (error) {
+        if (!hasFsErrorCode(error, 'ENOENT')) return null;
+        try {
+          await io.mkdir(expectedPath);
+        } catch (mkdirError) {
+          if (!hasFsErrorCode(mkdirError, 'EEXIST')) return null;
+          const racedEntry = await io.lstat(expectedPath);
+          if (!racedEntry.isDirectory()) return null;
+        }
+      }
+
+      const resolved = await io.realpath(expectedPath);
+      if (resolved !== expectedPath) return null;
+      canonicalPath = resolved;
+    }
+
+    return (await io.stat(canonicalPath)).isDirectory() ? canonicalPath : null;
   } catch {
     return null;
   }

--- a/server/modules/providers/services/external-cli-sessions/inference-and-spawn.ts
+++ b/server/modules/providers/services/external-cli-sessions/inference-and-spawn.ts
@@ -109,7 +109,7 @@ type EnsureHomeCwdIo = {
   lstat(pathname: string): Promise<{ isDirectory(): boolean }>;
   mkdir(pathname: string): Promise<unknown>;
   stat(pathname: string): Promise<{ isDirectory(): boolean }>;
-  createUnderRoot(root: string, components: string[]): Promise<CreateUnderRootResult>;
+  createUnderRoot(home: string, components: string[]): Promise<CreateUnderRootResult>;
 };
 
 function coreExecutablePath(): string {
@@ -123,9 +123,9 @@ function coreExecutablePath(): string {
   ));
 }
 
-async function createUnderRoot(root: string, components: string[]): Promise<CreateUnderRootResult> {
+async function createUnderRoot(home: string, components: string[]): Promise<CreateUnderRootResult> {
   return new Promise((resolve) => {
-    const child = spawn(coreExecutablePath(), ['mkdir-under', '--root', root, '--', ...components], {
+    const child = spawn(coreExecutablePath(), ['mkdir-under', '--home', home, '--', ...components], {
       stdio: ['ignore', 'pipe', 'ignore'],
       windowsHide: true,
     });
@@ -185,24 +185,7 @@ function hasFsErrorCode(error: unknown, code: string): boolean {
   return error instanceof Error && 'code' in error && error.code === code;
 }
 
-async function realpathExistingAncestor(
-  target: string,
-  io: EnsureHomeCwdIo,
-): Promise<{ path: string; realpath: string } | null> {
-  let ancestor = target;
-  while (true) {
-    try {
-      return { path: ancestor, realpath: await io.realpath(ancestor) };
-    } catch (error) {
-      if (!hasFsErrorCode(error, 'ENOENT')) return null;
-      const parent = dirname(ancestor);
-      if (parent === ancestor) return null;
-      ancestor = parent;
-    }
-  }
-}
-
-/** Creates a missing absolute cwd only after its existing ancestor is proven inside HOME. */
+/** Creates a missing absolute cwd by walking every component below canonical HOME. */
 export async function ensureHomeCwd(
   cwd: string,
   home = homedir(),
@@ -210,22 +193,20 @@ export async function ensureHomeCwd(
 ): Promise<string | null> {
   if (cwd.includes('\0') || !isAbsolute(cwd)) return null;
   try {
-    const [homeReal, ancestor] = await Promise.all([
-      io.realpath(home),
-      realpathExistingAncestor(cwd, io),
-    ]);
-    if (!ancestor || !isWithinHome(homeReal, ancestor.realpath)) return null;
+    const homeReal = await io.realpath(home);
+    const rel = relative(homeReal, cwd);
+    if (rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) return null;
+    const components = rel.split(sep).filter(Boolean);
 
-    const suffix = relative(ancestor.path, cwd).split(sep).filter(Boolean);
     if (process.platform !== 'win32') {
-      const created = await io.createUnderRoot(ancestor.realpath, suffix);
+      const created = await io.createUnderRoot(homeReal, components);
       return created.ok && typeof created.path === 'string' ? created.path : null;
     }
 
     // Windows fallback: nix does not expose the Unix openat/mkdirat contract
     // there, so retain the existing stepwise behavior on that platform.
-    let canonicalPath = ancestor.realpath;
-    for (const component of suffix) {
+    let canonicalPath = homeReal;
+    for (const component of components) {
       const expectedPath = join(canonicalPath, component);
       try {
         const entry = await io.lstat(expectedPath);

--- a/server/modules/providers/services/external-cli-sessions/inference-and-spawn.ts
+++ b/server/modules/providers/services/external-cli-sessions/inference-and-spawn.ts
@@ -1,7 +1,9 @@
+import { spawn } from 'node:child_process';
 import { constants as fsConstants } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, isAbsolute, relative, sep, delimiter, dirname } from 'node:path';
 import { mkdir, realpath, stat, lstat, access } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 
 import { CURSOR_CLI_COMMAND_CANDIDATES } from '@/modules/providers/list/cursor/cursor-cli-command.js';
 
@@ -98,14 +100,86 @@ function expandExternalCliCwd(input: string, home: string): string | null {
   return isAbsolute(trimmed) ? trimmed : join(home, trimmed);
 }
 
+type CreateUnderRootResult =
+  | { ok: true; path: string }
+  | { ok: false; code: string };
+
 type EnsureHomeCwdIo = {
   realpath(pathname: string): Promise<string>;
   lstat(pathname: string): Promise<{ isDirectory(): boolean }>;
   mkdir(pathname: string): Promise<unknown>;
   stat(pathname: string): Promise<{ isDirectory(): boolean }>;
+  createUnderRoot(root: string, components: string[]): Promise<CreateUnderRootResult>;
 };
 
-const defaultEnsureHomeCwdIo: EnsureHomeCwdIo = { realpath, lstat, mkdir, stat };
+function coreExecutablePath(): string {
+  const executable = process.platform === 'win32' ? 'chatmux-core.exe' : 'chatmux-core';
+  const compiled = !import.meta.url.endsWith('.ts');
+  return fileURLToPath(new URL(
+    compiled
+      ? `../../../../../../dist-native/${executable}`
+      : `../../../../../dist-native/${executable}`,
+    import.meta.url,
+  ));
+}
+
+async function createUnderRoot(root: string, components: string[]): Promise<CreateUnderRootResult> {
+  return new Promise((resolve) => {
+    const child = spawn(coreExecutablePath(), ['mkdir-under', '--root', root, '--', ...components], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let settled = false;
+    const finish = (result: CreateUnderRootResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      finish({ ok: false, code: 'TIMEOUT' });
+    }, 5_000);
+    child.stdout.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => {
+      stdout += chunk;
+      if (stdout.length > 64 * 1024) {
+        child.kill('SIGKILL');
+        finish({ ok: false, code: 'MALFORMED_OUTPUT' });
+      }
+    });
+    child.once('error', () => finish({ ok: false, code: 'SPAWN_ERROR' }));
+    child.once('close', (code) => {
+      if (code !== 0) {
+        finish({ ok: false, code: 'CORE_ERROR' });
+        return;
+      }
+      try {
+        const output: unknown = JSON.parse(stdout);
+        if (
+          typeof output === 'object' && output !== null &&
+          'ok' in output && output.ok === true &&
+          'path' in output && typeof output.path === 'string'
+        ) {
+          finish({ ok: true, path: output.path });
+          return;
+        }
+      } catch {
+        // Invalid core output is a closed failure below.
+      }
+      finish({ ok: false, code: 'MALFORMED_OUTPUT' });
+    });
+  });
+}
+
+const defaultEnsureHomeCwdIo: EnsureHomeCwdIo = {
+  realpath,
+  lstat,
+  mkdir,
+  stat,
+  createUnderRoot,
+};
 
 function hasFsErrorCode(error: unknown, code: string): boolean {
   return error instanceof Error && 'code' in error && error.code === code;
@@ -143,6 +217,13 @@ export async function ensureHomeCwd(
     if (!ancestor || !isWithinHome(homeReal, ancestor.realpath)) return null;
 
     const suffix = relative(ancestor.path, cwd).split(sep).filter(Boolean);
+    if (process.platform !== 'win32') {
+      const created = await io.createUnderRoot(ancestor.realpath, suffix);
+      return created.ok && typeof created.path === 'string' ? created.path : null;
+    }
+
+    // Windows fallback: nix does not expose the Unix openat/mkdirat contract
+    // there, so retain the existing stepwise behavior on that platform.
     let canonicalPath = ancestor.realpath;
     for (const component of suffix) {
       const expectedPath = join(canonicalPath, component);

--- a/server/modules/providers/services/external-cli-sessions/inference-and-spawn.ts
+++ b/server/modules/providers/services/external-cli-sessions/inference-and-spawn.ts
@@ -1,7 +1,7 @@
 import { constants as fsConstants } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, isAbsolute, relative, sep, delimiter, dirname } from 'node:path';
-import { realpath, stat, access } from 'node:fs/promises';
+import { mkdir, realpath, stat, access } from 'node:fs/promises';
 
 import { CURSOR_CLI_COMMAND_CANDIDATES } from '@/modules/providers/list/cursor/cursor-cli-command.js';
 
@@ -85,28 +85,70 @@ export function normalizeExternalPaneOutput(output: string, maxChars = 32_768): 
   return plain.length > maxChars ? plain.slice(-maxChars) : plain;
 }
 
-/** Resolves a web spawn cwd and rejects traversal/symlink escape outside HOME. */
-export async function resolveExternalCliCwd(input: string): Promise<string | null> {
-  const home = await realpath(homedir()).catch(() => null);
-  if (!home || input.includes('\0')) return null;
+function isWithinHome(home: string, target: string): boolean {
+  const rel = relative(home, target);
+  return rel !== '..' && !rel.startsWith(`..${sep}`) && !isAbsolute(rel);
+}
+
+function expandExternalCliCwd(input: string, home: string): string | null {
+  if (input.includes('\0')) return null;
   const trimmed = input.trim();
-  const expanded = trimmed === '~'
-    ? homedir()
-    : trimmed.startsWith('~/')
-      ? join(homedir(), trimmed.slice(2))
-      : isAbsolute(trimmed)
-        ? trimmed
-        : join(homedir(), trimmed);
-  try {
-    const resolved = await realpath(expanded);
-    const rel = relative(home, resolved);
-    if (rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
-      return null;
+  if (trimmed === '~') return home;
+  if (trimmed.startsWith('~/')) return join(home, trimmed.slice(2));
+  return isAbsolute(trimmed) ? trimmed : join(home, trimmed);
+}
+
+async function realpathExistingAncestor(target: string): Promise<string | null> {
+  let ancestor = target;
+  while (true) {
+    try {
+      return await realpath(ancestor);
+    } catch {
+      const parent = dirname(ancestor);
+      if (parent === ancestor) return null;
+      ancestor = parent;
     }
+  }
+}
+
+/** Creates a missing absolute cwd only after its existing ancestor is proven inside HOME. */
+export async function ensureHomeCwd(cwd: string, home = homedir()): Promise<string | null> {
+  if (cwd.includes('\0') || !isAbsolute(cwd)) return null;
+  try {
+    const [homeReal, ancestorReal] = await Promise.all([
+      realpath(home),
+      realpathExistingAncestor(cwd),
+    ]);
+    if (!ancestorReal || !isWithinHome(homeReal, ancestorReal)) return null;
+
+    await mkdir(cwd, { recursive: true });
+    const resolved = await realpath(cwd);
+    if (!isWithinHome(homeReal, resolved)) return null;
     return (await stat(resolved)).isDirectory() ? resolved : null;
   } catch {
     return null;
   }
+}
+
+/** Resolves a web spawn cwd and rejects traversal/symlink escape outside HOME. */
+export async function resolveExternalCliCwd(input: string): Promise<string | null> {
+  const home = homedir();
+  const expanded = expandExternalCliCwd(input, home);
+  if (!expanded) return null;
+  try {
+    const [homeReal, resolved] = await Promise.all([realpath(home), realpath(expanded)]);
+    if (!isWithinHome(homeReal, resolved)) return null;
+    return (await stat(resolved)).isDirectory() ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Resolves a web spawn cwd, creating a missing directory only after containment is proven. */
+export async function ensureExternalCliCwd(input: string): Promise<string | null> {
+  const home = homedir();
+  const expanded = expandExternalCliCwd(input, home);
+  return expanded ? ensureHomeCwd(expanded, home) : null;
 }
 
 export type ExternalSpawnCli = ExternalLocalCliKind;

--- a/server/modules/providers/services/live-spawn-guard.service.ts
+++ b/server/modules/providers/services/live-spawn-guard.service.ts
@@ -20,7 +20,15 @@ const GUARDED_PROVIDERS: ReadonlySet<string> = new Set<ExternalLocalCliKind>([
   'claude', 'codex', 'cursor', 'opencode', 'omp', 'omo',
 ]);
 
-export type LiveTmuxSpawnBlock = { tmuxName: string };
+export type LiveTmuxSpawnBlock = { readonly tmuxName: string };
+
+export type LiveTmuxSpawnGuardResult =
+  | { readonly kind: 'blocked'; readonly tmuxName: string }
+  | { readonly kind: 'clear' }
+  | { readonly kind: 'discovery_unavailable' };
+
+const CLEAR_RESULT = { kind: 'clear' } as const;
+const DISCOVERY_UNAVAILABLE_RESULT = { kind: 'discovery_unavailable' } as const;
 
 /** Pure matcher, exported for tests. */
 export function findLiveTmuxPaneForSession(
@@ -36,22 +44,21 @@ export function findLiveTmuxPaneForSession(
 }
 
 /**
- * Returns the live tmux owner of a provider-native session id, or null when
- * spawning is safe. Fail-open on unavailable or failed discovery evidence:
- * a false block would break the core chat path outright, while a false allow
- * merely restores the pre-guard behavior — and when tmux is not running at
- * all, no pane can own the transcript anyway.
+ * Distinguishes a clear fresh scan from unavailable discovery so callers can
+ * fail closed only when resuming a provider-native session could create a
+ * duplicate writer.
  */
 export async function findLiveTmuxSpawnBlock(
   provider: LLMProvider | string,
   providerSessionId: string | null | undefined,
-): Promise<LiveTmuxSpawnBlock | null> {
-  if (!providerSessionId || !GUARDED_PROVIDERS.has(provider)) return null;
+): Promise<LiveTmuxSpawnGuardResult> {
+  if (!providerSessionId || !GUARDED_PROVIDERS.has(provider)) return CLEAR_RESULT;
   try {
     const detailed = await getExternalCliSessionsDetailedFresh();
-    if (!detailed.ok) return null;
-    return findLiveTmuxPaneForSession(provider, providerSessionId, detailed.sessions);
+    if (!detailed.ok) return DISCOVERY_UNAVAILABLE_RESULT;
+    const owner = findLiveTmuxPaneForSession(provider, providerSessionId, detailed.sessions);
+    return owner ? { kind: 'blocked', tmuxName: owner.tmuxName } : CLEAR_RESULT;
   } catch {
-    return null;
+    return DISCOVERY_UNAVAILABLE_RESULT;
   }
 }

--- a/server/modules/providers/services/live-spawn-guard.service.ts
+++ b/server/modules/providers/services/live-spawn-guard.service.ts
@@ -48,17 +48,23 @@ export function findLiveTmuxPaneForSession(
  * fail closed only when resuming a provider-native session could create a
  * duplicate writer.
  */
-export async function findLiveTmuxSpawnBlock(
+export function createFindLiveTmuxSpawnBlock(
+  discover = getExternalCliSessionsDetailedFresh,
+): (
   provider: LLMProvider | string,
   providerSessionId: string | null | undefined,
-): Promise<LiveTmuxSpawnGuardResult> {
-  if (!providerSessionId || !GUARDED_PROVIDERS.has(provider)) return CLEAR_RESULT;
-  try {
-    const detailed = await getExternalCliSessionsDetailedFresh();
-    if (!detailed.ok) return DISCOVERY_UNAVAILABLE_RESULT;
-    const owner = findLiveTmuxPaneForSession(provider, providerSessionId, detailed.sessions);
-    return owner ? { kind: 'blocked', tmuxName: owner.tmuxName } : CLEAR_RESULT;
-  } catch {
-    return DISCOVERY_UNAVAILABLE_RESULT;
-  }
+) => Promise<LiveTmuxSpawnGuardResult> {
+  return async (provider, providerSessionId) => {
+    if (!providerSessionId || !GUARDED_PROVIDERS.has(provider)) return CLEAR_RESULT;
+    try {
+      const detailed = await discover();
+      if (!detailed.ok) return DISCOVERY_UNAVAILABLE_RESULT;
+      const owner = findLiveTmuxPaneForSession(provider, providerSessionId, detailed.sessions);
+      return owner ? { kind: 'blocked', tmuxName: owner.tmuxName } : CLEAR_RESULT;
+    } catch {
+      return DISCOVERY_UNAVAILABLE_RESULT;
+    }
+  };
 }
+
+export const findLiveTmuxSpawnBlock = createFindLiveTmuxSpawnBlock();

--- a/server/modules/providers/tests/builtin-relay.service.test.ts
+++ b/server/modules/providers/tests/builtin-relay.service.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
@@ -38,10 +38,11 @@ test('builtinSpawn: validated cwd, duplicate → conflict, then new-session + gj
   assert.equal(conflict.conflict, true);
 
   const fresh = runner((call) => (call.args[0] === 'has-session' ? { code: 1, output: '' } : ok));
-  const created = await builtinSpawn('newone', '~/workspace/proj', { run: fresh.run, home });
+  const created = await builtinSpawn('newone', '~/workspace/newone/nested', { run: fresh.run, home });
   assert.equal(created.ok, true);
   assert.deepEqual(fresh.calls[1].args.slice(0, 5), ['new-session', '-d', '-s', 'newone', '-c']);
-  assert.ok(fresh.calls[1].args[5].endsWith(`${path.sep}workspace${path.sep}proj`));
+  assert.ok(fresh.calls[1].args[5].endsWith(`${path.sep}workspace${path.sep}newone${path.sep}nested`));
+  assert.equal(statSync(path.join(home, 'workspace', 'newone', 'nested')).isDirectory(), true);
   assert.equal(fresh.calls[1].args[6], 'gjc');
   assert.equal(fresh.calls.length, 2, 'agent boot is atomic with session creation');
 });
@@ -56,17 +57,23 @@ test('builtinSpawn: company* reserved and non-home cwd fail closed', async () =>
   const home = mkdtempSync(path.join(tmpdir(), 'relay-home-'));
   const outside = await builtinSpawn('okname', '/etc', { run: noRun, home });
   assert.equal(outside.ok, false);
-  assert.ok(outside.detail.includes('홈 아래 실존 디렉터리만'));
 });
 
-test('resolveSpawnCwd: expanduser + realpath containment + must be a directory', async () => {
+test('resolveSpawnCwd: creates missing HOME directories while preserving containment checks', async () => {
+  // Given: an isolated HOME with an existing directory and file.
   const home = mkdtempSync(path.join(tmpdir(), 'relay-home-'));
   mkdirSync(path.join(home, 'workspace'));
   writeFileSync(path.join(home, 'afile'), '');
+
+  // When: the builtin fallback resolves existing and missing HOME paths.
   assert.ok((await resolveSpawnCwd('~/workspace', home))?.endsWith(`${path.sep}workspace`));
   assert.ok(await resolveSpawnCwd('~', home), 'home itself is allowed');
+  const created = await resolveSpawnCwd('~/missing/nested', home);
+
+  // Then: the missing directory exists and unsafe paths remain rejected.
+  assert.ok(created?.endsWith(`${path.sep}missing${path.sep}nested`));
+  assert.equal(statSync(created ?? '').isDirectory(), true);
   assert.equal(await resolveSpawnCwd('~/afile', home), null, 'files are not workdirs');
-  assert.equal(await resolveSpawnCwd('~/missing', home), null);
   assert.equal(await resolveSpawnCwd('/etc', home), null, 'outside home');
   assert.equal(await resolveSpawnCwd('relative/path', home), null, 'must be absolute after expansion');
 });

--- a/server/modules/providers/tests/external-cli-cwd-core.integration.test.ts
+++ b/server/modules/providers/tests/external-cli-cwd-core.integration.test.ts
@@ -15,12 +15,12 @@ type CoreOutput =
   | { ok: true; path: string }
   | { ok: false; code: string; component?: string };
 
-function runMkdirUnder(root: string, components: string[]): Promise<{
+function runMkdirUnder(home: string, components: string[]): Promise<{
   code: number | null;
   output: CoreOutput;
 }> {
   return new Promise((resolve, reject) => {
-    const child = spawn(corePath, ['mkdir-under', '--root', root, '--', ...components], {
+    const child = spawn(corePath, ['mkdir-under', '--home', home, '--', ...components], {
       stdio: ['ignore', 'pipe', 'pipe'],
     });
     let stdout = '';
@@ -69,6 +69,17 @@ test('real native core creates nested directories and refuses a symlink componen
     const nested = path.join(home, 'workspace', 'nested');
     assert.equal(await ensureHomeCwd(nested, home), nested);
     assert.equal((await lstat(nested)).isDirectory(), true);
+
+    const target = path.join(home, 'target');
+    await mkdir(path.join(target, 'existing'), { recursive: true });
+    await symlink(target, path.join(home, 'leading-link'));
+    assert.equal(
+      await ensureHomeCwd(path.join(home, 'leading-link', 'existing', 'must-not-exist'), home),
+      null,
+    );
+    assert.equal((await lstat(path.join(home, 'leading-link'))).isSymbolicLink(), true);
+    assert.equal((await lstat(path.join(target, 'existing'))).isDirectory(), true);
+    await assert.rejects(lstat(path.join(target, 'existing', 'must-not-exist')), { code: 'ENOENT' });
 
     await symlink(outside, path.join(home, 'link'));
     const rejected = await runMkdirUnder(home, ['link', 'escaped']);

--- a/server/modules/providers/tests/external-cli-cwd-core.integration.test.ts
+++ b/server/modules/providers/tests/external-cli-cwd-core.integration.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { access, lstat, mkdir, mkdtemp, rm, symlink } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+import { ensureHomeCwd } from '@/modules/providers/services/external-cli-sessions/inference-and-spawn.js';
+
+const executable = process.platform === 'win32' ? 'chatmux-core.exe' : 'chatmux-core';
+const corePath = fileURLToPath(new URL('../../../../dist-native/' + executable, import.meta.url));
+
+type CoreOutput =
+  | { ok: true; path: string }
+  | { ok: false; code: string; component?: string };
+
+function runMkdirUnder(root: string, components: string[]): Promise<{
+  code: number | null;
+  output: CoreOutput;
+}> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(corePath, ['mkdir-under', '--root', root, '--', ...components], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error('chatmux-core mkdir-under test timed out'));
+    }, 5_000);
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => { stdout += chunk; });
+    child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+    child.once('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once('close', (code) => {
+      clearTimeout(timer);
+      try {
+        resolve({ code, output: JSON.parse(stdout) as CoreOutput });
+      } catch (error) {
+        reject(new Error(`invalid core output; stderr=${stderr}`, { cause: error }));
+      }
+    });
+  });
+}
+
+test('real native core creates nested directories and refuses a symlink component', async (t) => {
+  if (process.platform === 'win32') {
+    t.skip('mkdir-under is explicitly unsupported by the native core on Windows');
+    return;
+  }
+  try {
+    await access(corePath);
+  } catch {
+    t.skip(`native core binary is absent at ${corePath}; run npm run build:core:dev`);
+    return;
+  }
+
+  const temporary = await mkdtemp(path.join(os.tmpdir(), 'chatmux-cwd-core-'));
+  const home = path.join(temporary, 'home');
+  const outside = path.join(temporary, 'outside');
+  await Promise.all([mkdir(home), mkdir(outside)]);
+
+  try {
+    const nested = path.join(home, 'workspace', 'nested');
+    assert.equal(await ensureHomeCwd(nested, home), nested);
+    assert.equal((await lstat(nested)).isDirectory(), true);
+
+    await symlink(outside, path.join(home, 'link'));
+    const rejected = await runMkdirUnder(home, ['link', 'escaped']);
+    assert.notEqual(rejected.code, 0);
+    assert.equal(rejected.output.ok, false);
+    assert.equal((await lstat(path.join(home, 'link'))).isSymbolicLink(), true);
+    await assert.rejects(lstat(path.join(outside, 'escaped')), { code: 'ENOENT' });
+  } finally {
+    await rm(temporary, { recursive: true, force: true });
+  }
+});

--- a/server/modules/providers/tests/external-cli-cwd-safety.test.ts
+++ b/server/modules/providers/tests/external-cli-cwd-safety.test.ts
@@ -1,124 +1,105 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { lstat, mkdir, mkdtemp, realpath, rm, stat, symlink } from 'node:fs/promises';
+import { lstat, mkdir, mkdtemp, realpath, rm, stat } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 
 import { ensureHomeCwd } from '@/modules/providers/services/external-cli-sessions/inference-and-spawn.js';
 
-const defaultIo = { realpath, lstat, mkdir, stat };
-
 function fsError(code: string): NodeJS.ErrnoException {
   return Object.assign(new Error(code), { code });
 }
 
-test('ensureHomeCwd aborts a parent symlink swap before creating through it', async () => {
-  const root = await mkdtemp(path.join(os.tmpdir(), 'chatmux-cwd-swap-'));
+async function fixture(prefix: string): Promise<{
+  root: string;
+  home: string;
+  target: string;
+}> {
+  const root = await mkdtemp(path.join(os.tmpdir(), prefix));
   const home = path.join(root, 'home');
-  const evil = path.join(root, 'evil');
-  await Promise.all([mkdir(home), mkdir(evil)]);
-  const first = path.join(home, 'first');
-  const target = path.join(first, 'second');
-  const mkdirCalls: string[] = [];
+  const target = path.join(home, 'first', 'second');
+  await mkdir(home);
+  return { root, home, target };
+}
 
-  const io = {
-    ...defaultIo,
+function testIo(
+  createUnderRoot: (root: string, components: string[]) => Promise<
+    { ok: true; path: string } | { ok: false; code: string }
+  >,
+) {
+  const mkdirCalls: string[] = [];
+  return {
+    realpath: (pathname: string) => realpath(pathname),
+    lstat: (pathname: string) => lstat(pathname),
+    stat: (pathname: string) => stat(pathname),
     mkdir: async (pathname: string) => {
       mkdirCalls.push(pathname);
-      await mkdir(pathname);
-      if (pathname === first) {
-        await rm(first, { recursive: true });
-        await symlink(evil, first);
-      }
     },
+    createUnderRoot,
+    mkdirCalls,
   };
+}
 
+const unixTest = process.platform === 'win32' ? test.skip : test;
+
+unixTest('ensureHomeCwd delegates the proven ancestor and suffix to the native core', async () => {
+  const { root, home, target } = await fixture('chatmux-cwd-delegate-');
+  const anchoredPath = path.join(home, 'native-result');
+  const calls: Array<{ root: string; components: string[] }> = [];
+
+  const io = testIo(async (provenRoot, components) => {
+    calls.push({ root: provenRoot, components });
+    return { ok: true, path: anchoredPath };
+  });
   try {
-    assert.equal(await ensureHomeCwd(target, home, io), null);
-    assert.deepEqual(mkdirCalls, [first], 'mkdir never traverses the swapped symlink parent');
-    await assert.rejects(lstat(path.join(evil, 'second')), { code: 'ENOENT' });
+    const result = await ensureHomeCwd(target, home, io);
+
+    assert.equal(result, anchoredPath, 'only the core-returned anchored path is accepted');
+    assert.deepEqual(calls, [{ root: await realpath(home), components: ['first', 'second'] }]);
+    assert.deepEqual(io.mkdirCalls, []);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
 
-test('ensureHomeCwd aborts when ancestor discovery hits EACCES', async () => {
-  const root = await mkdtemp(path.join(os.tmpdir(), 'chatmux-cwd-eacces-'));
-  const home = path.join(root, 'home');
-  const target = path.join(home, 'blocked', 'child');
-  await mkdir(home);
-  let mkdirCalled = false;
-  const io = {
-    ...defaultIo,
-    realpath: async (pathname: string) => {
-      if (pathname === target) throw fsError('EACCES');
-      return realpath(pathname);
-    },
-    mkdir: async (pathname: string) => {
-      mkdirCalled = true;
-      await mkdir(pathname);
-    },
+for (const [name, create] of [
+  ['failure', async () => ({ ok: false as const, code: 'CORE_ERROR' })],
+  ['timeout', async () => ({ ok: false as const, code: 'TIMEOUT' })],
+  ['exception', async () => { throw new Error('native core failed'); }],
+  [
+    'malformed output',
+    async () => ({ ok: true, path: 42 }) as unknown as { ok: true; path: string },
+  ],
+] as const) {
+  unixTest(`ensureHomeCwd fails closed on native core ${name}`, async () => {
+    const { root, home, target } = await fixture(`chatmux-cwd-${name.replace(' ', '-')}-`);
+    const io = testIo(create);
+    try {
+      assert.equal(await ensureHomeCwd(target, home, io), null);
+      assert.deepEqual(io.mkdirCalls, []);
+      await assert.rejects(lstat(path.join(home, 'first')), { code: 'ENOENT' });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+}
+
+unixTest('ensureHomeCwd aborts when ancestor discovery hits EACCES', async () => {
+  const { root, home, target } = await fixture('chatmux-cwd-eacces-');
+  let createCalled = false;
+  const io = testIo(async () => {
+    createCalled = true;
+    return { ok: true, path: target };
+  });
+  io.realpath = async (pathname: string) => {
+    if (pathname === target) throw fsError('EACCES');
+    return realpath(pathname);
   };
 
   try {
     assert.equal(await ensureHomeCwd(target, home, io), null);
-    assert.equal(mkdirCalled, false);
-  } finally {
-    await rm(root, { recursive: true, force: true });
-  }
-});
-
-test('ensureHomeCwd aborts an EACCES error during the component walk', async () => {
-  const root = await mkdtemp(path.join(os.tmpdir(), 'chatmux-cwd-walk-eacces-'));
-  const home = path.join(root, 'home');
-  await mkdir(home);
-  const first = path.join(home, 'first');
-  const blocked = path.join(first, 'blocked');
-  const mkdirCalls: string[] = [];
-  const io = {
-    ...defaultIo,
-    lstat: async (pathname: string) => {
-      if (pathname === blocked) throw fsError('EACCES');
-      return lstat(pathname);
-    },
-    mkdir: async (pathname: string) => {
-      mkdirCalls.push(pathname);
-      await mkdir(pathname);
-    },
-  };
-
-  try {
-    assert.equal(await ensureHomeCwd(blocked, home, io), null);
-    assert.deepEqual(mkdirCalls, [first]);
-  } finally {
-    await rm(root, { recursive: true, force: true });
-  }
-});
-
-test('ensureHomeCwd rejects an EEXIST race that installs a symlink', async () => {
-  const root = await mkdtemp(path.join(os.tmpdir(), 'chatmux-cwd-eexist-'));
-  const home = path.join(root, 'home');
-  const evil = path.join(root, 'evil');
-  await Promise.all([mkdir(home), mkdir(evil)]);
-  const raced = path.join(home, 'raced');
-  const target = path.join(raced, 'child');
-  let racedOnce = false;
-  const io = {
-    ...defaultIo,
-    mkdir: async (pathname: string) => {
-      if (pathname === raced && !racedOnce) {
-        racedOnce = true;
-        await symlink(evil, raced);
-        throw fsError('EEXIST');
-      }
-      await mkdir(pathname);
-    },
-  };
-
-  try {
-    assert.equal(await ensureHomeCwd(target, home, io), null);
-    assert.equal((await lstat(raced)).isSymbolicLink(), true);
-    await assert.rejects(lstat(path.join(evil, 'child')), { code: 'ENOENT' });
+    assert.equal(createCalled, false);
+    assert.deepEqual(io.mkdirCalls, []);
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/server/modules/providers/tests/external-cli-cwd-safety.test.ts
+++ b/server/modules/providers/tests/external-cli-cwd-safety.test.ts
@@ -23,7 +23,7 @@ async function fixture(prefix: string): Promise<{
 }
 
 function testIo(
-  createUnderRoot: (root: string, components: string[]) => Promise<
+  createUnderRoot: (home: string, components: string[]) => Promise<
     { ok: true; path: string } | { ok: false; code: string }
   >,
 ) {
@@ -42,20 +42,21 @@ function testIo(
 
 const unixTest = process.platform === 'win32' ? test.skip : test;
 
-unixTest('ensureHomeCwd delegates the proven ancestor and suffix to the native core', async () => {
+unixTest('ensureHomeCwd delegates canonical HOME and every relative component to the native core', async () => {
   const { root, home, target } = await fixture('chatmux-cwd-delegate-');
   const anchoredPath = path.join(home, 'native-result');
-  const calls: Array<{ root: string; components: string[] }> = [];
+  const calls: Array<{ home: string; components: string[] }> = [];
+  await mkdir(path.join(home, 'first'));
 
-  const io = testIo(async (provenRoot, components) => {
-    calls.push({ root: provenRoot, components });
+  const io = testIo(async (canonicalHome, components) => {
+    calls.push({ home: canonicalHome, components });
     return { ok: true, path: anchoredPath };
   });
   try {
     const result = await ensureHomeCwd(target, home, io);
 
     assert.equal(result, anchoredPath, 'only the core-returned anchored path is accepted');
-    assert.deepEqual(calls, [{ root: await realpath(home), components: ['first', 'second'] }]);
+    assert.deepEqual(calls, [{ home: await realpath(home), components: ['first', 'second'] }]);
     assert.deepEqual(io.mkdirCalls, []);
   } finally {
     await rm(root, { recursive: true, force: true });
@@ -84,7 +85,7 @@ for (const [name, create] of [
   });
 }
 
-unixTest('ensureHomeCwd aborts when ancestor discovery hits EACCES', async () => {
+unixTest('ensureHomeCwd aborts when HOME canonicalization hits EACCES', async () => {
   const { root, home, target } = await fixture('chatmux-cwd-eacces-');
   let createCalled = false;
   const io = testIo(async () => {
@@ -92,12 +93,29 @@ unixTest('ensureHomeCwd aborts when ancestor discovery hits EACCES', async () =>
     return { ok: true, path: target };
   });
   io.realpath = async (pathname: string) => {
-    if (pathname === target) throw fsError('EACCES');
+    if (pathname === home) throw fsError('EACCES');
     return realpath(pathname);
   };
 
   try {
     assert.equal(await ensureHomeCwd(target, home, io), null);
+    assert.equal(createCalled, false);
+    assert.deepEqual(io.mkdirCalls, []);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+unixTest('ensureHomeCwd rejects lexical HOME escapes before invoking the native core', async () => {
+  const { root, home } = await fixture('chatmux-cwd-escape-');
+  let createCalled = false;
+  const io = testIo(async () => {
+    createCalled = true;
+    return { ok: true, path: root };
+  });
+
+  try {
+    assert.equal(await ensureHomeCwd(path.join(root, 'outside'), home, io), null);
     assert.equal(createCalled, false);
     assert.deepEqual(io.mkdirCalls, []);
   } finally {

--- a/server/modules/providers/tests/external-cli-cwd-safety.test.ts
+++ b/server/modules/providers/tests/external-cli-cwd-safety.test.ts
@@ -1,0 +1,125 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { lstat, mkdir, mkdtemp, realpath, rm, stat, symlink } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { ensureHomeCwd } from '@/modules/providers/services/external-cli-sessions/inference-and-spawn.js';
+
+const defaultIo = { realpath, lstat, mkdir, stat };
+
+function fsError(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(code), { code });
+}
+
+test('ensureHomeCwd aborts a parent symlink swap before creating through it', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'chatmux-cwd-swap-'));
+  const home = path.join(root, 'home');
+  const evil = path.join(root, 'evil');
+  await Promise.all([mkdir(home), mkdir(evil)]);
+  const first = path.join(home, 'first');
+  const target = path.join(first, 'second');
+  const mkdirCalls: string[] = [];
+
+  const io = {
+    ...defaultIo,
+    mkdir: async (pathname: string) => {
+      mkdirCalls.push(pathname);
+      await mkdir(pathname);
+      if (pathname === first) {
+        await rm(first, { recursive: true });
+        await symlink(evil, first);
+      }
+    },
+  };
+
+  try {
+    assert.equal(await ensureHomeCwd(target, home, io), null);
+    assert.deepEqual(mkdirCalls, [first], 'mkdir never traverses the swapped symlink parent');
+    await assert.rejects(lstat(path.join(evil, 'second')), { code: 'ENOENT' });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('ensureHomeCwd aborts when ancestor discovery hits EACCES', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'chatmux-cwd-eacces-'));
+  const home = path.join(root, 'home');
+  const target = path.join(home, 'blocked', 'child');
+  await mkdir(home);
+  let mkdirCalled = false;
+  const io = {
+    ...defaultIo,
+    realpath: async (pathname: string) => {
+      if (pathname === target) throw fsError('EACCES');
+      return realpath(pathname);
+    },
+    mkdir: async (pathname: string) => {
+      mkdirCalled = true;
+      await mkdir(pathname);
+    },
+  };
+
+  try {
+    assert.equal(await ensureHomeCwd(target, home, io), null);
+    assert.equal(mkdirCalled, false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('ensureHomeCwd aborts an EACCES error during the component walk', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'chatmux-cwd-walk-eacces-'));
+  const home = path.join(root, 'home');
+  await mkdir(home);
+  const first = path.join(home, 'first');
+  const blocked = path.join(first, 'blocked');
+  const mkdirCalls: string[] = [];
+  const io = {
+    ...defaultIo,
+    lstat: async (pathname: string) => {
+      if (pathname === blocked) throw fsError('EACCES');
+      return lstat(pathname);
+    },
+    mkdir: async (pathname: string) => {
+      mkdirCalls.push(pathname);
+      await mkdir(pathname);
+    },
+  };
+
+  try {
+    assert.equal(await ensureHomeCwd(blocked, home, io), null);
+    assert.deepEqual(mkdirCalls, [first]);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('ensureHomeCwd rejects an EEXIST race that installs a symlink', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'chatmux-cwd-eexist-'));
+  const home = path.join(root, 'home');
+  const evil = path.join(root, 'evil');
+  await Promise.all([mkdir(home), mkdir(evil)]);
+  const raced = path.join(home, 'raced');
+  const target = path.join(raced, 'child');
+  let racedOnce = false;
+  const io = {
+    ...defaultIo,
+    mkdir: async (pathname: string) => {
+      if (pathname === raced && !racedOnce) {
+        racedOnce = true;
+        await symlink(evil, raced);
+        throw fsError('EEXIST');
+      }
+      await mkdir(pathname);
+    },
+  };
+
+  try {
+    assert.equal(await ensureHomeCwd(target, home, io), null);
+    assert.equal((await lstat(raced)).isSymbolicLink(), true);
+    await assert.rejects(lstat(path.join(evil, 'child')), { code: 'ENOENT' });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/server/modules/providers/tests/live-spawn-guard.test.ts
+++ b/server/modules/providers/tests/live-spawn-guard.test.ts
@@ -2,7 +2,10 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import type { ExternalCliSession } from '@/modules/providers/services/external-cli-sessions.service.js';
-import { findLiveTmuxPaneForSession } from '@/modules/providers/services/live-spawn-guard.service.js';
+import {
+  createFindLiveTmuxSpawnBlock,
+  findLiveTmuxPaneForSession,
+} from '@/modules/providers/services/live-spawn-guard.service.js';
 
 const tmux = {
   socketPath: '/tmp/tmux-1000/default',
@@ -39,6 +42,36 @@ test('a different provider, different id, or unresolved pane never blocks', () =
   assert.equal(findLiveTmuxPaneForSession('omp', 'S-1', sessions), null);
   assert.equal(findLiveTmuxPaneForSession('omo', 'S-other', sessions), null);
   assert.equal(findLiveTmuxPaneForSession('omo', 'S-1', []), null);
+});
+
+test('the discovery adapter preserves unavailable, clear, and blocked states', async () => {
+  const unavailable = createFindLiveTmuxSpawnBlock(async () => ({ ok: false, sessions: [] }));
+  assert.deepEqual(await unavailable('omo', 'S-1'), { kind: 'discovery_unavailable' });
+
+  const throwing = createFindLiveTmuxSpawnBlock(async () => { throw new Error('scan failed'); });
+  assert.deepEqual(await throwing('omo', 'S-1'), { kind: 'discovery_unavailable' });
+
+  const clear = createFindLiveTmuxSpawnBlock(async () => ({ ok: true, sessions: [] }));
+  assert.deepEqual(await clear('omo', 'S-1'), { kind: 'clear' });
+
+  const blocked = createFindLiveTmuxSpawnBlock(async () => ({
+    ok: true,
+    sessions: [session({ kind: 'omo', providerSessionId: 'S-1', tmuxName: 'omo-pane' })],
+  }));
+  assert.deepEqual(await blocked('omo', 'S-1'), { kind: 'blocked', tmuxName: 'omo-pane' });
+});
+
+test('the discovery adapter skips discovery without a guarded provider session id', async () => {
+  let discoveryCalls = 0;
+  const findBlock = createFindLiveTmuxSpawnBlock(async () => {
+    discoveryCalls++;
+    return { ok: true, sessions: [] };
+  });
+
+  assert.deepEqual(await findBlock('omo', null), { kind: 'clear' });
+  assert.deepEqual(await findBlock('omo', undefined), { kind: 'clear' });
+  assert.deepEqual(await findBlock('gjc', 'S-1'), { kind: 'clear' });
+  assert.equal(discoveryCalls, 0);
 });
 
 test('every headless-resume provider is guarded; gjc and non-CLI lanes are not', () => {

--- a/server/modules/providers/tests/provider-routes-contract-cases-3.ts
+++ b/server/modules/providers/tests/provider-routes-contract-cases-3.ts
@@ -108,6 +108,10 @@ test('external kill protects company-prefixed sessions', async () => {
 });
 
 test('external and live spawn create missing HOME cwd paths while retaining safety rejections', async () => {
+  assertError(await request('/sessions/external/spawn', { name: 'company', cwd: '~' }), 400, 'INVALID_SPAWN_NAME');
+  assertError(await request('/sessions/external/spawn', { name: 'contract', cwd: ' ' }), 400, 'EMPTY_CWD');
+  assertError(await request('/sessions/live/spawn', { name: 'contract', cwd: ' ' }), 400, 'EMPTY_CWD');
+
   // Given: an isolated HOME and paths which must remain outside it.
   const home = await mkdtemp(path.join(os.tmpdir(), 'chatmux-spawn-home-'));
   const outside = await mkdtemp(path.join(os.tmpdir(), 'chatmux-spawn-outside-'));

--- a/server/modules/providers/tests/provider-routes-contract-cases-3.ts
+++ b/server/modules/providers/tests/provider-routes-contract-cases-3.ts
@@ -1,3 +1,7 @@
+import { chmod, mkdir, mkdtemp, stat, symlink } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
 import { app, assert, assertError, assertSuccess,
   externalTmux, liveTmux, request, test, validProcess,
 } from './support/provider-routes-contract.support.js';
@@ -103,12 +107,45 @@ test('external kill protects company-prefixed sessions', async () => {
   }
 });
 
-test('external and live spawn preserve name and cwd validation contracts', async () => {
-  assertError(await request('/sessions/external/spawn', { name: 'company', cwd: '~' }), 400, 'INVALID_SPAWN_NAME');
-  assertError(await request('/sessions/external/spawn', { name: 'contract', cwd: ' ' }), 400, 'EMPTY_CWD');
-  assertError(await request('/sessions/external/spawn', { name: 'contract', cwd: '/definitely-not-a-chatmux-directory' }), 400, 'INVALID_CWD');
-  assertError(await request('/sessions/live/spawn', { name: 'contract', cwd: ' ' }), 400, 'EMPTY_CWD');
-  assertError(await request('/sessions/live/spawn', { name: 'contract', cwd: '/definitely-not-a-chatmux-directory' }), 400, 'INVALID_CWD');
+test('external and live spawn create missing HOME cwd paths while retaining safety rejections', async () => {
+  // Given: an isolated HOME and paths which must remain outside it.
+  const home = await mkdtemp(path.join(os.tmpdir(), 'chatmux-spawn-home-'));
+  const outside = await mkdtemp(path.join(os.tmpdir(), 'chatmux-spawn-outside-'));
+  const originalHome = process.env.HOME;
+  process.env.HOME = home;
+  try {
+    // When: both local spawn routes receive missing nested paths under HOME.
+    const externalCwd = 'projects/external/nested';
+    const liveCwd = 'projects/live/nested';
+    assertSuccess(await request('/sessions/external/spawn', { name: 'external-cwd-create', cwd: externalCwd, cli: 'codex' }), 201);
+    assertSuccess(await request('/sessions/live/spawn', { name: 'live-cwd-create', cwd: liveCwd }));
+
+    // Then: both request paths reached their spawn boundary with a real directory.
+    assert.equal((await stat(path.join(home, externalCwd))).isDirectory(), true);
+    assert.equal((await stat(path.join(home, liveCwd))).isDirectory(), true);
+
+    // Given: traversal, symlink escape, and absolute paths outside HOME.
+    await symlink(outside, path.join(home, 'escape'));
+    assertError(await request('/sessions/external/spawn', { name: 'traversal-cwd', cwd: '../escape' }), 400, 'INVALID_CWD');
+    assertError(await request('/sessions/live/spawn', { name: 'symlink-cwd', cwd: '~/escape/nested' }), 400, 'INVALID_CWD');
+    assertError(await request('/sessions/external/spawn', { name: 'outside-cwd', cwd: path.join(outside, 'nested') }), 400, 'INVALID_CWD');
+
+    // Given: a HOME child that cannot create descendants.
+    const blocked = path.join(home, 'blocked');
+    await mkdir(blocked);
+    await chmod(blocked, 0o500);
+    try {
+      // When: creation requires the inaccessible directory.
+      const response = await request('/sessions/live/spawn', { name: 'blocked-cwd', cwd: '~/blocked/nested' });
+      // Then: the failure remains a validation rejection and no spawn succeeds.
+      assertError(response, 400, 'INVALID_CWD');
+    } finally {
+      await chmod(blocked, 0o700);
+    }
+  } finally {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+  }
 });
 
 test('external spawn maps a failed tmux new-session to its 409 conflict contract', async () => {
@@ -156,5 +193,5 @@ test('spawn response and fresh-verifier boundaries stay explicit in the route so
   assert.match(externalSpawn, /createApiSuccessResponse\(\{ ok: true, tmuxName: body\.name, cwd, cli \}\)/);
   assert.doesNotMatch(externalSpawn, /paneId|sessionId|windowId|socketPath/);
   assert.doesNotMatch(externalSpawn, /assertFreshExternalTmuxTarget/);
-  assert.match(liveSpawn, /resolveExternalCliCwd\(cwdInput\)/);
+  assert.match(liveSpawn, /ensureExternalCliCwd\(cwdInput\)/);
 });

--- a/server/modules/websocket/services/chat-websocket.service.ts
+++ b/server/modules/websocket/services/chat-websocket.service.ts
@@ -59,6 +59,11 @@ type ProviderSpawnResult = Promise<unknown> & {
   abortHandle?: string;
 };
 
+type LiveTmuxSpawnGuardResult =
+  | { readonly kind: 'blocked'; readonly tmuxName: string }
+  | { readonly kind: 'clear' }
+  | { readonly kind: 'discovery_unavailable' };
+
 type ChatWebSocketDependencies = {
   /** Provider runtimes keyed by provider id. */
   spawnFns: Record<LLMProvider, ProviderSpawnFn>;
@@ -79,16 +84,13 @@ type ChatWebSocketDependencies = {
   /** Provider-runtime approvals included in `chat_subscribed` after reconnect. */
   getPendingApprovalsForSession: (providerSessionId: string) => unknown[];
   /**
-   * Live-pane spawn guard (#44): resolves the tmux session that currently
-   * owns a provider-native session id, or null when spawning is safe. When a
-   * transcript is live in a tmux pane, spawning a headless resume would put a
-   * second writer on the same JSONL and the live agent would never see the
-   * message, so `chat.send` must refuse instead.
+   * Live-pane spawn guard (#44): reports whether a fresh scan found the tmux
+   * owner, proved there is none, or could not establish either result.
    */
   findLiveTmuxSpawnBlock?: (
     provider: LLMProvider,
     providerSessionId: string | null | undefined,
-  ) => Promise<{ tmuxName: string } | null>;
+  ) => Promise<LiveTmuxSpawnGuardResult>;
   /** Optional non-chat protocol mounted on the authenticated /ws gateway. */
   handleDiscovery?: (ws: WebSocket, data: AnyRecord) => boolean;
 };
@@ -185,19 +187,32 @@ async function handleChatSend(
   }
 
   if (session.provider_session_id && dependencies.findLiveTmuxSpawnBlock) {
-    const liveOwner = await dependencies.findLiveTmuxSpawnBlock(
+    const spawnGuard = await dependencies.findLiveTmuxSpawnBlock(
       provider,
       session.provider_session_id,
     );
-    if (liveOwner) {
-      sendProtocolError(
-        ws,
-        'SESSION_LIVE_IN_TMUX',
-        `This session is currently live in tmux session "${liveOwner.tmuxName}". `
-          + 'Send input through the live session view instead of starting a second process.',
-        sessionId,
-      );
-      return;
+    switch (spawnGuard.kind) {
+      case 'blocked':
+        sendProtocolError(
+          ws,
+          'SESSION_LIVE_IN_TMUX',
+          `This session is currently live in tmux session "${spawnGuard.tmuxName}". `
+            + 'Send input through the live session view instead of starting a second process.',
+          sessionId,
+        );
+        return;
+      case 'discovery_unavailable':
+        sendProtocolError(
+          ws,
+          'DISCOVERY_UNAVAILABLE',
+          'Cannot safely resume this session because live session discovery is unavailable.',
+          sessionId,
+        );
+        return;
+      case 'clear':
+        break;
+      default:
+        spawnGuard satisfies never;
     }
   }
 

--- a/server/modules/websocket/tests/chat-websocket-resume-guard.test.ts
+++ b/server/modules/websocket/tests/chat-websocket-resume-guard.test.ts
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+import { closeConnection, initializeDatabase, sessionsDb } from '@/modules/database/index.js';
+import { chatRunRegistry } from '@/modules/websocket/services/chat-run-registry.service.js';
+import { handleChatConnection } from '@/modules/websocket/services/chat-websocket.service.js';
+import { connectedClients } from '@/modules/websocket/services/websocket-state.service.js';
+
+type Dependencies = Parameters<typeof handleChatConnection>[2];
+type SpawnGuard = NonNullable<Dependencies['findLiveTmuxSpawnBlock']>;
+
+class FakeWebSocket extends EventEmitter {
+  readonly readyState = 1;
+  readonly frames: Array<Record<string, unknown>> = [];
+
+  send(data: string): void {
+    this.frames.push(JSON.parse(data) as Record<string, unknown>);
+  }
+
+  async receive(data: Record<string, unknown>): Promise<void> {
+    const listeners = this.listeners('message');
+    assert.equal(listeners.length, 1);
+    await Promise.all(listeners.map((listener) => listener(Buffer.from(JSON.stringify(data)))));
+  }
+}
+
+function dependencies(guard: SpawnGuard, onSpawn: () => void): Dependencies {
+  const spawn: Dependencies['spawnFns']['claude'] = async () => {
+    onSpawn();
+  };
+  const abort: Dependencies['abortFns']['claude'] = async () => false;
+
+  return {
+    spawnFns: {
+      claude: spawn,
+      codex: spawn,
+      cursor: spawn,
+      opencode: spawn,
+      gjc: spawn,
+      omp: spawn,
+      omo: spawn,
+    },
+    abortFns: {
+      claude: abort,
+      codex: abort,
+      cursor: abort,
+      opencode: abort,
+      gjc: abort,
+      omp: abort,
+      omo: abort,
+    },
+    resolveToolApproval: () => undefined,
+    getPendingApprovalsForSession: () => [],
+    findLiveTmuxSpawnBlock: guard,
+  };
+}
+
+async function withIsolatedDatabase(runTest: () => void | Promise<void>): Promise<void> {
+  const previousDatabasePath = process.env.DATABASE_PATH;
+  const tempDirectory = await mkdtemp(path.join(tmpdir(), 'chat-websocket-resume-guard-'));
+
+  closeConnection();
+  process.env.DATABASE_PATH = path.join(tempDirectory, 'auth.db');
+  await initializeDatabase();
+
+  try {
+    await runTest();
+  } finally {
+    connectedClients.clear();
+    chatRunRegistry.clearAll();
+    closeConnection();
+    if (previousDatabasePath === undefined) {
+      delete process.env.DATABASE_PATH;
+    } else {
+      process.env.DATABASE_PATH = previousDatabasePath;
+    }
+    await rm(tempDirectory, { recursive: true, force: true });
+  }
+}
+
+test('chat.send rejects a resume when fresh discovery is unavailable', async () => {
+  await withIsolatedDatabase(async () => {
+    // Given: a persisted provider session whose live-owner discovery failed.
+    sessionsDb.createSession('provider-resume-1', 'claude', '/workspace/demo');
+    let spawnCount = 0;
+    const ws = new FakeWebSocket();
+    handleChatConnection(
+      ws as never,
+      {} as never,
+      dependencies(async () => ({ kind: 'discovery_unavailable' }), () => { spawnCount += 1; }),
+    );
+
+    // When: the client asks to resume that session.
+    await ws.receive({ type: 'chat.send', sessionId: 'provider-resume-1', content: 'continue' });
+
+    // Then: the gateway fails closed before starting a second writer.
+    assert.equal(spawnCount, 0);
+    assert.equal(ws.frames.length, 1);
+    assert.equal(ws.frames[0]?.kind, 'protocol_error');
+    assert.equal(ws.frames[0]?.code, 'DISCOVERY_UNAVAILABLE');
+    assert.equal(ws.frames[0]?.sessionId, 'provider-resume-1');
+  });
+});
+
+test('chat.send keeps blocking a resume owned by a discovered live pane', async () => {
+  await withIsolatedDatabase(async () => {
+    // Given: fresh discovery ties the persisted provider session to a live pane.
+    sessionsDb.createSession('provider-live-1', 'claude', '/workspace/demo');
+    let spawnCount = 0;
+    const ws = new FakeWebSocket();
+    handleChatConnection(
+      ws as never,
+      {} as never,
+      dependencies(
+        async () => ({ kind: 'blocked', tmuxName: 'live-pane' }),
+        () => { spawnCount += 1; },
+      ),
+    );
+
+    // When: the client asks to resume that session.
+    await ws.receive({ type: 'chat.send', sessionId: 'provider-live-1', content: 'continue' });
+
+    // Then: the existing duplicate-writer block still rejects the send.
+    assert.equal(spawnCount, 0);
+    assert.equal(ws.frames[0]?.kind, 'protocol_error');
+    assert.equal(ws.frames[0]?.code, 'SESSION_LIVE_IN_TMUX');
+  });
+});
+
+test('chat.send resumes when fresh discovery finds no live owner', async () => {
+  await withIsolatedDatabase(async () => {
+    // Given: fresh discovery proves no live pane owns the persisted provider session.
+    sessionsDb.createSession('provider-clear-1', 'claude', '/workspace/demo');
+    let spawnCount = 0;
+    const ws = new FakeWebSocket();
+    handleChatConnection(
+      ws as never,
+      {} as never,
+      dependencies(async () => ({ kind: 'clear' }), () => { spawnCount += 1; }),
+    );
+
+    // When: the client asks to resume that session.
+    await ws.receive({ type: 'chat.send', sessionId: 'provider-clear-1', content: 'continue' });
+
+    // Then: the provider run starts as it did before the tri-state guard.
+    assert.equal(spawnCount, 1);
+    assert.equal(ws.frames.some((frame) => frame.kind === 'protocol_error'), false);
+  });
+});
+
+test('chat.send starts a new session when fresh discovery is unavailable', async () => {
+  await withIsolatedDatabase(async () => {
+    // Given: an app session that has no provider-native session id yet.
+    sessionsDb.createAppSession('app-new-1', 'claude', '/workspace/demo');
+    let spawnCount = 0;
+    let guardCount = 0;
+    const ws = new FakeWebSocket();
+    handleChatConnection(
+      ws as never,
+      {} as never,
+      dependencies(
+        async () => {
+          guardCount += 1;
+          return { kind: 'discovery_unavailable' };
+        },
+        () => { spawnCount += 1; },
+      ),
+    );
+
+    // When: the client sends the first message.
+    await ws.receive({ type: 'chat.send', sessionId: 'app-new-1', content: 'start' });
+
+    // Then: discovery is irrelevant and the new provider run starts normally.
+    assert.equal(guardCount, 0);
+    assert.equal(spawnCount, 1);
+    assert.equal(ws.frames.some((frame) => frame.kind === 'protocol_error'), false);
+  });
+});

--- a/src/components/chat/hooks/useChatComposerState.ts
+++ b/src/components/chat/hooks/useChatComposerState.ts
@@ -841,7 +841,7 @@ export function useChatComposerState({
       });
 
       setIsUserScrolledUp(false);
-      setTimeout(() => scrollToBottom(), 100);
+      scrollToBottom();
 
       // One message shape for every provider. The backend resolves the
       // provider, project path, and provider-native resume id from the

--- a/src/components/chat/hooks/useChatSessionState.test.ts
+++ b/src/components/chat/hooks/useChatSessionState.test.ts
@@ -1,11 +1,234 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { createElement } from 'react';
+import TestRenderer, { act, type ReactTestRenderer } from 'react-test-renderer';
+
+import type { NormalizedMessage, SessionStore } from '../../../stores/useSessionStore';
+
 import {
   shouldApplySessionRefresh,
   shouldRefreshCachedImageWindow,
   shouldReplaceSessionMessageWindow,
+  useChatSessionState,
 } from './useChatSessionState';
+
+type SessionState = ReturnType<typeof useChatSessionState>;
+
+type FakeScrollContainer = HTMLDivElement & {
+  clientHeight: number;
+  scrollHeight: number;
+  scrollTop: number;
+};
+
+function fakeSessionStore(withMessage = false) {
+  let messages: NormalizedMessage[] = withMessage ? [{
+    id: 'message-1',
+    sessionId: 'session-1',
+    timestamp: new Date().toISOString(),
+    provider: 'claude' as const,
+    kind: 'text' as const,
+    role: 'user' as const,
+    content: 'keep this viewport under user control',
+  }] : [];
+  let pendingExternalContent: string | null = null;
+  const store = {
+    setActiveSession() {},
+    getMessages: () => messages,
+    has: () => withMessage,
+    fetchFromServer: async () => ({ hasMore: false, total: messages.length }),
+    refreshFromServer: async () => {
+      if (pendingExternalContent !== null) {
+        messages = [...messages, {
+          id: `message-${messages.length + 1}`,
+          sessionId: 'session-1',
+          timestamp: new Date().toISOString(),
+          provider: 'claude' as const,
+          kind: 'text' as const,
+          role: 'assistant' as const,
+          content: pendingExternalContent,
+        }];
+        pendingExternalContent = null;
+      }
+      return { hasMore: false, total: messages.length, serverMessages: messages };
+    },
+  } as unknown as SessionStore;
+
+  return {
+    store,
+    queueExternalMessage: (content: string) => {
+      pendingExternalContent = content;
+    },
+  };
+}
+
+function fakeScrollContainer(): FakeScrollContainer {
+  const listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
+  return {
+    clientHeight: 300,
+    scrollHeight: 900,
+    scrollTop: 600,
+    firstElementChild: {} as Element,
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+      const registered = listeners.get(type) ?? new Set<EventListenerOrEventListenerObject>();
+      registered.add(listener);
+      listeners.set(type, registered);
+    },
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+      listeners.get(type)?.delete(listener);
+    },
+  } as unknown as FakeScrollContainer;
+}
+
+function installScrollBrowserHarness() {
+  const originalRequestAnimationFrame = Object.getOwnPropertyDescriptor(globalThis, 'requestAnimationFrame');
+  const originalCancelAnimationFrame = Object.getOwnPropertyDescriptor(globalThis, 'cancelAnimationFrame');
+  const originalResizeObserver = Object.getOwnPropertyDescriptor(globalThis, 'ResizeObserver');
+  const originalFetch = Object.getOwnPropertyDescriptor(globalThis, 'fetch');
+  const frames = new Map<number, FrameRequestCallback>();
+  let nextFrame = 1;
+  let resizeCallback: ResizeObserverCallback | null = null;
+
+  class TestResizeObserver implements ResizeObserver {
+    constructor(callback: ResizeObserverCallback) {
+      resizeCallback = callback;
+    }
+
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+
+  Object.defineProperty(globalThis, 'requestAnimationFrame', {
+    configurable: true,
+    value: (callback: FrameRequestCallback) => {
+      const id = nextFrame++;
+      frames.set(id, callback);
+      return id;
+    },
+  });
+  Object.defineProperty(globalThis, 'cancelAnimationFrame', {
+    configurable: true,
+    value: (id: number) => frames.delete(id),
+  });
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    configurable: true,
+    value: TestResizeObserver,
+  });
+  Object.defineProperty(globalThis, 'fetch', {
+    configurable: true,
+    value: async () => ({
+      ok: false,
+      headers: { get: () => null },
+      json: async () => ({}),
+    }) as unknown as Response,
+  });
+
+  const runNextFrame = () => {
+    const next = frames.entries().next().value as [number, FrameRequestCallback] | undefined;
+    if (!next) return false;
+    frames.delete(next[0]);
+    next[1](0);
+    return true;
+  };
+
+  return {
+    pendingFrames: () => frames.size,
+    runNextFrame,
+    runAllFrames: () => {
+      let count = 0;
+      while (runNextFrame()) {
+        count++;
+        assert.ok(count < 100, 'animation-frame loop did not settle');
+      }
+    },
+    triggerResize: () => {
+      const callback = resizeCallback;
+      assert.ok(callback, 'ResizeObserver was not attached');
+      callback([], {} as ResizeObserver);
+    },
+    restore: () => {
+      if (originalRequestAnimationFrame) {
+        Object.defineProperty(globalThis, 'requestAnimationFrame', originalRequestAnimationFrame);
+      } else {
+        Reflect.deleteProperty(globalThis, 'requestAnimationFrame');
+      }
+      if (originalCancelAnimationFrame) {
+        Object.defineProperty(globalThis, 'cancelAnimationFrame', originalCancelAnimationFrame);
+      } else {
+        Reflect.deleteProperty(globalThis, 'cancelAnimationFrame');
+      }
+      if (originalResizeObserver) {
+        Object.defineProperty(globalThis, 'ResizeObserver', originalResizeObserver);
+      } else {
+        Reflect.deleteProperty(globalThis, 'ResizeObserver');
+      }
+      if (originalFetch) {
+        Object.defineProperty(globalThis, 'fetch', originalFetch);
+      } else {
+        Reflect.deleteProperty(globalThis, 'fetch');
+      }
+    },
+  };
+}
+
+async function mountScrollHarness({ withMessage = false } = {}) {
+  const browser = installScrollBrowserHarness();
+  const container = fakeScrollContainer();
+  const sessionStoreHarness = fakeSessionStore(withMessage);
+  const sessionStore = sessionStoreHarness.store;
+  let latest: SessionState | null = null;
+  let renderer: ReactTestRenderer | null = null;
+
+  function Probe() {
+    latest = useChatSessionState({
+      selectedProject: withMessage ? {
+        projectId: 'project-1',
+        displayName: 'Project 1',
+        fullPath: '/tmp/project-1',
+      } : null,
+      selectedSession: withMessage ? { id: 'session-1' } : null,
+      ws: null,
+      sendMessage: () => undefined,
+      resetStreamingState: () => undefined,
+      statusCheckSentAtRef: { current: new Map() },
+      lastSeqRef: { current: new Map() },
+      sessionStore,
+    });
+    return createElement('div', { ref: latest.scrollContainerRef });
+  }
+
+  try {
+    await act(async () => {
+      renderer = TestRenderer.create(createElement(Probe), {
+        createNodeMock: () => container,
+      });
+    });
+  } catch (error) {
+    browser.restore();
+    throw error;
+  }
+
+  return {
+    browser,
+    container,
+    latest: () => {
+      assert.ok(latest);
+      return latest;
+    },
+    pollExternalMessage: async (content: string) => {
+      sessionStoreHarness.queueExternalMessage(content);
+      await act(async () => {
+        await sessionStore.refreshFromServer('session-1');
+        renderer?.update(createElement(Probe));
+      });
+    },
+    dispose: async () => {
+      if (renderer) await act(async () => renderer?.unmount());
+      browser.restore();
+    },
+  };
+}
 
 test('same selected conversation preserves its expanded message window', () => {
   assert.equal(
@@ -48,4 +271,116 @@ test('cached image refresh cannot update a different selected conversation', () 
   assert.equal(shouldApplySessionRefresh('session-1', 'session-1'), true);
   assert.equal(shouldApplySessionRefresh('session-1', 'session-2'), false);
   assert.equal(shouldApplySessionRefresh('session-1', null), false);
+});
+
+test('scrollToBottom follows layout growth across the next two painted frames', async () => {
+  const harness = await mountScrollHarness();
+  try {
+    harness.container.scrollHeight = 900;
+    harness.container.scrollTop = 100;
+
+    act(() => harness.latest().scrollToBottom());
+    assert.equal(harness.container.scrollTop, 900, 'scrolls immediately');
+    assert.equal(harness.browser.pendingFrames(), 1);
+
+    harness.container.scrollHeight = 1_100;
+    act(() => { harness.browser.runNextFrame(); });
+    assert.equal(harness.container.scrollTop, 1_100, 'follows the first painted layout');
+    assert.equal(harness.browser.pendingFrames(), 1);
+
+    harness.container.scrollHeight = 1_300;
+    act(() => { harness.browser.runNextFrame(); });
+    assert.equal(harness.container.scrollTop, 1_300, 'follows the second painted layout');
+    assert.equal(harness.browser.pendingFrames(), 0);
+  } finally {
+    await harness.dispose();
+  }
+});
+
+test('manual scrolling cancels every pending follow-tail correction', async () => {
+  const harness = await mountScrollHarness({ withMessage: true });
+  try {
+    assert.equal(
+      harness.browser.pendingFrames(),
+      2,
+      'initial settling and short post-render correction are both active',
+    );
+
+    harness.container.scrollTop = 100;
+    await act(async () => { await harness.latest().handleScroll(); });
+
+    assert.equal(harness.latest().isUserScrolledUp, true);
+    assert.equal(harness.browser.pendingFrames(), 0, 'all forced-scroll frames are cancelled');
+    harness.container.scrollHeight = 1_400;
+    harness.browser.runAllFrames();
+    assert.equal(harness.container.scrollTop, 100, 'the user-selected position is preserved');
+  } finally {
+    await harness.dispose();
+  }
+});
+
+test('ResizeObserver follows delayed content growth only while viewing the tail', async () => {
+  const harness = await mountScrollHarness();
+  try {
+    harness.container.scrollHeight = 1_000;
+    harness.container.scrollTop = 400;
+    act(() => harness.browser.triggerResize());
+    assert.equal(harness.container.scrollTop, 1_000);
+    act(() => harness.browser.runAllFrames());
+
+    act(() => harness.latest().setIsUserScrolledUp(true));
+    harness.container.scrollHeight = 1_300;
+    harness.container.scrollTop = 250;
+    act(() => harness.browser.triggerResize());
+
+    assert.equal(harness.container.scrollTop, 250);
+    assert.equal(harness.browser.pendingFrames(), 0);
+  } finally {
+    await harness.dispose();
+  }
+});
+
+test('Given a followed live CLI transcript, when polling reconciles a new message, then it stays pinned to the tail', async () => {
+  const harness = await mountScrollHarness({ withMessage: true });
+  try {
+    act(() => harness.browser.runAllFrames());
+    harness.container.scrollHeight = 1_100;
+
+    await harness.pollExternalMessage('arrived through external live polling');
+
+    assert.equal(harness.container.scrollTop, 1_100);
+    assert.equal(harness.browser.pendingFrames(), 1, 'the polled render keeps correcting painted layout');
+
+    harness.container.scrollHeight = 1_300;
+    act(() => harness.browser.triggerResize());
+    assert.equal(harness.container.scrollTop, 1_300, 'follows content growth after the polled update');
+  } finally {
+    await harness.dispose();
+  }
+});
+
+test('Given a detached live CLI transcript, when polling updates and the user returns to the bottom, then follow-tail reattaches', async () => {
+  const harness = await mountScrollHarness({ withMessage: true });
+  try {
+    act(() => harness.browser.runAllFrames());
+    harness.container.scrollTop = 200;
+    await act(async () => { await harness.latest().handleScroll(); });
+
+    harness.container.scrollHeight = 1_100;
+    await harness.pollExternalMessage('new output while reviewing older text');
+
+    assert.equal(harness.container.scrollTop, 200);
+    assert.equal(harness.latest().hasNewMessagesBelow, true);
+
+    harness.container.scrollTop = 800;
+    await act(async () => { await harness.latest().handleScroll(); });
+    assert.equal(harness.latest().isUserScrolledUp, false);
+    assert.equal(harness.latest().hasNewMessagesBelow, false);
+
+    harness.container.scrollHeight = 1_300;
+    await harness.pollExternalMessage('new output after returning to the tail');
+    assert.equal(harness.container.scrollTop, 1_300);
+  } finally {
+    await harness.dispose();
+  }
 });

--- a/src/components/chat/hooks/useChatSessionState.test.ts
+++ b/src/components/chat/hooks/useChatSessionState.test.ts
@@ -32,12 +32,14 @@ function fakeSessionStore(withMessage = false) {
     content: 'keep this viewport under user control',
   }] : [];
   let pendingExternalContent: string | null = null;
+  const refreshRequests: string[] = [];
   const store = {
     setActiveSession() {},
     getMessages: () => messages,
     has: () => withMessage,
     fetchFromServer: async () => ({ hasMore: false, total: messages.length }),
-    refreshFromServer: async () => {
+    refreshFromServer: async (sessionId: string) => {
+      refreshRequests.push(sessionId);
       if (pendingExternalContent !== null) {
         messages = [...messages, {
           id: `message-${messages.length + 1}`,
@@ -59,6 +61,7 @@ function fakeSessionStore(withMessage = false) {
     queueExternalMessage: (content: string) => {
       pendingExternalContent = content;
     },
+    refreshRequests,
   };
 }
 
@@ -219,10 +222,10 @@ async function mountScrollHarness({ withMessage = false } = {}) {
     pollExternalMessage: async (content: string) => {
       sessionStoreHarness.queueExternalMessage(content);
       await act(async () => {
-        await sessionStore.refreshFromServer('session-1');
-        renderer?.update(createElement(Probe));
+        await latest?.refreshCurrentMessages();
       });
     },
+    refreshRequests: sessionStoreHarness.refreshRequests,
     dispose: async () => {
       if (renderer) await act(async () => renderer?.unmount());
       browser.restore();
@@ -348,6 +351,7 @@ test('Given a followed live CLI transcript, when polling reconciles a new messag
 
     await harness.pollExternalMessage('arrived through external live polling');
 
+    assert.deepEqual(harness.refreshRequests, ['session-1']);
     assert.equal(harness.container.scrollTop, 1_100);
     assert.equal(harness.browser.pendingFrames(), 1, 'the polled render keeps correcting painted layout');
 
@@ -369,6 +373,7 @@ test('Given a detached live CLI transcript, when polling updates and the user re
     harness.container.scrollHeight = 1_100;
     await harness.pollExternalMessage('new output while reviewing older text');
 
+    assert.deepEqual(harness.refreshRequests, ['session-1']);
     assert.equal(harness.container.scrollTop, 200);
     assert.equal(harness.latest().hasNewMessagesBelow, true);
 
@@ -379,6 +384,7 @@ test('Given a detached live CLI transcript, when polling updates and the user re
 
     harness.container.scrollHeight = 1_300;
     await harness.pollExternalMessage('new output after returning to the tail');
+    assert.deepEqual(harness.refreshRequests, ['session-1', 'session-1']);
     assert.equal(harness.container.scrollTop, 1_300);
   } finally {
     await harness.dispose();

--- a/src/components/chat/hooks/useChatSessionState.ts
+++ b/src/components/chat/hooks/useChatSessionState.ts
@@ -144,7 +144,7 @@ export function useChatSessionState({
   const [isLoadingMoreMessages, setIsLoadingMoreMessages] = useState(false);
   const [hasMoreMessages, setHasMoreMessages] = useState(false);
   const [totalMessages, setTotalMessages] = useState(0);
-  const [isUserScrolledUp, setIsUserScrolledUp] = useState(false);
+  const [isUserScrolledUp, setIsUserScrolledUpState] = useState(false);
   const [hasNewMessagesBelow, setHasNewMessagesBelow] = useState(false);
   const [tokenBudget, setTokenBudget] = useState<Record<string, unknown> | null>(null);
   const [visibleMessageCount, setVisibleMessageCount] = useState(INITIAL_VISIBLE_MESSAGES);
@@ -155,6 +155,9 @@ export function useChatSessionState({
   const [viewHiddenCount, setViewHiddenCount] = useState(0);
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const isUserScrolledUpRef = useRef(false);
+  const scrollToBottomFrameRef = useRef<number | null>(null);
+  const initialScrollFrameRef = useRef<number | null>(null);
   const wasNearTopRef = useRef(false);
   const [searchTarget, setSearchTarget] = useState<{ timestamp?: string; uuid?: string; snippet?: string } | null>(null);
   const searchScrollActiveRef = useRef(false);
@@ -173,6 +176,11 @@ export function useChatSessionState({
     enabled: showImagePreviews,
   });
   const transcriptRefreshInFlightRef = useRef(false);
+
+  const setIsUserScrolledUp = useCallback((next: boolean) => {
+    isUserScrolledUpRef.current = next;
+    setIsUserScrolledUpState(next);
+  }, []);
   /**
    * Tracks the last processed value from `useProjectsState.newSessionTrigger`.
    *
@@ -351,11 +359,69 @@ export function useChatSessionState({
 
   const rewindMessages = useCallback((count: number) => setViewHiddenCount(count), []);
 
-  const scrollToBottom = useCallback(() => {
-    const container = scrollContainerRef.current;
-    if (!container) return;
-    container.scrollTop = container.scrollHeight;
+  const cancelPendingScrollToBottom = useCallback(() => {
+    if (scrollToBottomFrameRef.current === null) return;
+    cancelAnimationFrame(scrollToBottomFrameRef.current);
+    scrollToBottomFrameRef.current = null;
   }, []);
+
+  const cancelPendingInitialScroll = useCallback(() => {
+    pendingInitialScrollRef.current = false;
+    if (initialScrollFrameRef.current === null) return;
+    cancelAnimationFrame(initialScrollFrameRef.current);
+    initialScrollFrameRef.current = null;
+  }, []);
+
+  const scrollToBottom = useCallback(() => {
+    const apply = () => {
+      const container = scrollContainerRef.current;
+      if (!container) return;
+      container.scrollTop = container.scrollHeight;
+    };
+
+    apply();
+
+    // A send updates the message list, activity indicator, and composer in the
+    // same React turn. The old 100ms timer could run before those layout
+    // changes settled, leaving the newly sent bubble below the viewport.
+    // Re-apply on the next two painted layouts so callers do not have to guess
+    // how long rendering will take.
+    if (typeof requestAnimationFrame !== 'function') return;
+    cancelPendingScrollToBottom();
+    scrollToBottomFrameRef.current = requestAnimationFrame(() => {
+      apply();
+      scrollToBottomFrameRef.current = requestAnimationFrame(() => {
+        apply();
+        scrollToBottomFrameRef.current = null;
+      });
+    });
+  }, [cancelPendingScrollToBottom]);
+
+  useEffect(() => cancelPendingScrollToBottom, [cancelPendingScrollToBottom]);
+
+  // Markdown highlighting, images, tool results, and streaming blocks can
+  // change height without changing the message count. Follow those delayed
+  // reflows only while the user is already following the tail; manual review
+  // higher in the transcript must keep its position.
+  useEffect(() => {
+    const container = scrollContainerRef.current;
+    const content = container?.firstElementChild;
+    if (!container || !content || typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver(() => {
+      if (
+        isUserScrolledUpRef.current
+        || isLoadingMoreRef.current
+        || pendingScrollRestoreRef.current
+        || searchScrollActiveRef.current
+      ) {
+        return;
+      }
+      scrollToBottom();
+    });
+    observer.observe(content);
+    return () => observer.disconnect();
+  }, [activeSessionId, scrollToBottom]);
 
   const scrollToBottomAndReset = useCallback(() => {
     scrollToBottom();
@@ -476,7 +542,14 @@ export function useChatSessionState({
 
     const nearBottom = isNearBottom();
     setIsUserScrolledUp(!nearBottom);
-    if (nearBottom) setHasNewMessagesBelow(false);
+    if (nearBottom) {
+      setHasNewMessagesBelow(false);
+    } else {
+      // A real user scroll wins over both the short post-render correction
+      // loop and the longer initial lazy-content settling loop.
+      cancelPendingScrollToBottom();
+      cancelPendingInitialScroll();
+    }
 
     const scrolledNearTop = container.scrollTop < 100;
 
@@ -505,7 +578,14 @@ export function useChatSessionState({
       const didLoad = await loadOlderMessages(container);
       if (didLoad) topLoadLockRef.current = true;
     }
-  }, [hasMoreMessages, isNearBottom, loadOlderMessages]);
+  }, [
+    cancelPendingInitialScroll,
+    cancelPendingScrollToBottom,
+    hasMoreMessages,
+    isNearBottom,
+    loadOlderMessages,
+    setIsUserScrolledUp,
+  ]);
 
   useLayoutEffect(() => {
     restorePendingScroll();
@@ -513,6 +593,7 @@ export function useChatSessionState({
 
   // Reset scroll/pagination state on session change
   useEffect(() => {
+    cancelPendingInitialScroll();
     if (!searchScrollActiveRef.current) {
       pendingInitialScrollRef.current = true;
       setVisibleMessageCount(INITIAL_VISIBLE_MESSAGES);
@@ -522,7 +603,12 @@ export function useChatSessionState({
     isLoadingMoreRef.current = false;
     wasNearTopRef.current = false;
     setIsUserScrolledUp(false);
-  }, [selectedProject?.projectId, selectedSession?.id]);
+  }, [
+    cancelPendingInitialScroll,
+    selectedProject?.projectId,
+    selectedSession?.id,
+    setIsUserScrolledUp,
+  ]);
 
   // Initial scroll to bottom — robust to lazy content reflow.
   // The previous implementation fired one scrollToBottom() at +200ms and
@@ -538,15 +624,18 @@ export function useChatSessionState({
     if (!pendingInitialScrollRef.current || !scrollContainerRef.current || isLoadingSessionMessages) return;
     if (chatMessages.length === 0) { pendingInitialScrollRef.current = false; return; }
     if (searchScrollActiveRef.current) { pendingInitialScrollRef.current = false; return; }
+    if (typeof requestAnimationFrame !== 'function') return;
 
     const container = scrollContainerRef.current;
     let frame = 0;
     let lastHeight = 0;
     let stableCount = 0;
-    let rafId = 0;
 
     const tick = () => {
-      if (!pendingInitialScrollRef.current || !scrollContainerRef.current) return;
+      if (!pendingInitialScrollRef.current || !scrollContainerRef.current) {
+        initialScrollFrameRef.current = null;
+        return;
+      }
       container.scrollTop = container.scrollHeight;
       if (container.scrollHeight === lastHeight) {
         stableCount++;
@@ -556,14 +645,18 @@ export function useChatSessionState({
       }
       frame++;
       if (stableCount < 3 && frame < 60) {
-        rafId = requestAnimationFrame(tick);
+        initialScrollFrameRef.current = requestAnimationFrame(tick);
       } else {
         pendingInitialScrollRef.current = false;
+        initialScrollFrameRef.current = null;
       }
     };
-    rafId = requestAnimationFrame(tick);
+    initialScrollFrameRef.current = requestAnimationFrame(tick);
     return () => {
-      if (rafId) cancelAnimationFrame(rafId);
+      if (initialScrollFrameRef.current !== null) {
+        cancelAnimationFrame(initialScrollFrameRef.current);
+        initialScrollFrameRef.current = null;
+      }
     };
   }, [chatMessages.length, isLoadingSessionMessages, scrollToBottom]);
 
@@ -719,7 +812,7 @@ export function useChatSessionState({
           });
 
           if (isNearBottom()) {
-            setTimeout(() => scrollToBottom(), 200);
+            scrollToBottom();
           }
         }
       } catch (error) {
@@ -873,7 +966,7 @@ export function useChatSessionState({
     if (searchScrollActiveRef.current) return;
 
     if (!isUserScrolledUp) {
-      setTimeout(() => scrollToBottom(), 50);
+      scrollToBottom();
       return;
     }
 


### PR DESCRIPTION
## Summary

Three defects reported from real device use, fixed on top of v1.8.17 (`97be2ff`):

1. **Autoscroll stops while a session is actively working.** The follow effect scrolled
   once per content-signature change while markdown/image layout kept growing
   asynchronously, and any native scroll event observed mid-layout flipped
   `isUserScrolledUp`, permanently detaching follow until the user manually returned
   to the bottom. Adopts the follow-tail design from Hako's unmerged `2084ad0`
   (ref-based follow state, rAF double-frame guard around programmatic scrolls,
   ResizeObserver on the content) and extends coverage to the external live-CLI
   polling path (`useChatLiveRefresh` -> `refreshers` reconcile).
2. **A new session with a not-yet-existing folder path was rejected.** Both local spawn
   routes and the builtin GJC fallback required an existing directory. They now create
   the missing cwd recursively under HOME after the existing containment validation
   (nearest existing ancestor proven inside HOME first), re-resolve realpath, and
   re-verify containment before tmux receives it. Traversal, symlink escape, NUL,
   permission failures, and non-directory collisions still return `INVALID_CWD` 400.
   Fleet peer spawn verification intentionally stays strict (no implicit cross-host
   directory creation). A cwd match still authorizes nothing.
3. **Resume guard failed open when discovery was unavailable.** `findLiveTmuxSpawnBlock`
   returned null on discovery failure and `handleChatSend` proceeded with a headless
   resume — risking a duplicate writer against a live TUI, contrary to the AGENTS.md
   fail-closed invariant. Sends for sessions with a `provider_session_id` are now
   rejected with a `DISCOVERY_UNAVAILABLE` protocol error when fresh discovery cannot
   run; new-session sends (no `provider_session_id`) proceed unchanged.

## Commits

- `fix(chat): keep the transcript pinned to the tail while following` (adopted from 2084ad0 by Hako)
- `fix(chat): refuse resume sends when discovery cannot verify the live roster`
- `feat(sessions): create a missing session cwd under HOME at spawn`

## Test plan

- RED -> GREEN captured per fix under `.omo/evidence/ulw-trifix/<lane>/{red,green,notes}.md`
- Focused suites (lead-run, corrected tsconfig env):
  - `TSX_TSCONFIG_PATH=server/tsconfig.json node --import tsx --test` over
    `chat-websocket-resume-guard.test.ts`, `builtin-relay.service.test.ts`,
    `provider-routes-contract-cases-3.ts`, `live-spawn-guard.test.ts`: 21/21 pass
  - `node --import tsx --test src/components/chat/hooks/useChatSessionState.test.ts`: 9/9 pass
- `npm run typecheck` exit 0; eslint clean on all changed files; `git diff --check` clean.

## Safety review notes

- Directory creation happens only after ancestor containment validation and is
  followed by realpath re-resolution; it grants no authorization of any kind.
- The resume-guard change narrows a fail-open path only; blocked/clear outcomes are
  unchanged, and binding-grade enforcement is untouched.