### PR TITLE
fix(sidebar): remove idle attention clutter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatmux",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatmux",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chatmux",
   "private": true,
-  "version": "1.9.0",
+  "version": "1.9.1",
   "productName": "ChatMux",
   "description": "A self-hosted web interface for coding-agent sessions running in tmux",
   "type": "module",

--- a/packaging/release/update-compatibility.json
+++ b/packaging/release/update-compatibility.json
@@ -228,6 +228,17 @@
           "1.8.19"
         ]
       }
+    },
+    "1.9.1": {
+      "database": {
+        "schemaGeneration": 20,
+        "rollbackCompatibleFrom": [
+          "1.8.17",
+          "1.8.18",
+          "1.8.19",
+          "1.9.0"
+        ]
+      }
     }
   }
 }

--- a/scripts/cua/improvement-interactions.py
+++ b/scripts/cua/improvement-interactions.py
@@ -171,14 +171,20 @@ def check_diagnostics(page, mobile, evidence, name, checks):
 
 def check_attention(page, mobile, checks):
     open_sidebar(page, mobile)
+    control = page.locator('[data-attention-filter-select]')
+    # The fixture's idle list intentionally has no attention chrome. Mounted
+    # coverage exercises report changes and keeps empty active filters resettable.
+    if control.count() == 0:
+        expect(page.locator('[data-attention-toolbar]')).to_have_count(0)
+        expect(page.locator('[data-attention-next]')).to_have_count(0)
+        expect(page.get_by_text('cua-01-omo', exact=True).first).to_be_visible()
+        checks['idle_local_list_has_no_attention_toolbar'] = True
+        return
     for value in ['input', 'failure', 'connection', 'all']:
-        control = page.locator(f'[data-attention-filter="{value}"]')
         expect(control).to_be_visible()
-        activate(control, mobile)
-        expect(control).to_have_attribute('aria-pressed', 'true')
-        assert page.locator('[data-attention-filter][aria-pressed="true"]').count() == 1
+        control.select_option(value)
+        expect(control).to_have_value(value)
     expect(page.get_by_text('cua-01-omo', exact=True).first).to_be_visible()
-    expect(page.locator('[data-attention-next]')).to_be_visible()
     checks['local_attention_filters_and_restore'] = True
 
 

--- a/server/install-cli.test.ts
+++ b/server/install-cli.test.ts
@@ -355,6 +355,7 @@ test('managed install automatically uses Tailscale identity and prints its HTTPS
       platform: 'linux',
       arch: 'x64',
       nodeVersion: '22.22.2',
+      portAvailable: async (port) => port === 39102,
       healthCheck: async () => {},
       run: async (command, args) => {
         commands.push([command, ...args].join(' '));

--- a/src/components/chat/hooks/useChatInterfaceState.ts
+++ b/src/components/chat/hooks/useChatInterfaceState.ts
@@ -8,6 +8,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 
 import type { ChatInterfaceProps } from '../types/types';
+import { createChatEscapeHandler } from '../utils/chatEscape';
 
 import { useChatComposerState } from './useChatComposerState';
 import { useChatLiveRefresh } from './useChatLiveRefresh';
@@ -154,14 +155,7 @@ export function useChatInterfaceState(props: InterfaceStateProps) {
       return;
     }
 
-    const handleGlobalEscape = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape' || event.repeat || event.defaultPrevented) {
-        return;
-      }
-
-      event.preventDefault();
-      handleAbortSession();
-    };
+    const handleGlobalEscape = createChatEscapeHandler(handleAbortSession);
 
     document.addEventListener('keydown', handleGlobalEscape, { capture: true });
     return () => {

--- a/src/components/chat/utils/chatEscape.test.ts
+++ b/src/components/chat/utils/chatEscape.test.ts
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { createChatEscapeHandler } from './chatEscape';
+
+test('native select and option Escape cannot trigger chat abort or cancel native handling', () => {
+  let aborts = 0;
+  const handler = createChatEscapeHandler(() => { aborts += 1; });
+  for (const tag of ['SELECT', 'OPTION']) {
+    const target = Object.assign(new EventTarget(), {
+      tagName: tag,
+      closest: (selector: string) => selector === 'select' ? { tagName: 'SELECT' } : null,
+    });
+    target.addEventListener('keydown', handler as EventListener, { capture: true });
+    const event = Object.assign(new Event('keydown', { cancelable: true }), { key: 'Escape', repeat: false });
+    target.dispatchEvent(event);
+    assert.equal(event.defaultPrevented, false);
+  }
+  assert.equal(aborts, 0);
+});
+
+test('ordinary Escape still aborts once; repeated, consumed, and other keys do not', () => {
+  let aborts = 0;
+  const target = new EventTarget();
+  target.addEventListener('keydown', createChatEscapeHandler(() => { aborts += 1; }) as EventListener, { capture: true });
+  const send = (key: string, repeat = false, prevented = false) => {
+    const event = Object.assign(new Event('keydown', { cancelable: true }), { key, repeat });
+    if (prevented) event.preventDefault();
+    target.dispatchEvent(event);
+    return event;
+  };
+  send('Enter');
+  send('Escape', true);
+  send('Escape', false, true);
+  assert.equal(aborts, 0);
+  assert.equal(send('Escape').defaultPrevented, true);
+  assert.equal(aborts, 1);
+});

--- a/src/components/chat/utils/chatEscape.ts
+++ b/src/components/chat/utils/chatEscape.ts
@@ -1,0 +1,9 @@
+/** Keep native picker cancellation separate from the chat abort shortcut. */
+export function createChatEscapeHandler(onAbort: () => void) {
+  return (event: KeyboardEvent) => {
+    if (event.key !== 'Escape' || event.repeat || event.defaultPrevented) return;
+    if ((event.target as Element | null)?.closest?.('select')) return;
+    event.preventDefault();
+    onAbort();
+  };
+}

--- a/src/components/sidebar/view/subcomponents/SidebarAttentionControls.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarAttentionControls.tsx
@@ -1,8 +1,7 @@
-import { useId } from 'react';
+import { useId, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ArrowDown } from 'lucide-react';
+import { ArrowDown, ListFilter } from 'lucide-react';
 
-import { cn } from '../../../../lib/utils';
 import type { SessionAttentionFilter } from '../../utils/sessionAttention';
 
 type Props = {
@@ -16,37 +15,58 @@ type Props = {
 export default function SidebarAttentionControls({ filter, counts, hasNext, onFilter, onNext }: Props) {
   const { t } = useTranslation('sidebar');
   const scopeId = useId();
+  const filterRef = useRef<HTMLSelectElement>(null);
+  const [focusedControl, setFocusedControl] = useState<'filter' | 'next' | null>(null);
+  useLayoutEffect(() => {
+    if (!hasNext && focusedControl === 'next') filterRef.current?.focus();
+  }, [hasNext, focusedControl]);
+  // An idle list does not need an attention toolbar. Keep an active filter
+  // available after its last match clears, and retain keyboard focus until blur.
+  if (filter === 'all' && !Object.values(counts).some((count) => count > 0) && focusedControl === null) return null;
+
   return (
-    <div className="space-y-1 border-b border-border/60 px-2 py-2">
-      <p id={scopeId} className="text-[11px] text-muted-foreground">{t('attention.scope')}</p>
-      <div role="group" aria-label={t('attention.filterLabel')} aria-describedby={scopeId} className="flex flex-wrap gap-1">
-        {(['all', 'input', 'failure', 'connection'] as const).map((value) => (
-          <button
-            key={value}
-            type="button"
-            data-attention-filter={value}
-            aria-pressed={filter === value}
-            onClick={() => onFilter(value)}
-            className={cn(
-              'min-h-11 rounded-md border px-2 py-1 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-              filter === value ? 'border-primary/30 bg-primary/10 text-foreground' : 'border-border text-muted-foreground hover:bg-muted',
-            )}
-          >
-            {t(`attention.${value}`)}{value !== 'all' && ` (${counts[value]})`}
-          </button>
-        ))}
-      </div>
-      <button
-        type="button"
-        data-attention-next
-        disabled={!hasNext}
-        aria-describedby={scopeId}
-        onClick={onNext}
-        className="flex min-h-11 w-full items-center justify-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-      >
-        <ArrowDown className="h-3.5 w-3.5" aria-hidden />
-        {t(filter === 'all' ? 'attention.nextAttention' : 'attention.nextMatch')}
-      </button>
+    <div
+      className="flex items-center gap-1 px-2 pt-1"
+      data-attention-toolbar
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) setFocusedControl(null);
+      }}
+    >
+      <span id={scopeId} className="sr-only">{t('attention.scope')}</span>
+      <label className="relative min-w-0 flex-1">
+        <ListFilter className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" aria-hidden />
+        <select
+          ref={filterRef}
+          data-attention-filter-select
+          value={filter}
+          aria-label={t('attention.filterLabel')}
+          aria-describedby={scopeId}
+          onFocus={() => setFocusedControl('filter')}
+          onChange={(event) => onFilter(event.target.value as SessionAttentionFilter)}
+          className="min-h-11 w-full rounded-md border-0 bg-background py-1 pl-7 pr-2 text-xs text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring md:min-h-8"
+        >
+          {(['all', 'input', 'failure', 'connection'] as const).map((value) => (
+            <option key={value} value={value}>
+              {t(`attention.${value}`)}{value !== 'all' && ` (${counts[value]})`}
+            </option>
+          ))}
+        </select>
+      </label>
+      {(hasNext || focusedControl === 'next') && (
+        <button
+          type="button"
+          data-attention-next
+          aria-disabled={!hasNext}
+          aria-label={t(filter === 'all' ? 'attention.nextAttention' : 'attention.nextMatch')}
+          title={t(filter === 'all' ? 'attention.nextAttention' : 'attention.nextMatch')}
+          aria-describedby={scopeId}
+          onFocus={() => setFocusedControl('next')}
+          onClick={() => { if (hasNext) onNext(); }}
+          className="flex min-h-11 min-w-11 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring md:min-h-8 md:min-w-8"
+        >
+          <ArrowDown className="h-3.5 w-3.5" aria-hidden />
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/sidebar/view/subcomponents/SidebarLiveSection.attention.mounted.test.tsx
+++ b/src/components/sidebar/view/subcomponents/SidebarLiveSection.attention.mounted.test.tsx
@@ -66,12 +66,12 @@ const controls = (renderer: ReactTestRenderer) => renderer.root.findByType(Sideb
 const visibleIds = (renderer: ReactTestRenderer) => renderer.root.findAllByType(SortableSessionRow)
   .filter((row) => !row.props.hidden).map((row) => row.props.id);
 const chooseFilter = async (renderer: ReactTestRenderer, filter: string) => {
-  const button = renderer.root.findAllByType('button').find((node) => node.props['data-attention-filter'] === filter)!;
-  await act(async () => { button.props.onClick(); });
+  const select = renderer.root.findByType('select');
+  await act(async () => { select.props.onChange({ target: { value: filter } }); });
 };
 const next = async (renderer: ReactTestRenderer) => {
   const button = renderer.root.findAllByType('button').find((node) => node.props['data-attention-next'] === true)!;
-  assert.equal(button.props.disabled, false);
+  assert.notEqual(button.props.disabled, true);
   await act(async () => { button.props.onClick(); });
 };
 
@@ -81,28 +81,48 @@ test('attention filters only local reported rows, preserves order, and distingui
   try {
     const initialOrder = visibleIds(view.renderer);
     assert.deepEqual(controls(view.renderer).props.counts, { input: 2, failure: 1, connection: 1 });
-    const scope = view.renderer.root.findAllByType('p').find((node) => node.children.includes(enSidebar.attention.scope));
+    const scope = view.renderer.root.findAllByType('span').find((node) => node.children.includes(enSidebar.attention.scope));
     assert.ok(scope);
-    const filters = view.renderer.root.findAllByType('button').filter((node) => node.props['data-attention-filter']);
-    assert.equal(filters.length, 4);
-    for (const button of filters) {
-      assert.equal(button.props.type, 'button');
-      assert.match(button.props.className, /min-h-11/);
-      assert.match(button.props.className, /focus-visible:ring-2/);
-    }
+    const select = view.renderer.root.findByType('select');
+    assert.equal(select.props['aria-label'], enSidebar.attention.filterLabel);
+    assert.equal(select.props['aria-describedby'], scope.props.id);
+    assert.equal(select.props.value, 'all');
+    assert.deepEqual(select.findAllByType('option').map((option) => [option.props.value, option.children.join('')]), [
+      ['all', 'All local'], ['input', 'Response needed (2)'], ['failure', 'Failures (1)'], ['connection', 'Connection issues (1)'],
+    ]);
     await chooseFilter(view.renderer, 'input');
     const inputIds = [createSessionOrderId('s-live', props.liveSessionTargets.get('s-live')!.tmux), createSessionOrderId('', props.externalSessions![1]!.tmux)];
     assert.deepEqual(visibleIds(view.renderer), inputIds);
-    assert.equal(view.renderer.root.findAllByType('button').find((node) => node.props['data-attention-filter'] === 'input')!.props['aria-pressed'], true);
+    assert.equal(view.renderer.root.findByType('select').props.value, 'input');
     assert.ok(view.renderer.root.findAllByType(SortableSessionRow).every((row) => row.props.disabled), 'filtering cannot overwrite saved ordering');
     await chooseFilter(view.renderer, 'failure');
     assert.deepEqual(visibleIds(view.renderer), [createSessionOrderId('', props.externalSessions![2]!.tmux)]);
     await chooseFilter(view.renderer, 'connection');
     assert.deepEqual(visibleIds(view.renderer), [createSessionOrderId('', props.externalSessions![6]!.tmux)]);
     assert.equal(controls(view.renderer).props.hasNext, false, 'a connection exclusion never becomes selectable through navigation');
+    assert.equal(view.renderer.root.findAllByType('button').filter((node) => node.props['data-attention-next']).length, 0);
     assert.ok(view.renderer.root.findAllByType('span').some((node) => node.children.includes('LINK')));
     await chooseFilter(view.renderer, 'all');
     assert.deepEqual(visibleIds(view.renderer), initialOrder);
+  } finally { await view.unmount(); }
+});
+
+test('an idle list has no attention toolbar and an empty active filter can still be reset', async () => {
+  const idle = { ...baseProps(), liveSessionInput: new Set<string>(), externalSessions: [external('ready', 'waiting_user')] };
+  const view = await mount(idle);
+  try {
+    assert.equal(view.renderer.root.findAllByType('select').length, 0);
+    assert.equal(view.renderer.root.findAllByType('button').filter((node) => node.props['data-attention-next']).length, 0);
+    const idleOrder = visibleIds(view.renderer);
+    await view.update(baseProps());
+    await chooseFilter(view.renderer, 'failure');
+    await view.update(idle);
+    assert.equal(view.renderer.root.findByType('select').props.value, 'failure');
+    assert.deepEqual(visibleIds(view.renderer), []);
+    assert.equal(view.renderer.root.findAllByType('button').filter((node) => node.props['data-attention-next']).length, 0);
+    await chooseFilter(view.renderer, 'all');
+    assert.equal(view.renderer.root.findAllByType('select').length, 0);
+    assert.deepEqual(visibleIds(view.renderer), idleOrder);
   } finally { await view.unmount(); }
 });
 


### PR DESCRIPTION
New session was followed by a scope explanation, four filter buttons, and a disabled Next action even when every local attention count was zero. Idle lists now go directly to sessions. A compact native filter and usable Next action appear when attention is reported, while empty active filters remain resettable.

Keyboard focus survives report changes, and Escape in native pickers no longer aborts the selected chat. The existing mocked installer test now injects port availability so an unrelated outgoing TCP connection cannot fail it. This also prepares patch release 1.9.1 with unchanged schema generation 20 and declared rollback to 1.8.17, 1.8.18, 1.8.19, and 1.9.0.

Validation: `npm run verify` passed; five Chrome/WebKit component browser cases cover desktop/mobile, English/Korean, light/dark themes, empty-filter reset, focus handoff, and native-picker Escape. Five existing operator-feature CUA cases passed. The idle layout recovers 129–178px in the comparison fixture; active controls fit one 36–48px row.
