### PR TITLE
fix(chat): prevent iOS stalls on large tool outputs

### DIFF
--- a/server/modules/providers/services/sessions.service.ts
+++ b/server/modules/providers/services/sessions.service.ts
@@ -19,7 +19,9 @@ type CreateAppSessionResult = {
   projectPath: string;
 };
 
-const HISTORY_TOOL_OUTPUT_PREVIEW_BYTES = 64 * 1024;
+const HISTORY_TOOL_OUTPUT_PREVIEW_BYTES = 16 * 1024;
+const HISTORY_TOOL_OUTPUT_MAX_LINE_BYTES = 4 * 1024;
+const HISTORY_TOOL_OUTPUT_MARKER_RESERVE_BYTES = 128;
 
 function isUtf8ContinuationByte(value: number | undefined): boolean {
   return value !== undefined && (value & 0xc0) === 0x80;
@@ -50,6 +52,45 @@ function stringifyToolOutput(content: unknown): string {
   }
 }
 
+function buildMiddleTruncatedPreview(
+  serialized: string,
+  maxBytes: number,
+  label: string,
+): string {
+  const source = Buffer.from(serialized);
+  if (source.length <= maxBytes) return serialized;
+
+  const contentBudget = Math.max(0, maxBytes - HISTORY_TOOL_OUTPUT_MARKER_RESERVE_BYTES);
+  const requestedHeadBytes = Math.floor(contentBudget * 0.75);
+  const requestedTailBytes = contentBudget - requestedHeadBytes;
+  const headEnd = utf8SafeHeadEnd(source, requestedHeadBytes);
+  const tailStart = utf8SafeTailStart(source, source.length - requestedTailBytes);
+  const omittedBytes = Math.max(0, tailStart - headEnd);
+  const head = source.subarray(0, headEnd).toString('utf8');
+  const tail = source.subarray(tailStart).toString('utf8');
+  return `${head}\n… [${omittedBytes} ${label}] …\n${tail}`;
+}
+
+function boundToolOutputLines(serialized: string): {
+  content: string;
+  truncated: boolean;
+} {
+  let truncated = false;
+  const content = serialized
+    .split('\n')
+    .map((line) => {
+      if (Buffer.byteLength(line) <= HISTORY_TOOL_OUTPUT_MAX_LINE_BYTES) return line;
+      truncated = true;
+      return buildMiddleTruncatedPreview(
+        line,
+        HISTORY_TOOL_OUTPUT_MAX_LINE_BYTES,
+        'bytes omitted from line',
+      );
+    })
+    .join('\n');
+  return { content, truncated };
+}
+
 function buildToolOutputPreview(content: unknown): {
   content: unknown;
   truncated: boolean;
@@ -57,19 +98,21 @@ function buildToolOutputPreview(content: unknown): {
 } {
   const serialized = stringifyToolOutput(content);
   const bytes = Buffer.byteLength(serialized);
-  if (bytes <= HISTORY_TOOL_OUTPUT_PREVIEW_BYTES) {
+  const aggregateTruncated = bytes > HISTORY_TOOL_OUTPUT_PREVIEW_BYTES;
+  const aggregateBounded = aggregateTruncated
+    ? buildMiddleTruncatedPreview(
+        serialized,
+        HISTORY_TOOL_OUTPUT_PREVIEW_BYTES,
+        'bytes omitted from output',
+      )
+    : serialized;
+  const lineBounded = boundToolOutputLines(aggregateBounded);
+  if (!aggregateTruncated && !lineBounded.truncated) {
     return { content, truncated: false, bytes };
   }
 
-  const source = Buffer.from(serialized);
-  const headBytes = Math.floor(HISTORY_TOOL_OUTPUT_PREVIEW_BYTES * 0.75);
-  const tailBytes = HISTORY_TOOL_OUTPUT_PREVIEW_BYTES - headBytes;
-  const headEnd = utf8SafeHeadEnd(source, headBytes);
-  const tailStart = utf8SafeTailStart(source, source.length - tailBytes);
-  const head = source.subarray(0, headEnd).toString('utf8');
-  const tail = source.subarray(tailStart).toString('utf8');
   return {
-    content: `${head}\n\n… [${tailStart - headEnd} bytes omitted] …\n\n${tail}`,
+    content: lineBounded.content,
     truncated: true,
     bytes,
   };

--- a/server/modules/providers/tests/codex-sessions.test.ts
+++ b/server/modules/providers/tests/codex-sessions.test.ts
@@ -12,7 +12,11 @@ import {
   isCodexHistoryCacheable,
   normalizeCodexToolName,
 } from '@/modules/providers/list/codex/codex-sessions.provider.js';
-import { sessionsService } from '@/modules/providers/services/sessions.service.js';
+import {
+  prepareHistoryMessagesForTransport,
+  sessionsService,
+} from '@/modules/providers/services/sessions.service.js';
+import type { NormalizedMessage } from '@/shared/types.js';
 
 test('Codex request_user_input uses the shared question renderer', () => {
   assert.equal(normalizeCodexToolName('request_user_input'), 'AskUserQuestion');
@@ -24,6 +28,36 @@ test('Codex history cache budget includes normalized messages, partial tails, an
   assert.equal(isCodexHistoryCacheable(9, 0, 0, 8), false);
   assert.equal(isCodexHistoryCacheable(0, 9, 0, 8), false);
   assert.equal(isCodexHistoryCacheable(0, 0, 9, 8), false);
+});
+
+test('tool history previews bound aggregate bytes and individual lines', () => {
+  const outputs = [
+    `start-${'x'.repeat(8 * 1024)}-end`,
+    Array.from({ length: 40 }, () => 'y'.repeat(1024)).join('\n'),
+  ];
+
+  for (const [index, output] of outputs.entries()) {
+    const message: NormalizedMessage = {
+      id: `tool-${index}`,
+      sessionId: 'session-preview-bounds',
+      timestamp: '2026-08-10T00:00:00.000Z',
+      provider: 'codex',
+      kind: 'tool_use',
+      toolName: 'exec',
+      toolId: `tool-${index}`,
+      toolResult: { content: output, isError: false },
+    };
+    const [prepared] = prepareHistoryMessagesForTransport([message]);
+    const preview = String(prepared.toolResult?.content ?? '');
+
+    assert.equal(prepared.toolResultTruncated, true);
+    assert.equal(prepared.toolResultBytes, Buffer.byteLength(output));
+    assert.ok(Buffer.byteLength(preview) <= 16 * 1024);
+    assert.ok(Math.max(...preview.split('\n').map((line) => Buffer.byteLength(line))) <= 4 * 1024);
+    assert.equal(preview.includes('\uFFFD'), false);
+    assert.equal(preview.startsWith(output.slice(0, 32)), true);
+    assert.equal(preview.endsWith(output.slice(-32)), true);
+  }
 });
 
 test('Codex SDK stays pinned to the CLI version required by synchronized models', () => {
@@ -488,8 +522,7 @@ test('Codex history sends bounded tool previews and loads the full result on dem
   try {
     const sessionId = 'codex-tool-preview-history';
     const transcriptPath = await writeCodexTranscript(tempRoot, sessionId, workspacePath);
-    // The 7-byte Korean prefix deliberately makes the fixed 48 KiB head cut
-    // land inside a three-byte UTF-8 character.
+    // The Korean prefix exercises UTF-8-safe line and aggregate preview cuts.
     const output = `시작-${'한'.repeat(40 * 1024)}-끝`;
     await appendFile(transcriptPath, [
       JSON.stringify({
@@ -545,6 +578,12 @@ test('Codex history sends bounded tool previews and loads the full result on dem
       assert.equal(toolUse?.toolResultTruncated, true);
       assert.equal(toolUse?.toolResultBytes, Buffer.byteLength(output));
       assert.ok(String(toolUse?.toolResult?.content).length < output.length);
+      assert.ok(Buffer.byteLength(String(toolUse?.toolResult?.content)) <= 16 * 1024);
+      assert.ok(Math.max(
+        ...String(toolUse?.toolResult?.content)
+          .split('\n')
+          .map((line) => Buffer.byteLength(line)),
+      ) <= 4 * 1024);
       assert.equal(String(toolUse?.toolResult?.content).includes('\uFFFD'), false);
       assert.equal(String(toolUse?.toolResult?.content).startsWith('시작-'), true);
       assert.equal(String(toolUse?.toolResult?.content).endsWith('-끝'), true);

--- a/src/components/chat/tools/ToolRenderer.tsx
+++ b/src/components/chat/tools/ToolRenderer.tsx
@@ -325,6 +325,7 @@ export const ToolRenderer: React.FC<ToolRendererProps> = memo(({
         showRawParameters={mode === 'input' && showRawParameters}
         rawContent={rawToolInput}
         toolCategory={getToolCategory(toolName)}
+        unmountOnClose={mode === 'result'}
       >
         {contentComponent}
       </CollapsibleDisplay>

--- a/src/components/chat/tools/components/CollapsibleDisplay.tsx
+++ b/src/components/chat/tools/components/CollapsibleDisplay.tsx
@@ -17,6 +17,7 @@ interface CollapsibleDisplayProps {
   rawContent?: string;
   className?: string;
   toolCategory?: string;
+  unmountOnClose?: boolean;
 }
 
 const borderColorMap: Record<string, string> = {
@@ -43,6 +44,7 @@ export const CollapsibleDisplay: React.FC<CollapsibleDisplayProps> = ({
   rawContent,
   className = '',
   toolCategory,
+  unmountOnClose = false,
 }) => {
   const borderColor = borderColorMap[toolCategory || 'default'] || borderColorMap.default;
 
@@ -55,6 +57,7 @@ export const CollapsibleDisplay: React.FC<CollapsibleDisplayProps> = ({
         action={action}
         badge={badge}
         onTitleClick={onTitleClick}
+        unmountOnClose={unmountOnClose}
       >
         {children}
 
@@ -71,7 +74,7 @@ export const CollapsibleDisplay: React.FC<CollapsibleDisplayProps> = ({
               </svg>
               raw params
             </CollapsibleTrigger>
-            <CollapsibleContent>
+            <CollapsibleContent unmountOnClose>
               <pre className="mt-1 overflow-hidden whitespace-pre-wrap break-words rounded border border-border/40 bg-muted p-2 font-mono text-[11px] text-muted-foreground">
                 {rawContent}
               </pre>

--- a/src/components/chat/tools/components/CollapsibleSection.tsx
+++ b/src/components/chat/tools/components/CollapsibleSection.tsx
@@ -12,6 +12,7 @@ interface CollapsibleSectionProps {
   onTitleClick?: () => void;
   children: React.ReactNode;
   className?: string;
+  unmountOnClose?: boolean;
 }
 
 /**
@@ -26,6 +27,7 @@ export const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
   onTitleClick,
   children,
   className = '',
+  unmountOnClose = false,
 }) => {
   return (
     <Collapsible defaultOpen={open} className={cn('group/section', className)}>
@@ -79,7 +81,7 @@ export const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({
         </CollapsibleTrigger>
       )}
 
-      <CollapsibleContent>
+      <CollapsibleContent unmountOnClose={unmountOnClose}>
         <div className="mt-1.5 pl-[18px]">
           {children}
         </div>

--- a/src/components/chat/tools/components/ContentRenderers/TextContent.tsx
+++ b/src/components/chat/tools/components/ContentRenderers/TextContent.tsx
@@ -26,7 +26,7 @@ export const TextContent: React.FC<TextContentProps> = ({
     }
 
     return (
-      <pre className={`mt-1 overflow-x-auto rounded bg-gray-900 p-2.5 font-mono text-xs text-gray-100 dark:bg-gray-950 ${className}`}>
+      <pre className={`mt-1 min-w-0 max-w-full overflow-x-auto whitespace-pre-wrap break-all rounded bg-gray-900 p-2.5 font-mono text-xs text-gray-100 [overflow-wrap:anywhere] dark:bg-gray-950 ${className}`}>
         {formattedJson}
       </pre>
     );
@@ -34,7 +34,7 @@ export const TextContent: React.FC<TextContentProps> = ({
 
   if (format === 'code') {
     return (
-      <pre className={`mt-1 overflow-hidden whitespace-pre-wrap break-words rounded border border-gray-200/50 bg-gray-50 p-2 font-mono text-xs text-gray-700 dark:border-gray-700/50 dark:bg-gray-800/50 dark:text-gray-300 ${className}`}>
+      <pre className={`mt-1 min-w-0 max-w-full overflow-x-auto whitespace-pre-wrap break-all rounded border border-gray-200/50 bg-gray-50 p-2 font-mono text-xs text-gray-700 [overflow-wrap:anywhere] dark:border-gray-700/50 dark:bg-gray-800/50 dark:text-gray-300 ${className}`}>
         {content}
       </pre>
     );
@@ -42,7 +42,7 @@ export const TextContent: React.FC<TextContentProps> = ({
 
   // Plain text
   return (
-    <div className={`mt-1 whitespace-pre-wrap text-sm text-gray-700 dark:text-gray-300 ${className}`}>
+    <div className={`mt-1 min-w-0 max-w-full overflow-x-auto whitespace-pre-wrap break-all text-sm text-gray-700 [overflow-wrap:anywhere] dark:text-gray-300 ${className}`}>
       {content}
     </div>
   );

--- a/src/components/chat/view/subcomponents/MessageComponent.test.tsx
+++ b/src/components/chat/view/subcomponents/MessageComponent.test.tsx
@@ -20,7 +20,7 @@ const renderMessage = (
   suppressedAskToolId,
 }));
 
-test('standalone conversation errors keep details collapsed and omit the redundant provider header', () => {
+test('standalone conversation errors keep details collapsed and defer the full body', () => {
   const html = renderMessage({
     type: 'error',
     content: 'Request failed\nInternal stack line',
@@ -29,11 +29,11 @@ test('standalone conversation errors keep details collapsed and omit the redunda
 
   assert.match(html, /<details(?![^>]*\sopen(?:=|\s|>))[^>]*>/);
   assert.match(html, /<summary[^>]*>[\s\S]*Request failed[\s\S]*<\/summary>/);
-  assert.match(html, /Internal stack line/);
+  assert.doesNotMatch(html, /Internal stack line/);
   assert.equal((html.match(/>Error</g) || []).length, 1);
 });
 
-test('non-Bash tool failures expose full output only through a collapsed disclosure', () => {
+test('non-Bash tool failures defer full output behind a collapsed disclosure', () => {
   const html = renderMessage({
     type: 'assistant',
     content: '',
@@ -50,7 +50,26 @@ test('non-Bash tool failures expose full output only through a collapsed disclos
 
   assert.match(html, /<details[^>]*id="tool-result-tool-1"(?![^>]*\sopen(?:=|\s|>))[^>]*>/);
   assert.match(html, /Read Error/);
-  assert.match(html, /Internal lookup detail/);
+  assert.doesNotMatch(html, /Internal lookup detail/);
+});
+
+test('non-Bash successful tool results do not mount closed result content', () => {
+  const html = renderMessage({
+    type: 'assistant',
+    content: '',
+    timestamp: '2026-07-29T12:00:00.000Z',
+    isToolUse: true,
+    toolName: 'exec',
+    toolInput: JSON.stringify({ command: 'diagnostic' }),
+    toolId: 'tool-success',
+    toolResult: {
+      content: 'closed-result-sentinel',
+      isError: false,
+    },
+  });
+
+  assert.match(html, /exec/);
+  assert.doesNotMatch(html, /closed-result-sentinel/);
 });
 
 test('screen-driven multi-question asks hide the inert transcript duplicate', () => {

--- a/src/components/chat/view/subcomponents/MessageComponent.tsx
+++ b/src/components/chat/view/subcomponents/MessageComponent.tsx
@@ -70,12 +70,18 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, s
   const [fullToolResult, setFullToolResult] = useState<ToolResult | null>(null);
   const [isLoadingFullToolResult, setIsLoadingFullToolResult] = useState(false);
   const [fullToolResultError, setFullToolResultError] = useState(false);
+  const [isToolErrorOpen, setIsToolErrorOpen] = useState(false);
+  const [isConversationErrorOpen, setIsConversationErrorOpen] = useState(false);
   useEffect(() => {
     setFullToolResult(null);
     setIsLoadingFullToolResult(false);
     setFullToolResultError(false);
+    setIsToolErrorOpen(false);
   }, [message.sessionId, message.toolId]);
-  const effectiveToolResult = fullToolResult ?? message.toolResult;
+  useEffect(() => {
+    setIsConversationErrorOpen(false);
+  }, [message.sessionId, message.timestamp, message.content]);
+  const effectiveToolResult = message.toolResult;
   const errorContent = String(message.content || '');
   const errorSummary = compactErrorSummary(errorContent, t('messageTypes.error'));
   const toolResultContent = String(effectiveToolResult?.content || '');
@@ -247,6 +253,7 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, s
                     <details
                       id={`tool-result-${message.toolId}`}
                       className="relative mt-2 scroll-mt-4 rounded border border-red-200/60 bg-red-50/50 p-3 dark:border-red-800/40 dark:bg-red-950/10"
+                      onToggle={(event) => setIsToolErrorOpen(event.currentTarget.open)}
                     >
                       <summary className="flex cursor-pointer items-center gap-1.5 text-xs font-medium text-red-700 dark:text-red-300">
                         <svg className="h-4 w-4 flex-shrink-0 text-red-500 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -255,11 +262,13 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, s
                         <span className="flex-shrink-0">{message.toolName || 'UnknownTool'} {t('messageTypes.error')}</span>
                         <span className="truncate text-red-900 dark:text-red-100">{toolErrorSummary}</span>
                       </summary>
-                      <div className="relative mt-2 text-sm text-red-900 dark:text-red-100">
-                        <Markdown className="prose prose-sm prose-red max-w-none font-serif dark:prose-invert">
-                          {toolResultContent}
-                        </Markdown>
-                      </div>
+                      {isToolErrorOpen && (
+                        <div className="relative mt-2 min-w-0 max-w-full overflow-x-auto text-sm text-red-900 [overflow-wrap:anywhere] dark:text-red-100">
+                          <Markdown className="prose prose-sm prose-red max-w-none break-all font-serif dark:prose-invert">
+                            {toolResultContent}
+                          </Markdown>
+                        </div>
+                      )}
                     </details>
                   ) : (
                     // Non-error results - route through ToolRenderer (single source of truth)
@@ -299,6 +308,19 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, s
                         {t('session.messages.fullToolOutputFailed')}
                       </span>
                     )}
+                  </div>
+                )}
+                {fullToolResult && (
+                  <div className="mt-2 min-w-0 max-w-full rounded border border-border bg-muted/30 p-2">
+                    <textarea
+                      aria-label={t('session.messages.loadFullToolOutput')}
+                      className="h-64 min-h-32 w-full max-w-full resize-y overflow-auto whitespace-pre rounded bg-background p-2 font-mono text-xs text-foreground"
+                      dir="ltr"
+                      readOnly
+                      spellCheck={false}
+                      value={String(fullToolResult.content || '')}
+                      wrap="off"
+                    />
                   </div>
                 )}
               </>
@@ -397,7 +419,10 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, s
                 </ReasoningContent>
               </Reasoning>
             ) : message.type === 'error' ? (
-              <details className="rounded border border-red-200/60 bg-red-50/50 p-3 text-sm text-red-900 dark:border-red-800/40 dark:bg-red-950/10 dark:text-red-100">
+              <details
+                className="rounded border border-red-200/60 bg-red-50/50 p-3 text-sm text-red-900 dark:border-red-800/40 dark:bg-red-950/10 dark:text-red-100"
+                onToggle={(event) => setIsConversationErrorOpen(event.currentTarget.open)}
+              >
                 <summary className="flex cursor-pointer items-center gap-1.5 font-medium text-red-700 dark:text-red-300">
                   <svg className="h-4 w-4 flex-shrink-0 text-red-500 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
@@ -405,9 +430,11 @@ const MessageComponent = memo(({ message, prevMessage, createDiff, onFileOpen, s
                   <span className="flex-shrink-0">{t('messageTypes.error')}</span>
                   <span className="truncate text-red-900 dark:text-red-100">{errorSummary}</span>
                 </summary>
-                <div className="mt-2 whitespace-pre-wrap">
-                  {errorContent}
-                </div>
+                {isConversationErrorOpen && (
+                  <div className="mt-2 min-w-0 max-w-full overflow-x-auto whitespace-pre-wrap break-all [overflow-wrap:anywhere]">
+                    {errorContent}
+                  </div>
+                )}
               </details>
             ) : (
               <div dir="auto" className="text-sm text-gray-700 dark:text-gray-300">

--- a/src/shared/view/ui/Collapsible.test.tsx
+++ b/src/shared/view/ui/Collapsible.test.tsx
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { Collapsible, CollapsibleContent } from './Collapsible';
+
+const renderCollapsible = (
+  defaultOpen: boolean,
+  unmountOnClose: boolean,
+): string => renderToStaticMarkup(createElement(
+  Collapsible,
+  { defaultOpen },
+  createElement(
+    CollapsibleContent,
+    { unmountOnClose },
+    createElement('span', null, 'expensive-result'),
+  ),
+));
+
+test('unmountOnClose omits closed disclosure content from the DOM', () => {
+  assert.doesNotMatch(renderCollapsible(false, true), /expensive-result/);
+});
+
+test('unmountOnClose renders disclosure content when initially open', () => {
+  assert.match(renderCollapsible(true, true), /expensive-result/);
+});
+
+test('closed disclosures preserve existing mounted-content behavior by default', () => {
+  assert.match(renderCollapsible(false, false), /expensive-result/);
+});

--- a/src/shared/view/ui/Collapsible.tsx
+++ b/src/shared/view/ui/Collapsible.tsx
@@ -21,6 +21,10 @@ interface CollapsibleProps extends React.HTMLAttributes<HTMLDivElement> {
   onOpenChange?: (open: boolean) => void;
 }
 
+interface CollapsibleContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  unmountOnClose?: boolean;
+}
+
 const Collapsible = React.forwardRef<HTMLDivElement, CollapsibleProps>(
   ({ defaultOpen = false, open: controlledOpen, onOpenChange: controlledOnOpenChange, className, children, ...props }, ref) => {
     const [internalOpen, setInternalOpen] = React.useState(defaultOpen);
@@ -76,9 +80,10 @@ const CollapsibleTrigger = React.forwardRef<HTMLButtonElement, React.ButtonHTMLA
 );
 CollapsibleTrigger.displayName = 'CollapsibleTrigger';
 
-const CollapsibleContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, children, ...props }, ref) => {
+const CollapsibleContent = React.forwardRef<HTMLDivElement, CollapsibleContentProps>(
+  ({ className, children, unmountOnClose = false, ...props }, ref) => {
     const { open } = useCollapsible();
+    const shouldRenderContent = open || !unmountOnClose;
 
     return (
       <div
@@ -91,9 +96,11 @@ const CollapsibleContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes
         )}
         {...props}
       >
-        <div className="overflow-hidden">
-          {children}
-        </div>
+        {shouldRenderContent && (
+          <div className="min-w-0 overflow-hidden">
+            {children}
+          </div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- unmount closed tool-result and error bodies instead of laying out hidden output
- bound UTF-8-safe history previews to 16 KiB total and 4 KiB per line
- keep complete persisted output available only through the existing on-demand endpoint
- render explicitly loaded full output in a no-wrap native text area and constrain visible text layout

## WebKit evidence
- exercised the real large Codex transcript through an isolated database copy and WebKit 18.2 at a 390x844 mobile viewport
- before: 69,812 characters remained mounted while disclosures were closed
- after: 3,541 mounted characters, the pathological minified line absent, HTTP 200, loading indicator cleared, and no page errors across three runs
- preview expansion and a 41,028-character full-output fetch remained responsive

## Verification
- `npm run verify` with deployment-only environment variables removed
- server tests: 1,448 passed
- real tmux/PTY tests: 48 passed
- client tests: 525 passed
- Rust tests: 29 passed
- lint, identity checks, type checks, and production build passed