### PR TITLE
fix(test): restore complete isolated verification inventory

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 
-const TEST_FILE_PATTERN = /\.(?:test|spec)\.(?:js|ts|tsx)$/;
+const TEST_FILE_PATTERN = /\.(?:test|spec)\.(?:js|mjs|ts|tsx)$/;
 const SKIPPED_DIRECTORIES = new Set(['dist', 'dist-server', 'node_modules']);
 export const REAL_RESOURCE_TESTS = Object.freeze([
   'server/gjc-core-host.test.ts',
@@ -66,11 +66,14 @@ export function runTests(label, files, { tsconfig, testConcurrency } = {}) {
 
   console.log(`\n[test] ${label}: ${files.length} files`);
   const runtime = tsconfig ? ['--import', 'tsx'] : [];
+  if (tsconfig === 'server/tsconfig.json') runtime.push('--import', fileURLToPath(new URL('./test-database.mjs', import.meta.url)));
   const concurrency = testConcurrency === undefined ? [] : [`--test-concurrency=${testConcurrency}`];
   const args = [...runtime, '--test', ...concurrency, ...files];
   const result = spawnSync(process.execPath, args, {
     cwd: process.cwd(),
-    env: tsconfig ? { ...process.env, TSX_TSCONFIG_PATH: tsconfig } : process.env,
+    // Each test worker owns its database, including import-time auth bootstrap.
+    // Individual persistence fixtures override this with their own temp paths.
+    env: { ...process.env, DATABASE_PATH: ':memory:', ...(tsconfig ? { TSX_TSCONFIG_PATH: tsconfig } : {}) },
     stdio: 'inherit',
   });
 
@@ -79,14 +82,15 @@ export function runTests(label, files, { tsconfig, testConcurrency } = {}) {
 }
 
 export async function discoverTests() {
-  const [serverTests, scriptTests, clientTests] = await Promise.all([
+  const [serverTests, scriptTests, clientTests, sharedTests] = await Promise.all([
     collectTests('server'),
     collectTests('scripts'),
     collectTests('src'),
+    collectTests('shared'),
   ]);
 
   return {
-    serverTests: [...serverTests, ...scriptTests].sort(),
+    serverTests: [...serverTests, ...scriptTests, ...sharedTests].sort(),
     clientTests,
   };
 }

--- a/scripts/run-tests.test.mjs
+++ b/scripts/run-tests.test.mjs
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import test from 'node:test';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
 
 import * as runner from './run-tests.mjs';
 
@@ -19,6 +22,41 @@ const EXPECTED_REAL_RESOURCE_TESTS = [
 test('server-side discovery includes release verification tests in scripts', async () => {
   const { serverTests } = await runner.discoverTests();
   assert.ok(serverTests.includes(path.join('scripts', 'release', 'verify-db-rollback-compatibility.test.ts')));
+});
+
+test('server test workers use an initialized private database and preserve an ambient database', async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), 'chatmux-runner-isolation-'));
+  const ambient = path.join(directory, 'operator.db');
+  const fixture = path.join(directory, 'database.test.mjs');
+  const marker = path.join(directory, 'executed');
+  try {
+    await writeFile(ambient, 'operator database must stay untouched');
+    await writeFile(fixture, `import assert from 'node:assert/strict';
+      const { getConnection } = await import(${JSON.stringify(new URL('../server/modules/database/connection.ts', import.meta.url).href)});
+      const db = getConnection();
+      assert.ok(db.prepare("SELECT name FROM sqlite_master WHERE name = 'sessions'").get());
+      db.exec('CREATE TABLE fixture_only (value TEXT)');
+      const {writeFileSync} = await import('node:fs');
+      writeFileSync(${JSON.stringify(marker)}, process.env.DATABASE_PATH);`);
+    const source = `const {runTests} = await import(${JSON.stringify(new URL('./run-tests.mjs', import.meta.url).href)});
+      runTests('isolated fixture', [${JSON.stringify(fixture)}], {tsconfig:'server/tsconfig.json'});`;
+    const environment = { ...process.env, DATABASE_PATH: ambient };
+    delete environment.NODE_TEST_CONTEXT;
+    const result = spawnSync(process.execPath, ['--input-type=module', '--eval', source], {
+      env: environment, encoding: 'utf8', timeout: 20_000,
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.notEqual(await readFile(marker, 'utf8'), ambient, 'the fixture must actually execute against its private database');
+    assert.equal(await readFile(ambient, 'utf8'), 'operator database must stay untouched');
+  } finally { await rm(directory, { recursive: true, force: true }); }
+});
+
+test('shared fleet contracts are executed by the canonical test inventory', async () => {
+  const { serverTests } = await runner.discoverTests();
+  assert.ok(serverTests.includes(path.join('shared', 'fleet.test.ts')));
+  assert.ok(serverTests.includes(path.join('shared', 'fleet-completion.test.ts')));
+  assert.ok(serverTests.includes(path.join('scripts', 'verify-owner.test.mjs')));
+  assert.ok(serverTests.includes(path.join('scripts', 'run-tests.test.mjs')));
 });
 
 test('real tmux and PTY files form the exact serial resource partition', () => {

--- a/scripts/test-database.mjs
+++ b/scripts/test-database.mjs
@@ -3,15 +3,20 @@
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { isMainThread } from 'node:worker_threads';
 
-const directory = mkdtempSync(path.join(tmpdir(), 'chatmux-test-db-'));
-process.env.DATABASE_PATH = path.join(directory, 'auth.db');
-const { closeConnection } = await import('../server/modules/database/connection.ts');
-const { initializeDatabase } = await import('../server/modules/database/init-db.ts');
-const log = console.log;
-process.once('exit', () => {
+// Explicit Worker fixtures own their database and register scoped TS loaders.
+// Node 22 does not install the process-level tsx hooks in those worker threads.
+if (isMainThread) {
+  const directory = mkdtempSync(path.join(tmpdir(), 'chatmux-test-db-'));
+  process.env.DATABASE_PATH = path.join(directory, 'auth.db');
+  const { closeConnection } = await import('../server/modules/database/connection.ts');
+  const { initializeDatabase } = await import('../server/modules/database/init-db.ts');
+  const log = console.log;
+  process.once('exit', () => {
+    console.log = () => undefined;
+    try { closeConnection(); } finally { rmSync(directory, { recursive: true, force: true }); console.log = log; }
+  });
   console.log = () => undefined;
-  try { closeConnection(); } finally { rmSync(directory, { recursive: true, force: true }); console.log = log; }
-});
-console.log = () => undefined;
-try { await initializeDatabase(); } finally { console.log = log; }
+  try { await initializeDatabase(); } finally { console.log = log; }
+}

--- a/scripts/test-database.mjs
+++ b/scripts/test-database.mjs
@@ -1,0 +1,17 @@
+// Loaded after tsx, separately in each server test worker. Import-time auth and
+// fleet initialization must never fall through to an operator's real database.
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const directory = mkdtempSync(path.join(tmpdir(), 'chatmux-test-db-'));
+process.env.DATABASE_PATH = path.join(directory, 'auth.db');
+const { closeConnection } = await import('../server/modules/database/connection.ts');
+const { initializeDatabase } = await import('../server/modules/database/init-db.ts');
+const log = console.log;
+process.once('exit', () => {
+  console.log = () => undefined;
+  try { closeConnection(); } finally { rmSync(directory, { recursive: true, force: true }); console.log = log; }
+});
+console.log = () => undefined;
+try { await initializeDatabase(); } finally { console.log = log; }

--- a/server/modules/fleet/tests/task-12-remote-terminal.live.test.ts
+++ b/server/modules/fleet/tests/task-12-remote-terminal.live.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, watch } from 'node:fs';
+import { mkdtempSync, rmSync, watch, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -8,7 +8,7 @@ import test from 'node:test';
 import { attachVerifiedLocalTmuxTerminal } from '../terminal/local-peer.js';
 
 function tmux(socketPath: string, args: readonly string[]): string {
-  const result = spawnSync('tmux', ['-S', socketPath, ...args], { encoding: 'utf8' });
+  const result = spawnSync('tmux', ['-f', '/dev/null', '-S', socketPath, ...args], { encoding: 'utf8' });
   if (result.status !== 0) throw new TypeError(`tmux fixture failed: ${result.stderr}`);
   return result.stdout;
 }
@@ -57,7 +57,12 @@ test('real peer-owned PTY attaches peer A, accepts input and resize, and leaves 
   const controllerBefore = controllerState();
   let terminal: ReturnType<typeof attachVerifiedLocalTmuxTerminal> | undefined;
   try {
-    tmux(socketA, ['new-session', '-d', '-s', 'peer-a', 'bash --noprofile --norc']);
+    const quote = (value: string): string => `'${value.replaceAll("'", "'\\''")}'`;
+    const rc = path.join(root, 'bashrc');
+    const signal = path.join(root, 'peer-a-resized');
+    const resizedSignal = `test "$(stty size)" = '39 120' && touch ${quote(signal)}`;
+    writeFileSync(rc, `PS1='bash-fixture$ '\ntrap ${quote(resizedSignal)} WINCH\n`);
+    tmux(socketA, ['new-session', '-d', '-s', 'peer-a', `bash --noprofile --rcfile ${quote(rc)}`]);
     const peerBReady = armCreated(root, 'peer-b-ready');
     tmux(socketB, ['new-session', '-d', '-s', 'peer-b', `touch '${path.join(root, 'peer-b-ready')}'; exec bash --noprofile --norc`]);
     await peerBReady;
@@ -91,11 +96,13 @@ test('real peer-owned PTY attaches peer A, accepts input and resize, and leaves 
     const timeout = setTimeout(() => failure('terminal output timed out'), 30_000);
 
     // When
-    terminal.resize(120, 40);
     // Input written before the tmux client replays the pane is flushed by the
     // client's terminal setup and never reaches the pane, so wait for the
     // attach screen before writing (observed as lost input on slow CI hosts).
     await attached;
+    const resized = armCreated(root, 'peer-a-resized');
+    terminal.resize(120, 40);
+    await resized;
     terminal.write("stty size; printf 'LIVE_A_MARKER\\n'\n");
     try { await marker; } finally { clearTimeout(timeout); }
 

--- a/shared/fleet.test.ts
+++ b/shared/fleet.test.ts
@@ -101,11 +101,14 @@ test('Given malformed fleet inputs, When parsed, Then each fails closed', async 
     kind: 'request', protocolVersion: FLEET_PROTOCOL_VERSION, connectionGeneration: 1,
     requestId: 'request-1', operation: 'session.read', target: { kind: 'session', localId: 'session-42' }, body: null,
   }));
-  assert.throws(() => parseFleetEventEnvelope({
+  // RFC revision 3 keeps bodies opaque; enums are validated in descriptors,
+  // not in arbitrary operation payloads that happen to reuse a field name.
+  const opaque = { capabilities: ['catalog.read', 'catalog.read'] };
+  assert.deepEqual(parseFleetEventEnvelope({
     kind: 'event', protocolVersion: FLEET_PROTOCOL_VERSION, connectionGeneration: 1,
     eventId: 'event-1', event: 'catalog.snapshot', hostId: hostA,
-    body: { capabilities: ['catalog.read', 'catalog.read'] },
-  }));
+    body: opaque,
+  }).body, opaque);
   assert.throws(() => parseFleetResponseEnvelope({
     kind: 'response', protocolVersion: FLEET_PROTOCOL_VERSION, connectionGeneration: 1,
     requestId: 'request-1', target, status: 'failure', sideEffect: 'none', error: 'UNKNOWN', body: null,


### PR DESCRIPTION
The canonical test runner omitted all shared contracts and `.test.mjs` files, including its own inventory and verification-owner tests. Import-time auth/database users also inherited the developer database, making some tests pass only when that database already had a schema.

Include shared and ESM tests, initialize a private database per server worker before imports, and clean it on exit. A subprocess regression proves the test actually ran, initialized its own schema, and left an ambient database unchanged. Update the formerly unexecuted opaque-body assertion to Fleet RFC revision 3 while retaining strict descriptor/envelope checks.

The real terminal resize test now creates its own tmux/bash configuration and waits for the shell's SIGWINCH acknowledgement before querying `stty`. A tmux layout update can precede the kernel PTY resize; accepting that earlier event caused the test to read 23x80 while the final pane was 39x120.

Validation: inventory/isolation regressions pass, the restored shared tests pass, and the real PTY test passes with input, resize, peer isolation, and controller preservation assertions intact. Full required CI runs on this standalone change.
