### PR TITLE
fix(shell): improve terminal accessibility

### DIFF
--- a/src/components/shell/view/subcomponents/ShellConnectionOverlay.test.tsx
+++ b/src/components/shell/view/subcomponents/ShellConnectionOverlay.test.tsx
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import TestRenderer, { act } from 'react-test-renderer';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import ShellConnectionOverlay from './ShellConnectionOverlay';
+
+const labels = {
+  description: 'Ready to connect to the selected terminal.',
+  loadingLabel: 'Loading terminal…',
+  connectLabel: 'Connect terminal',
+  connectTitle: 'Connect to the selected terminal',
+  connectingLabel: 'Connecting…',
+};
+
+test('connection modes update one polite status region without requesting focus or including the connect button', async (t) => {
+  let connects = 0;
+  const onConnect = () => { connects += 1; };
+  let renderer!: TestRenderer.ReactTestRenderer;
+  await act(async () => {
+    renderer = TestRenderer.create(<ShellConnectionOverlay {...labels} mode="loading" onConnect={onConnect} />);
+  });
+  t.after(() => act(() => renderer.unmount()));
+  const status = renderer.root.findByProps({ role: 'status' });
+
+  for (const [mode, expected] of [
+    ['loading', labels.loadingLabel],
+    ['connecting', labels.connectingLabel],
+    ['connect', labels.description],
+    ['connecting', labels.connectingLabel],
+  ] as const) {
+    await act(async () => renderer.update(<ShellConnectionOverlay {...labels} mode={mode} onConnect={onConnect} />));
+    assert.equal(renderer.root.findAllByProps({ role: 'status' }).length, 1);
+    assert.equal(renderer.root.findByProps({ role: 'status' }), status);
+    assert.equal(status.props['aria-live'], 'polite');
+    assert.equal(status.props['aria-atomic'], 'true');
+    assert.deepEqual(status.findByType('span').children, [expected]);
+    assert.equal(status.findAllByType('button').length, 0);
+    assert.equal(renderer.root.findAllByProps({ role: 'alert' }).length, 0);
+    assert.equal(renderer.root.findAll((node) => node.props.autoFocus || node.props.tabIndex !== undefined).length, 0);
+    assert.equal(connects, 0);
+
+    const buttons = renderer.root.findAllByType('button');
+    assert.equal(buttons.length, mode === 'connect' ? 1 : 0);
+    for (const icon of renderer.root.findAllByType('svg')) {
+      assert.equal(icon.props['aria-hidden'], 'true');
+    }
+  }
+});
+
+test('connect remains a native button with one callback per activation', async (t) => {
+  let connects = 0;
+  let renderer!: TestRenderer.ReactTestRenderer;
+  await act(async () => {
+    renderer = TestRenderer.create(
+      <ShellConnectionOverlay {...labels} mode="connect" onConnect={() => { connects += 1; }} />,
+    );
+  });
+  t.after(() => act(() => renderer.unmount()));
+  const button = renderer.root.findByType('button');
+  assert.equal(button.props.type, 'button');
+  assert.equal(button.props.title, labels.connectTitle);
+  assert.deepEqual(button.findByType('span').children, [labels.connectLabel]);
+  assert.equal(button.props.onPointerDown, undefined);
+  assert.equal(button.props.onKeyDown, undefined);
+  assert.equal(button.props.onKeyUp, undefined);
+  assert.equal(connects, 0);
+  await act(async () => button.props.onClick());
+  assert.equal(connects, 1);
+});
+
+test('long connection labels can wrap within mobile and desktop overlay widths', () => {
+  for (const mode of ['loading', 'connect', 'connecting'] as const) {
+    const markup = renderToStaticMarkup(
+      <ShellConnectionOverlay
+        {...labels}
+        mode={mode}
+        loadingLabel={'Loading '.repeat(20)}
+        connectLabel={'Connect '.repeat(20)}
+        connectingLabel={'Connecting '.repeat(20)}
+        onConnect={() => {}}
+      />,
+    );
+    assert.match(markup, /w-full min-w-0 max-w-md/);
+    assert.match(markup, /min-w-0 break-words/);
+    assert.match(markup, /shrink-0/);
+    assert.doesNotMatch(markup, /\btruncate\b|\bwhitespace-nowrap\b/);
+  }
+});

--- a/src/components/shell/view/subcomponents/ShellConnectionOverlay.tsx
+++ b/src/components/shell/view/subcomponents/ShellConnectionOverlay.tsx
@@ -19,44 +19,49 @@ export default function ShellConnectionOverlay({
   connectingLabel,
   onConnect,
 }: ShellConnectionOverlayProps) {
-  if (mode === 'loading') {
-    return (
-      <div className="absolute inset-0 z-20 flex items-center justify-center bg-gray-950/90">
-        <div className="inline-flex items-center gap-2 text-sm font-medium text-gray-100">
-          <Loader2 className="h-4 w-4 animate-spin text-blue-300" aria-hidden="true" />
-          <span>{loadingLabel}</span>
-        </div>
-      </div>
-    );
-  }
+  const statusLabel = mode === 'loading' ? loadingLabel : mode === 'connect' ? description : connectingLabel;
 
-  if (mode === 'connect') {
-    return (
-      <div className="absolute inset-0 z-20 flex items-center justify-center bg-gray-950/90 p-6">
-        <div className="flex w-full max-w-md flex-col items-center gap-3 text-center">
+  return (
+    <div className="absolute inset-0 z-20 flex items-center justify-center bg-gray-950/90 p-6">
+      <div className="flex w-full min-w-0 max-w-md flex-col items-center gap-3 text-center">
+        {mode === 'connect' && (
           <button
             type="button"
             onClick={onConnect}
             className="pointer-events-auto inline-flex min-h-12 w-full max-w-xs cursor-pointer items-center justify-center gap-2 rounded-md bg-emerald-600 px-5 py-3 text-base font-semibold text-white shadow-lg shadow-emerald-950/30 transition-colors hover:bg-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-300 focus:ring-offset-2 focus:ring-offset-gray-950 active:bg-emerald-700"
             title={connectTitle}
           >
-            <RotateCcw className="h-4 w-4" aria-hidden="true" />
-            <span className="min-w-0 truncate">{connectLabel}</span>
+            <RotateCcw className="h-4 w-4 shrink-0" aria-hidden="true" />
+            <span className="min-w-0 whitespace-normal break-words">{connectLabel}</span>
           </button>
-          <p className="max-w-md break-words px-2 text-sm leading-6 text-gray-300">{description}</p>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="absolute inset-0 z-20 flex items-center justify-center bg-gray-950/90 p-6">
-      <div className="flex w-full max-w-md flex-col items-center gap-3 text-center">
-        <div className="flex items-center justify-center gap-3 text-yellow-300">
-          <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
-          <span className="text-base font-medium">{connectingLabel}</span>
-        </div>
-        <p className="max-w-md break-words px-2 text-sm leading-6 text-gray-300">{description}</p>
+        )}
+        {/* Keep the same polite status node across modes, outside the connect button. */}
+        <p
+          role="status"
+          aria-live="polite"
+          aria-atomic="true"
+          className="flex w-full min-w-0 items-center justify-center gap-2"
+        >
+          {mode !== 'connect' && (
+            <Loader2
+              className={mode === 'loading'
+                ? 'h-4 w-4 shrink-0 animate-spin text-blue-300'
+                : 'h-5 w-5 shrink-0 animate-spin text-yellow-300'}
+              aria-hidden="true"
+            />
+          )}
+          <span className={mode === 'loading'
+            ? 'min-w-0 break-words text-sm font-medium text-gray-100'
+            : mode === 'connect'
+              ? 'min-w-0 break-words px-2 text-sm leading-6 text-gray-300'
+              : 'min-w-0 break-words text-base font-medium text-yellow-300'}
+          >
+            {statusLabel}
+          </span>
+        </p>
+        {mode === 'connecting' && (
+          <p className="max-w-full break-words px-2 text-sm leading-6 text-gray-300">{description}</p>
+        )}
       </div>
     </div>
   );

--- a/src/components/shell/view/subcomponents/TerminalShortcutsPanel.test.tsx
+++ b/src/components/shell/view/subcomponents/TerminalShortcutsPanel.test.tsx
@@ -1,23 +1,184 @@
 import assert from 'node:assert/strict';
-import test from 'node:test';
+import { readFileSync, readdirSync } from 'node:fs';
+import test, { type TestContext } from 'node:test';
 
-import { renderToStaticMarkup } from 'react-dom/server';
+import type { ComponentProps } from 'react';
+import i18next from 'i18next';
+import { I18nextProvider } from 'react-i18next';
+import TestRenderer, { act } from 'react-test-renderer';
+import type { Terminal } from '@xterm/xterm';
 
 import TerminalShortcutsPanel from './TerminalShortcutsPanel';
 
-test('mobile terminal shortcuts reserve layout space instead of covering CLI output', () => {
-  const markup = renderToStaticMarkup(
-    <TerminalShortcutsPanel
-      wsRef={{ current: null }}
-      terminalRef={{ current: null }}
-      isConnected
-    />,
-  );
+type PanelProps = ComponentProps<typeof TerminalShortcutsPanel>;
+const localesRoot = new URL('../../../../i18n/locales/', import.meta.url);
 
-  assert.match(markup, /pointer-events-none z-20 shrink-0/);
-  assert.match(markup, /pb-safe-area-inset-bottom/);
-  assert.doesNotMatch(markup, /\bfixed\b/);
-  assert.doesNotMatch(markup, /\binset-x-0\b/);
-  assert.match(markup, />Esc</);
-  assert.match(markup, />Tab</);
+function readSettings(language: string) {
+  return JSON.parse(readFileSync(new URL(`${language}/settings.json`, localesRoot), 'utf8'));
+}
+
+async function panelElement(props: Partial<PanelProps> = {}, language = 'en') {
+  const i18n = i18next.createInstance();
+  await i18n.init({
+    lng: language,
+    fallbackLng: false,
+    resources: { [language]: { settings: readSettings(language) } },
+    interpolation: { escapeValue: false },
+  });
+  return (
+    <I18nextProvider i18n={i18n}>
+      <TerminalShortcutsPanel
+        wsRef={{ current: null }}
+        terminalRef={{ current: null }}
+        isConnected
+        {...props}
+      />
+    </I18nextProvider>
+  );
+}
+
+async function mountPanel(t: TestContext, props: Partial<PanelProps> = {}) {
+  const element = await panelElement(props);
+  let renderer!: TestRenderer.ReactTestRenderer;
+  await act(async () => { renderer = TestRenderer.create(element); });
+  t.after(() => act(() => renderer.unmount()));
+  return renderer;
+}
+
+function socketRecorder() {
+  const messages: unknown[] = [];
+  const wsRef = {
+    current: {
+      readyState: WebSocket.OPEN,
+      send: (data: string) => { messages.push(JSON.parse(data)); },
+    } as WebSocket,
+  };
+  return { messages, wsRef };
+}
+
+test('mobile terminal shortcuts reserve layout space and horizontal scrolling below the desktop breakpoint', async (t) => {
+  const renderer = await mountPanel(t);
+  const classes = renderer.root.findAllByType('div').map((node) => node.props.className).join(' ');
+
+  assert.match(classes, /pointer-events-none z-20 shrink-0/);
+  assert.match(classes, /pb-safe-area-inset-bottom/);
+  assert.match(classes, /md:hidden/);
+  assert.match(classes, /overflow-x-auto/);
+  assert.doesNotMatch(classes, /\bfixed\b/);
+  assert.doesNotMatch(classes, /\binset-x-0\b/);
+  const labels = renderer.root.findAllByType('button').flatMap((node) => node.children);
+  assert.ok(labels.includes('Esc'));
+  assert.ok(labels.includes('Tab'));
+});
+
+for (const locale of readdirSync(localesRoot, { withFileTypes: true }).filter((entry) => entry.isDirectory())) {
+  test(`terminal arrow labels use the shipped ${locale.name} translations`, async (t) => {
+    const settings = readSettings(locale.name);
+    const element = await panelElement({}, locale.name);
+    let renderer!: TestRenderer.ReactTestRenderer;
+    await act(async () => { renderer = TestRenderer.create(element); });
+    t.after(() => act(() => renderer.unmount()));
+    const buttons = renderer.root.findAllByType('button');
+
+    for (const key of ['arrowUp', 'arrowDown', 'arrowLeft', 'arrowRight']) {
+      const label = settings.terminalShortcuts[key];
+      assert.equal(typeof label, 'string');
+      assert.ok(label.trim().length > 0);
+      const button = buttons.find((entry) => entry.props['aria-label'] === label);
+      assert.ok(button, `missing accessible button for ${key}`);
+      assert.equal(button.props.title, label);
+      assert.equal(button.findByType('svg').props['aria-hidden'], 'true');
+      assert.equal(button.props['aria-pressed'], undefined);
+    }
+
+    assert.equal(new Set(['arrowUp', 'arrowDown', 'arrowLeft', 'arrowRight']
+      .map((key) => settings.terminalShortcuts[key])).size, 4);
+    assert.ok(buttons.some((button) => button.props['aria-label'] === (settings.terminalShortcuts.paste ?? 'Paste')));
+    assert.ok(buttons.some((button) => button.props['aria-label'] === settings.terminalShortcuts.scrollDown));
+  });
+}
+
+test('Ctrl and Alt expose independent pressed states and reset after one key activation', async (t) => {
+  const { messages, wsRef } = socketRecorder();
+  const renderer = await mountPanel(t, { wsRef });
+  const button = (label: string) => renderer.root.findAllByType('button')
+    .find((entry) => entry.children.includes(label))!;
+  const ctrl = button('CTRL');
+  const alt = button('ALT');
+
+  assert.equal(ctrl.props['aria-pressed'], false);
+  assert.equal(alt.props['aria-pressed'], false);
+  await act(async () => ctrl.props.onClick());
+  assert.equal(ctrl.props['aria-pressed'], true);
+  assert.equal(alt.props['aria-pressed'], false);
+  await act(async () => ctrl.props.onClick());
+  assert.equal(ctrl.props['aria-pressed'], false);
+  await act(async () => {
+    ctrl.props.onClick();
+    alt.props.onClick();
+  });
+  assert.equal(ctrl.props['aria-pressed'], true);
+  assert.equal(alt.props['aria-pressed'], true);
+  assert.deepEqual(messages, []);
+
+  await act(async () => button('Tab').props.onClick());
+  assert.deepEqual(messages, [{ type: 'input', data: '\x1b\t' }]);
+  assert.equal(ctrl.props['aria-pressed'], false);
+  assert.equal(alt.props['aria-pressed'], false);
+  await act(async () => button('Tab').props.onClick());
+  assert.deepEqual(messages, [{ type: 'input', data: '\x1b\t' }, { type: 'input', data: '\t' }]);
+});
+
+test('pointer presses preserve terminal focus and clicks send each key exactly once to the supplied socket', async (t) => {
+  const { messages, wsRef } = socketRecorder();
+  let scrolls = 0;
+  const terminalRef = { current: { scrollToBottom: () => { scrolls += 1; } } as Terminal };
+  const renderer = await mountPanel(t, { wsRef, terminalRef });
+  const buttons = renderer.root.findAllByType('button');
+
+  for (const button of buttons) {
+    let prevented = 0;
+    await act(async () => button.props.onPointerDown({ preventDefault: () => { prevented += 1; } }));
+    assert.equal(prevented, 1);
+    assert.equal(button.props.type, 'button');
+    assert.equal(button.props.onKeyDown, undefined);
+    assert.equal(button.props.onKeyUp, undefined);
+    assert.equal(button.props.tabIndex, undefined);
+  }
+  assert.deepEqual(messages, []);
+  assert.equal(scrolls, 0);
+
+  for (const [label, sequence] of [
+    ['Esc', '\x1b'], ['Tab', '\t'], ['⇧Tab', '\x1b[Z'],
+    ['Arrow Up', '\x1b[A'], ['Arrow Down', '\x1b[B'],
+    ['Arrow Left', '\x1b[D'], ['Arrow Right', '\x1b[C'], ['Ctrl+C', '\x03'],
+  ]) {
+    const button = buttons.find((entry) => entry.props['aria-label'] === label || entry.children.includes(label))!;
+    const before: number = messages.length;
+    await act(async () => button.props.onClick());
+    assert.equal(messages.length, before + 1);
+    assert.deepEqual(messages.at(-1), { type: 'input', data: sequence });
+  }
+
+  const scroll = buttons.find((button) => button.props['aria-label'] === 'Scroll Down')!;
+  await act(async () => scroll.props.onClick());
+  assert.equal(scrolls, 1);
+  assert.equal(messages.length, 8);
+});
+
+test('disconnected controls stay disabled and a closed socket receives no shortcut input', async (t) => {
+  const { messages, wsRef } = socketRecorder();
+  const renderer = await mountPanel(t, { wsRef, isConnected: false });
+  for (const button of renderer.root.findAllByType('button')) {
+    assert.equal(button.props.disabled, true);
+  }
+  assert.deepEqual(messages, []);
+
+  wsRef.current = { ...wsRef.current, readyState: WebSocket.CLOSED } as WebSocket;
+  const connectedElement = await panelElement({ wsRef, isConnected: true });
+  await act(async () => renderer.update(connectedElement));
+  const arrow = renderer.root.findAllByType('button')
+    .find((button) => button.props['aria-label'] === 'Arrow Up')!;
+  await act(async () => arrow.props.onClick());
+  assert.deepEqual(messages, []);
 });

--- a/src/components/shell/view/subcomponents/TerminalShortcutsPanel.tsx
+++ b/src/components/shell/view/subcomponents/TerminalShortcutsPanel.tsx
@@ -37,6 +37,13 @@ const ARROW_ICONS = {
   right: ArrowRight,
 } as const;
 
+const ARROW_LABELS = {
+  up: 'terminalShortcuts.arrowUp',
+  down: 'terminalShortcuts.arrowDown',
+  left: 'terminalShortcuts.arrowLeft',
+  right: 'terminalShortcuts.arrowRight',
+} as const;
+
 type TerminalShortcutsPanelProps = {
   wsRef: MutableRefObject<WebSocket | null>;
   terminalRef: MutableRefObject<Terminal | null>;
@@ -120,7 +127,7 @@ export default function TerminalShortcutsPanel({
           title={t('terminalShortcuts.paste', { defaultValue: 'Paste' })}
           aria-label={t('terminalShortcuts.paste', { defaultValue: 'Paste' })}
         >
-          <Clipboard className="h-4 w-4" />
+          <Clipboard className="h-4 w-4" aria-hidden="true" />
         </button>
 
         {MOBILE_KEYS.map((key) => {
@@ -137,6 +144,7 @@ export default function TerminalShortcutsPanel({
                 onPointerDown={preventFocusSteal}
                 onClick={toggle}
                 disabled={!isConnected}
+                aria-pressed={isActive}
                 className={isActive ? KEY_BTN_ACTIVE : KEY_BTN}
               >
                 {key.label}
@@ -154,8 +162,10 @@ export default function TerminalShortcutsPanel({
                 onClick={() => sendInput(key.sequence)}
                 disabled={!isConnected}
                 className={ICON_BTN}
+                title={t(ARROW_LABELS[key.icon])}
+                aria-label={t(ARROW_LABELS[key.icon])}
               >
-                <Icon className="h-4 w-4" />
+                <Icon className="h-4 w-4" aria-hidden="true" />
               </button>
             );
           }
@@ -183,7 +193,7 @@ export default function TerminalShortcutsPanel({
           title={t('terminalShortcuts.scrollDown')}
           aria-label={t('terminalShortcuts.scrollDown')}
         >
-          <ArrowDownToLine className="h-4 w-4" />
+          <ArrowDownToLine className="h-4 w-4" aria-hidden="true" />
         </button>
       </div>
     </div>

--- a/src/i18n/locales/de/settings.json
+++ b/src/i18n/locales/de/settings.json
@@ -59,6 +59,8 @@
     "shiftTab": "Shift+Tab",
     "arrowUp": "Pfeil oben",
     "arrowDown": "Pfeil unten",
+    "arrowLeft": "Pfeil links",
+    "arrowRight": "Pfeil rechts",
     "scrollDown": "Nach unten scrollen",
     "handle": {
       "closePanel": "Tastenkürzel-Panel schließen",

--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -59,6 +59,8 @@
     "shiftTab": "Shift+Tab",
     "arrowUp": "Arrow Up",
     "arrowDown": "Arrow Down",
+    "arrowLeft": "Arrow Left",
+    "arrowRight": "Arrow Right",
     "scrollDown": "Scroll Down",
     "handle": {
       "closePanel": "Close shortcuts panel",

--- a/src/i18n/locales/fr/settings.json
+++ b/src/i18n/locales/fr/settings.json
@@ -59,6 +59,8 @@
     "shiftTab": "Maj+Tab",
     "arrowUp": "Flèche haut",
     "arrowDown": "Flèche bas",
+    "arrowLeft": "Flèche gauche",
+    "arrowRight": "Flèche droite",
     "scrollDown": "Défiler vers le bas",
     "handle": {
       "closePanel": "Fermer le panneau de raccourcis",

--- a/src/i18n/locales/it/settings.json
+++ b/src/i18n/locales/it/settings.json
@@ -59,6 +59,8 @@
     "shiftTab": "Shift+Tab",
     "arrowUp": "Freccia su",
     "arrowDown": "Freccia giù",
+    "arrowLeft": "Freccia sinistra",
+    "arrowRight": "Freccia destra",
     "scrollDown": "Scorri giù",
     "handle": {
       "closePanel": "Chiudi pannello scorciatoie",

--- a/src/i18n/locales/ja/settings.json
+++ b/src/i18n/locales/ja/settings.json
@@ -59,6 +59,8 @@
     "shiftTab": "Shift+Tab",
     "arrowUp": "上矢印",
     "arrowDown": "下矢印",
+    "arrowLeft": "左矢印",
+    "arrowRight": "右矢印",
     "scrollDown": "下にスクロール",
     "handle": {
       "closePanel": "ショートカットパネルを閉じる",

--- a/src/i18n/locales/ko/settings.json
+++ b/src/i18n/locales/ko/settings.json
@@ -59,6 +59,8 @@
     "shiftTab": "Shift+Tab",
     "arrowUp": "위쪽 화살표",
     "arrowDown": "아래쪽 화살표",
+    "arrowLeft": "왼쪽 화살표",
+    "arrowRight": "오른쪽 화살표",
     "scrollDown": "아래로 스크롤",
     "handle": {
       "closePanel": "단축키 패널 닫기",

--- a/src/i18n/locales/ru/settings.json
+++ b/src/i18n/locales/ru/settings.json
@@ -59,6 +59,8 @@
     "shiftTab": "Shift+Tab",
     "arrowUp": "Стрелка вверх",
     "arrowDown": "Стрелка вниз",
+    "arrowLeft": "Стрелка влево",
+    "arrowRight": "Стрелка вправо",
     "scrollDown": "Прокрутка вниз",
     "handle": {
       "closePanel": "Закрыть панель горячих клавиш",

--- a/src/i18n/locales/tr/settings.json
+++ b/src/i18n/locales/tr/settings.json
@@ -59,6 +59,8 @@
     "shiftTab": "Shift+Tab",
     "arrowUp": "Yukarı Ok",
     "arrowDown": "Aşağı Ok",
+    "arrowLeft": "Sol Ok",
+    "arrowRight": "Sağ Ok",
     "scrollDown": "Aşağı Kaydır",
     "handle": {
       "closePanel": "Kısayol panelini kapat",

--- a/src/i18n/locales/zh-CN/settings.json
+++ b/src/i18n/locales/zh-CN/settings.json
@@ -59,6 +59,8 @@
     "shiftTab": "Shift+Tab",
     "arrowUp": "上箭头",
     "arrowDown": "下箭头",
+    "arrowLeft": "向左箭头",
+    "arrowRight": "向右箭头",
     "scrollDown": "滚动到底部",
     "handle": {
       "closePanel": "关闭快捷键面板",

--- a/src/i18n/locales/zh-TW/settings.json
+++ b/src/i18n/locales/zh-TW/settings.json
@@ -59,6 +59,8 @@
     "shiftTab": "Shift+Tab",
     "arrowUp": "向上箭頭",
     "arrowDown": "向下箭頭",
+    "arrowLeft": "向左箭頭",
+    "arrowRight": "向右箭頭",
     "scrollDown": "捲動到底部",
     "handle": {
       "closePanel": "關閉快速鍵面板",


### PR DESCRIPTION
Terminal shortcut state was conveyed only through color, and icon-only arrow buttons had no accessible names. This change exposes Ctrl/Alt pressed state, adds translated arrow labels, and keeps connection updates in one polite status region. Long connection labels wrap on narrow screens.

Validation:
- 18 focused shell accessibility and activation tests passed.
- Client/server TypeScript checks and scoped ESLint passed.
- Full verification and required Node 22/24/bundle CI are being run before merge.

The existing shortcut activation, focus handling, and verified terminal input paths are preserved. Physical screen-reader/device testing has not been performed.
