### PR TITLE
fix(codex): terminate reverse title scans at chunk boundaries

### DIFF
--- a/server/modules/providers/list/codex/codex-session-synchronizer.provider.ts
+++ b/server/modules/providers/list/codex/codex-session-synchronizer.provider.ts
@@ -228,8 +228,13 @@ export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
           ? Buffer.concat([buffer.subarray(0, bytesRead), leadingFragment])
           : buffer.subarray(0, bytesRead);
         let lineEnd = combined.length;
-        let newline = combined.lastIndexOf(0x0a, lineEnd - 1);
-        while (newline >= 0) {
+        // Buffer.lastIndexOf treats -1 as an offset from the end. Stop at zero
+        // so a newline at the start of this chunk cannot restart the scan.
+        while (lineEnd > 0) {
+          const newline = combined.lastIndexOf(0x0a, lineEnd - 1);
+          if (newline < 0) {
+            break;
+          }
           const title = parseCodexTaskCompleteTitle(
             combined.subarray(newline + 1, lineEnd).toString('utf8'),
           );
@@ -237,7 +242,6 @@ export class CodexSessionSynchronizer implements IProviderSessionSynchronizer {
             return title;
           }
           lineEnd = newline;
-          newline = combined.lastIndexOf(0x0a, lineEnd - 1);
         }
 
         leadingFragment = Buffer.from(combined.subarray(0, lineEnd));

--- a/server/modules/providers/tests/codex-title-scan.test.ts
+++ b/server/modules/providers/tests/codex-title-scan.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const CHUNK_BYTES = 256 * 1024;
+const completed = (title: string) => JSON.stringify({
+  type: 'event_msg', payload: { type: 'task_complete', last_agent_message: title },
+});
+const metadata = (id: string) => JSON.stringify({
+  type: 'session_meta', payload: { id, cwd: '/synthetic/codex-title-scan' },
+});
+
+// The watchdog belongs to the parent process: a same-thread test timeout cannot
+// interrupt a synchronous loop that has starved Node's event loop.
+test('Codex title scanning terminates at blank-line and chunk boundaries', async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), 'chatmux-codex-title-boundaries-'));
+  try {
+    const event = JSON.stringify({ type: 'event_msg', payload: { type: 'task_started' } });
+    const alignedTail = `\n${event}${' '.repeat(CHUNK_BYTES - Buffer.byteLength(event) - 2)}\n`;
+    assert.equal(Buffer.byteLength(alignedTail), CHUNK_BYTES);
+
+    const fixtures = [
+      { id: 'leading-blank', body: `\n${metadata('leading-blank')}\n`, title: 'Untitled Codex Session' },
+      { id: 'blank-tail', body: `${metadata('blank-tail')}\n\n\n`, title: 'Untitled Codex Session' },
+      {
+        id: 'aligned-completed',
+        body: `${metadata('aligned-completed')}\n${completed('Older title')}\n${completed('Latest completed title')}\n${alignedTail}`,
+        title: 'Latest completed title',
+      },
+      {
+        id: 'aligned-untitled',
+        body: `${metadata('aligned-untitled')}\n${alignedTail}`,
+        title: 'Untitled Codex Session',
+      },
+      {
+        id: 'several-aligned-chunks',
+        body: `${metadata('several-aligned-chunks')}\n${completed('Before three chunks')}\n${alignedTail.repeat(3)}`,
+        title: 'Before three chunks',
+      },
+      {
+        id: 'malformed-and-partial',
+        body: `${metadata('malformed-and-partial')}\r\n${completed('Valid before partial tail')}\r\nnull\n{invalid\n{"type":"event_msg","payload":`,
+        title: 'Valid before partial tail',
+      },
+      {
+        id: 'unterminated-title',
+        body: `${metadata('unterminated-title')}\n${completed('No trailing newline')}`,
+        title: 'No trailing newline',
+      },
+      {
+        id: 'unicode-boundary',
+        // Move the last chunk boundary inside the four-byte emoji, so decoding
+        // individual chunks would corrupt the recovered title.
+        body: `${metadata('unicode-boundary')}\n${completed('한글 🧪 완료')}${' '.repeat(CHUNK_BYTES - Buffer.byteLength('🧪 완료"}}') + 2)}`,
+        title: '한글 🧪 완료',
+      },
+      { id: 'empty', body: '', title: null },
+    ];
+    for (const fixture of fixtures) {
+      await writeFile(path.join(root, `${fixture.id}.jsonl`), fixture.body);
+    }
+    await writeFile(path.join(root, 'cases.json'), JSON.stringify(fixtures.map(({ id }) => id)));
+    const result = spawnSync(process.execPath, [
+      '--import', 'tsx',
+      fileURLToPath(new URL('./support/codex-title-scan-probe.ts', import.meta.url)),
+      root,
+    ], {
+      env: {
+        ...process.env,
+        DATABASE_PATH: path.join(root, 'auth.db'),
+        TSX_TSCONFIG_PATH: 'server/tsconfig.json',
+      },
+      encoding: 'utf8', timeout: 20_000, killSignal: 'SIGKILL', maxBuffer: 1024 * 1024,
+    });
+    assert.equal(result.error, undefined, `Title scan exceeded its process deadline: ${result.error?.message}`);
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    const output = result.stdout.split('\n').find((line) => line.startsWith('TITLE_SCAN_RESULTS='));
+    assert.ok(output, result.stdout);
+    assert.deepEqual(JSON.parse(output.slice('TITLE_SCAN_RESULTS='.length)), fixtures.map(({ id, title }) => ({ id, title })));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/server/modules/providers/tests/support/codex-title-scan-probe.ts
+++ b/server/modules/providers/tests/support/codex-title-scan-probe.ts
@@ -1,0 +1,23 @@
+import { readFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { closeConnection, initializeDatabase, sessionsDb } from '@/modules/database/index.js';
+import { CodexSessionSynchronizer } from '@/modules/providers/list/codex/codex-session-synchronizer.provider.js';
+
+const root = process.argv[2];
+if (!root) throw new Error('An isolated fixture root is required.');
+Object.defineProperty(os, 'homedir', { value: () => root });
+await initializeDatabase();
+try {
+  const synchronizer = new CodexSessionSynchronizer();
+  const ids = JSON.parse(await readFile(path.join(root, 'cases.json'), 'utf8')) as string[];
+  const results = [];
+  for (const id of ids) {
+    const sessionId = await synchronizer.synchronizeFile(path.join(root, `${id}.jsonl`));
+    results.push({ id, title: sessionId ? sessionsDb.getSessionById(sessionId)?.custom_name : null });
+  }
+  console.log(`TITLE_SCAN_RESULTS=${JSON.stringify(results)}`);
+} finally {
+  closeConnection();
+}


### PR DESCRIPTION
A Codex transcript with a newline at byte zero of a reverse-scan chunk could trap the title indexer in a synchronous loop, occupying one CPU core and preventing all HTTP requests (including `/health`) from completing. Stop scanning when the cursor reaches zero so `Buffer.lastIndexOf(-1)` cannot wrap back to the end.

Add a subprocess-bounded regression covering nine transcript shapes: leading and repeated blank lines, aligned single/multiple chunks with and without an older completed title, malformed/partial tails, an unterminated final record, split UTF-8, and an empty file. The original implementation fails by timeout; the fix completes and preserves the expected titles.

Validation: focused Codex tests (18 passing) and the full `npm run verify` gate passed. Existing browser E2E checks passed against the isolated fixture. Mobile and deployment verification continue separately; no private transcript or operational diagnostics are included.
