### PR TITLE
fix(codex): 구조화된 도구 출력을 정상 렌더링

### DIFF
--- a/server/modules/providers/list/codex/codex-sessions.provider.ts
+++ b/server/modules/providers/list/codex/codex-sessions.provider.ts
@@ -130,6 +130,87 @@ function extractCodexTextContent(content: unknown): string {
     .join('\n');
 }
 
+type CodexToolOutput = {
+  content: string;
+  isError: boolean;
+};
+
+function parseStructuredCodexToolBlock(text: string): CodexToolOutput {
+  const trimmed = text.trim();
+  if (trimmed === '{}' || trimmed === '[]') {
+    return { content: '', isError: false };
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as AnyRecord;
+    const isExecEnvelope = parsed
+      && typeof parsed === 'object'
+      && !Array.isArray(parsed)
+      && typeof parsed.output === 'string'
+      && (
+        'exit_code' in parsed
+        || 'session_id' in parsed
+        || 'chunk_id' in parsed
+        || 'wall_time_seconds' in parsed
+      );
+    if (isExecEnvelope) {
+      return {
+        content: parsed.output,
+        isError: typeof parsed.exit_code === 'number' && parsed.exit_code !== 0,
+      };
+    }
+  } catch {
+    // Most text blocks are ordinary output rather than serialized JSON.
+  }
+
+  return { content: text, isError: false };
+}
+
+function extractCodexToolOutput(output: unknown): CodexToolOutput {
+  if (typeof output === 'string') {
+    return { content: output, isError: false };
+  }
+  if (!Array.isArray(output)) {
+    if (!output || typeof output !== 'object') {
+      return { content: '', isError: false };
+    }
+    return { content: JSON.stringify(output), isError: false };
+  }
+
+  const blocks: string[] = [];
+  let isError = false;
+  for (const item of output) {
+    let text = '';
+    if (typeof item === 'string') {
+      text = item;
+    } else if (item && typeof item === 'object') {
+      const record = item as AnyRecord;
+      if (
+        ['input_text', 'output_text', 'text'].includes(String(record.type))
+        && typeof record.text === 'string'
+      ) {
+        text = record.text;
+      }
+    }
+    if (!text) continue;
+
+    const normalized = parseStructuredCodexToolBlock(text);
+    isError ||= normalized.isError;
+    if (normalized.content) {
+      blocks.push(normalized.content);
+    }
+  }
+
+  let content = blocks.reduce((joined, block) => {
+    if (!joined) return block;
+    return joined.endsWith('\n') ? `${joined}${block}` : `${joined}\n${block}`;
+  }, '');
+  if (blocks.length === 1) {
+    content = content.replace(/\nOutput:\s*$/u, '').trimEnd();
+  }
+  return { content, isError };
+}
+
 type CodexHistoryAccumulator = {
   messages: AnyRecord[];
   tokenUsage: AnyRecord | null;
@@ -290,11 +371,13 @@ function parseCodexHistoryLine(line: string, accumulator: CodexHistoryAccumulato
     }
 
     if (entry.type === 'response_item' && entry.payload?.type === 'function_call_output') {
+      const result = extractCodexToolOutput(entry.payload.output);
       accumulator.messages.push({
         type: 'tool_result',
         timestamp: entry.timestamp,
         toolCallId: entry.payload.call_id,
-        output: entry.payload.output,
+        output: result.content,
+        isError: result.isError,
       });
     }
 
@@ -340,11 +423,13 @@ function parseCodexHistoryLine(line: string, accumulator: CodexHistoryAccumulato
     }
 
     if (entry.type === 'response_item' && entry.payload?.type === 'custom_tool_call_output') {
+      const result = extractCodexToolOutput(entry.payload.output);
       accumulator.messages.push({
         type: 'tool_result',
         timestamp: entry.timestamp,
         toolCallId: entry.payload.call_id,
-        output: entry.payload.output || '',
+        output: result.content,
+        isError: result.isError,
       });
     }
   } catch {

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -336,6 +336,134 @@ test('Codex history incrementally appends complete JSONL records', { concurrency
   }
 });
 
+test('Codex history renders structured custom tool output without leaking transport blocks', { concurrency: false }, async () => {
+  const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-history-custom-tool-output-'));
+  const workspacePath = path.join(tempRoot, 'workspace');
+  await mkdir(workspacePath, { recursive: true });
+
+  try {
+    const sessionId = 'codex-structured-custom-tool-output';
+    const transcriptPath = await writeCodexTranscript(tempRoot, sessionId, workspacePath);
+    const header = 'Script completed\nWall time 0.0 seconds\nOutput:\n';
+    await appendFile(transcriptPath, [
+      JSON.stringify({
+        type: 'response_item',
+        timestamp: '2026-09-03T00:00:00.000Z',
+        payload: {
+          type: 'custom_tool_call',
+          name: 'apply_patch',
+          input: '*** Begin Patch\n*** Update File: example.ts\n*** End Patch',
+          call_id: 'empty-result',
+        },
+      }),
+      JSON.stringify({
+        type: 'response_item',
+        timestamp: '2026-09-03T00:00:01.000Z',
+        payload: {
+          type: 'custom_tool_call_output',
+          call_id: 'empty-result',
+          output: [
+            { type: 'input_text', text: header },
+            { type: 'input_text', text: '{}' },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'response_item',
+        timestamp: '2026-09-03T00:00:02.000Z',
+        payload: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          input: '{}',
+          call_id: 'successful-result',
+        },
+      }),
+      JSON.stringify({
+        type: 'response_item',
+        timestamp: '2026-09-03T00:00:03.000Z',
+        payload: {
+          type: 'custom_tool_call_output',
+          call_id: 'successful-result',
+          output: [
+            { type: 'input_text', text: header },
+            {
+              type: 'input_text',
+              text: JSON.stringify({
+                chunk_id: 'chunk-success',
+                wall_time_seconds: 0.1,
+                exit_code: 0,
+                output: 'rendered output\n',
+              }),
+            },
+          ],
+        },
+      }),
+      JSON.stringify({
+        type: 'response_item',
+        timestamp: '2026-09-03T00:00:04.000Z',
+        payload: {
+          type: 'custom_tool_call',
+          name: 'exec',
+          input: '{}',
+          call_id: 'failed-result',
+        },
+      }),
+      JSON.stringify({
+        type: 'response_item',
+        timestamp: '2026-09-03T00:00:05.000Z',
+        payload: {
+          type: 'custom_tool_call_output',
+          call_id: 'failed-result',
+          output: [
+            { type: 'input_text', text: header },
+            {
+              type: 'input_text',
+              text: JSON.stringify({
+                wall_time_seconds: 0.1,
+                exit_code: 2,
+                output: 'command failed\n',
+              }),
+            },
+          ],
+        },
+      }),
+      '',
+    ].join('\n'), 'utf8');
+
+    await withIsolatedDatabase(async () => {
+      sessionsDb.createSession(
+        sessionId,
+        'codex',
+        workspacePath,
+        undefined,
+        undefined,
+        undefined,
+        transcriptPath,
+      );
+
+      const history = await new CodexSessionsProvider().fetchHistory(sessionId);
+      const toolUses = history.messages.filter((message) => message.kind === 'tool_use');
+      assert.equal(toolUses.length, 3);
+      assert.deepEqual(toolUses[0].toolResult, {
+        content: 'Script completed\nWall time 0.0 seconds',
+        isError: false,
+      });
+      assert.deepEqual(toolUses[1].toolResult, {
+        content: `${header}rendered output\n`,
+        isError: false,
+      });
+      assert.deepEqual(toolUses[2].toolResult, {
+        content: `${header}command failed\n`,
+        isError: true,
+      });
+      assert.equal(JSON.stringify(toolUses).includes('input_text'), false);
+      assert.equal(history.messages.some((message) => message.kind === 'tool_result'), false);
+    });
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+});
+
 test('Codex history reads response-item-only user prompts without exposing injected context', { concurrency: false }, async () => {
   const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'codex-history-response-user-'));
   const workspacePath = path.join(tempRoot, 'workspace');


### PR DESCRIPTION
## 문제

최근 Codex transcript의 `custom_tool_call_output.output`이 문자열 대신 content block 배열로 기록될 수 있습니다.

```json
[{"type":"input_text","text":"Script completed..."},{"type":"input_text","text":"{}"}]
```

ChatMux는 이 값을 그대로 `tool_result.content`에 넣고 있어, 도구 카드에 실제 결과 대신 내부 `input_text` 배열 JSON이 노출됩니다. 실행은 성공했지만 사용자에게 오류처럼 보이며, 중첩 실행 결과도 다시 JSON 문자열로 표시됩니다.

## 원인

사용자·어시스턴트 메시지에는 이미 content block 텍스트 추출이 적용되어 있지만, `function_call_output`과 `custom_tool_call_output`은 `payload.output`을 정규화하지 않고 전달하고 있었습니다.

## 수정

- 기존 문자열 출력은 변경 없이 보존합니다.
- `input_text`, `output_text`, `text` content block을 순서대로 합칩니다.
- 통합 실행 결과 envelope는 실제 `output`만 꺼내 표시합니다.
- `exit_code`가 0이 아니면 도구 결과를 오류 상태로 전달합니다.
- 빈 구조 결과인 `{}`와 `[]`는 표시하지 않습니다.
- 빈 결과 때문에 마지막에 남는 `Output:` 자리표시자도 제거합니다.
- 알 수 없는 JSON 및 일반 텍스트는 원문을 보존해 향후 형식 변경에도 fail-soft로 동작합니다.
- 동일 정규화를 `function_call_output`과 `custom_tool_call_output` 양쪽에 적용합니다.

## 회귀 테스트

실제 관찰한 transcript 형태를 바탕으로 다음을 검증합니다.

1. `Script completed` + `{}`: 내부 배열과 빈 객체가 노출되지 않음
2. 성공한 실행 envelope: 실제 stdout만 도구 카드에 표시됨
3. 실패한 실행 envelope: 실제 출력 보존 및 `isError: true`
4. tool result는 기존처럼 대응하는 tool-use 카드 안에만 들어가고 독립 메시지로 중복되지 않음

## 검증

- Codex provider 집중 테스트: 16/16 통과
- `npm run typecheck` 통과
- 수정 파일 ESLint 통과
- `npm run verify` 전체 통과

실제 tmux 세션이나 Codex 실행 제어는 변경하지 않고 transcript 표시만 수정합니다.