### PR TITLE
chore(release): v1.8.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatmux",
-  "version": "1.8.17",
+  "version": "1.8.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatmux",
-      "version": "1.8.17",
+      "version": "1.8.18",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chatmux",
   "private": true,
-  "version": "1.8.17",
+  "version": "1.8.18",
   "productName": "ChatMux",
   "description": "A self-hosted web interface for coding-agent sessions running in tmux",
   "type": "module",

--- a/packaging/release/update-compatibility.json
+++ b/packaging/release/update-compatibility.json
@@ -201,6 +201,14 @@
           "1.8.16"
         ]
       }
+    },
+    "1.8.18": {
+      "database": {
+        "schemaGeneration": 20,
+        "rollbackCompatibleFrom": [
+          "1.8.17"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- bump ChatMux from 1.8.17 to 1.8.18
- declare database schema generation 20 for migration 20
- prove rollback compatibility against the immediate predecessor v1.8.17

## Verification
- `node scripts/release/check-release-metadata.mjs`
- release metadata and rollback compatibility tests
- `npm run check:identity`
- `npm run verify`
- Node 22.22.2 server bundle reached the platform guard locally; canonical glibc 2.35 archive verification is delegated to the required Ubuntu 22.04 CI job
- `git diff --check`