### PR TITLE
chore(deps): bump transitive fast-uri to 3.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8004,9 +8004,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
npm audit --audit-level=high fails on main since the fast-uri GHSA (range 3.0.0-3.1.5) was published 2026-09-02, red-blocking the Verify gate for every PR. This bumps the transitive fast-uri resolution (via ajv) from 3.1.5 to 3.1.7 inside the existing ^3 range — lockfile-only, no direct dependency added, no product version change. Local npm audit --audit-level=high now exits 0.