### PR TITLE
chore(release): prepare 1.9.0 operator improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatmux",
-  "version": "1.8.19",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatmux",
-      "version": "1.8.19",
+      "version": "1.9.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chatmux",
   "private": true,
-  "version": "1.8.19",
+  "version": "1.9.0",
   "productName": "ChatMux",
   "description": "A self-hosted web interface for coding-agent sessions running in tmux",
   "type": "module",

--- a/packaging/release/update-compatibility.json
+++ b/packaging/release/update-compatibility.json
@@ -218,6 +218,16 @@
           "1.8.18"
         ]
       }
+    },
+    "1.9.0": {
+      "database": {
+        "schemaGeneration": 20,
+        "rollbackCompatibleFrom": [
+          "1.8.17",
+          "1.8.18",
+          "1.8.19"
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
Prepare ChatMux 1.9.0 for the merged operator improvements: cached diagnostics and bounded indexing, attention navigation, browser-local pins and conversation excerpts, mobile terminal accessibility, explicit custom CLI/tmux socket discovery, and stronger binding/reconnect validation.

The release keeps schema generation 20 and carries forward the complete predecessor rollback window: 1.8.17, 1.8.18, and 1.8.19. Published compatibility entries and dependencies are unchanged.

Validation: release metadata passed against the canonical v1.8.19 compatibility declaration and migration registry; identity and whitespace checks passed. The unchanged application source at dbd4229 already passed 2,343 Node tests, 29 Rust tests, and all 13 final CUA requirements, including desktop/mobile/PWA checks. Required CI reruns on this versioned latest-main head before merge; the sole release workflow then verifies the canonical archive, extracted runtime, Ubuntu compatibility, and every declared rollback target before publication.
