### PR TITLE
fix(codex): follow active conversations after rollback

### DIFF
--- a/server/modules/providers/services/external-cli-sessions/codex-fork-inference.ts
+++ b/server/modules/providers/services/external-cli-sessions/codex-fork-inference.ts
@@ -1,0 +1,282 @@
+import { homedir } from 'node:os';
+import { join, relative, isAbsolute, sep } from 'node:path';
+import { open, realpath, stat } from 'node:fs/promises';
+
+import Database from 'better-sqlite3';
+
+import { tmuxPaneIdentityKey } from '../../../../../shared/tmux.js';
+
+import type { ExternalCliSession, ExternalPane, ProcessTreeEntry } from './contracts-and-resume.js';
+import { CODEX_THREAD_ID_RE, externalSessionInferenceKey } from './contracts-and-resume.js';
+import { descendants, isCodexRuntimeProcess, processCliKind, runCommand } from './process-classification.js';
+import { readOpenCodexThreads } from './codex-runtime-inference.js';
+import { isCodexMainThreadMetadata } from './session-correlation.js';
+
+const MAX_THREADS = 32;
+const MAX_ANCESTORS = 16;
+const MAX_TAIL_BYTES = 1024 * 1024;
+const MAX_LOG_ROWS = 256;
+const ANCHOR_LENGTH = 96;
+const MIN_ANCHOR_LENGTH = 64;
+
+/** Text is evidence for display only, never a native session-binding receipt. */
+export function normalizeCodexDisplayText(text: string): string {
+  return text.normalize('NFKC').replace(/[^\p{L}\p{N}]/gu, '');
+}
+
+export function codexRenderAnchor(bodies: readonly string[]): string | null {
+  let rendered = '';
+  let completed = '';
+  for (const body of bodies) {
+    if (body.startsWith('ConsolidateAgentMessage:') && body.includes('source_len=')) {
+      completed = rendered;
+      rendered = '';
+      continue;
+    }
+    if (!body.startsWith('push_delta: ')) continue;
+    try {
+      const delta: unknown = JSON.parse(body.slice('push_delta: '.length));
+      if (typeof delta !== 'string') return null;
+      rendered = (rendered + normalizeCodexDisplayText(delta)).slice(-ANCHOR_LENGTH);
+      completed = '';
+    } catch {
+      // A truncated/unrecognized delta must not bridge two unrelated messages.
+      rendered = '';
+    }
+  }
+  const anchor = rendered || completed;
+  return anchor.length >= MIN_ANCHOR_LENGTH && new Set(anchor).size >= 12 ? anchor : null;
+}
+
+export function selectCodexForkByDisplay(args: {
+  anchor: string;
+  paneOutput: string;
+  candidates: readonly { id: string; messages: readonly string[] }[];
+}): string | null {
+  if (args.anchor.length < MIN_ANCHOR_LENGTH || args.anchor.length > ANCHOR_LENGTH) return null;
+  // /new or /resume can leave old cells in scrollback above a new welcome card.
+  const headers = [...args.paneOutput.matchAll(/OpenAI Codex \(v[^\n]*\)/g)];
+  const output = args.paneOutput.slice(headers.at(-1)?.index ?? 0);
+  if (!normalizeCodexDisplayText(output).includes(args.anchor)) return null;
+  const matches = new Set(args.candidates.filter((candidate) => (
+    candidate.messages.some((message) => normalizeCodexDisplayText(message).includes(args.anchor))
+  )).map((candidate) => candidate.id));
+  return matches.size === 1 ? [...matches][0] : null;
+}
+
+type ForkTranscript = { id: string; parentId?: string; messages: string[] };
+type CachedTranscript = { signature: string; transcript: ForkTranscript };
+type CachedForkBinding = { processKey: string; anchor: string; selectedId: string };
+// Bounded, server-private text cache. No prompt bodies enter logs or descriptors.
+const transcriptCache = new Map<string, CachedTranscript>();
+const forkBindingsByTarget = new Map<string, CachedForkBinding>();
+
+export async function readCodexForkTranscript(path: string, expectedId: string, root: string): Promise<ForkTranscript | null> {
+  try {
+    const canonical = await realpath(path);
+    const rel = relative(root, canonical);
+    if (rel === '..' || rel.startsWith(`..${sep}`) || isAbsolute(rel)) return null;
+    const metadata = await stat(canonical);
+    if (!metadata.isFile()) return null;
+    const signature = `${metadata.dev}:${metadata.ino}:${metadata.size}:${metadata.mtimeMs}`;
+    const cached = transcriptCache.get(canonical);
+    if (cached?.signature === signature && cached.transcript.id === expectedId) return cached.transcript;
+    const handle = await open(canonical, 'r');
+    let head: string;
+    let tail: string;
+    try {
+      const header = Buffer.alloc(Math.min(metadata.size, 128 * 1024));
+      const headerRead = await handle.read(header, 0, header.length, 0);
+      head = header.subarray(0, headerRead.bytesRead).toString('utf8').split('\n')[0];
+      const buffer = Buffer.alloc(Math.min(metadata.size, MAX_TAIL_BYTES));
+      const offset = metadata.size - buffer.length;
+      const result = await handle.read(buffer, 0, buffer.length, offset);
+      tail = buffer.subarray(0, result.bytesRead).toString('utf8');
+      if (offset > 0) tail = tail.slice(tail.indexOf('\n') + 1);
+    } finally {
+      await handle.close();
+    }
+    const record = JSON.parse(head) as { type?: string; payload?: { id?: string; forked_from_id?: string } };
+    if (record.type !== 'session_meta' || record.payload?.id !== expectedId) return null;
+    const parentId = record.payload.forked_from_id;
+    if (parentId !== undefined && !CODEX_THREAD_ID_RE.test(parentId)) return null;
+    const messages: string[] = [];
+    for (const line of tail.split('\n')) {
+      try {
+        const item = JSON.parse(line) as { type?: string; payload?: { type?: string; role?: string; content?: { type?: string; text?: string }[]; last_agent_message?: unknown } };
+        if (item.type === 'response_item' && item.payload?.type === 'message'
+          && item.payload.role === 'assistant' && Array.isArray(item.payload.content)) {
+          const text = item.payload.content.filter((part) => part.type === 'output_text' && typeof part.text === 'string').map((part) => part.text).join('');
+          // Keep a bounded suffix; a missing/oversize anchor simply cannot bind.
+          messages.push(text.slice(-8192));
+          if (messages.length > 8) messages.shift();
+        } else if (item.type === 'event_msg' && item.payload?.type === 'task_complete') {
+          const text = item.payload.last_agent_message;
+          if (typeof text === 'string' && text.trim()) {
+            messages.push(text.slice(-8192));
+            if (messages.length > 8) messages.shift();
+          }
+        }
+      } catch { /* Partial appended records are retried on the next file change. */ }
+    }
+    const transcript = { id: expectedId, ...(parentId ? { parentId } : {}), messages };
+    transcriptCache.delete(canonical);
+    transcriptCache.set(canonical, { signature, transcript });
+    while (transcriptCache.size > MAX_THREADS) transcriptCache.delete(transcriptCache.keys().next().value!);
+    return transcript;
+  } catch {
+    return null;
+  }
+}
+
+export function readCodexRenderAnchor(db: Database.Database, pid: number, startedAtMs: number): string | null {
+  try {
+    // Resolve the log process UUID first so the tail query can use exact index
+    // equality. A recycled PID with conflicting generations is not evidence.
+    const generations = db.prepare(`
+      SELECT DISTINCT process_uuid AS id FROM logs INDEXED BY idx_logs_process_uuid_threadless_ts
+      WHERE process_uuid GLOB ? AND thread_id IS NULL AND ts >= ? LIMIT 2
+    `).all(`pid:${pid}:*`, Math.ceil(startedAtMs / 1000)) as { id: string }[];
+    if (generations.length !== 1) return null;
+    const rows = db.prepare(`
+      SELECT substr(feedback_log_body, 1, 4096) AS body FROM logs
+      WHERE process_uuid = ? AND thread_id IS NULL AND ts >= ?
+        AND target IN ('codex_tui::markdown_stream', 'codex_tui::app::agent_message_consolidation')
+      ORDER BY ts DESC, ts_nanos DESC, id DESC LIMIT ?
+    `).all(generations[0].id, Math.ceil(startedAtMs / 1000), MAX_LOG_ROWS) as { body: string }[];
+    return codexRenderAnchor(rows.reverse().map((row) => row.body));
+  } catch { return null; }
+}
+
+/**
+ * Shared app-server Codex releases no longer keep rollouts open in the TUI.
+ * Recover a *display-only* fork link from native ancestry + exact TUI render
+ * content + that pane's current output. Do not promote this to `observed`:
+ * neither timestamps, text equality nor ancestry is a provider identity receipt.
+ */
+export async function inferSharedCodexForkIds(args: {
+  sessions: ExternalCliSession[];
+  panes: ExternalPane[];
+  procs: ProcessTreeEntry[];
+  observed: ReadonlyMap<string, string>;
+}): Promise<Map<string, string>> {
+  const targets = args.sessions.filter((session) => session.kind === 'codex'
+    && !session.connectionIssue && session.providerSessionId && session.startedAtMs !== undefined
+    && !args.observed.has(tmuxPaneIdentityKey(session.tmux)));
+  const resolved = new Map<string, string>();
+  if (!targets.length) {
+    forkBindingsByTarget.clear();
+    return resolved;
+  }
+  let state: Database.Database | undefined;
+  let logs: Database.Database | undefined;
+  try {
+    const codexHome = join(homedir(), '.codex');
+    const root = await realpath(join(codexHome, 'sessions'));
+    logs = new Database(join(codexHome, 'logs_2.sqlite'), { readonly: true, fileMustExist: true, timeout: 100 });
+    const children = new Map<number, number[]>();
+    const byPid = new Map(args.procs.map((proc) => [proc.pid, proc]));
+    for (const proc of args.procs) children.set(proc.ppid, [...(children.get(proc.ppid) ?? []), proc.pid]);
+    const pending: Array<{
+      session: ExternalCliSession;
+      pane: ExternalPane;
+      key: string;
+      processKey: string;
+      anchor: string;
+      previous?: CachedForkBinding;
+    }> = [];
+    for (const session of targets) {
+      const key = tmuxPaneIdentityKey(session.tmux);
+      const pane = args.panes.find((candidate) => tmuxPaneIdentityKey(candidate.tmux) === key);
+      if (!pane) continue;
+      const anchors = new Set<string>();
+      const codexPids = descendants(pane.pid, children).filter((pid) => {
+        const proc = byPid.get(pid);
+        return proc ? isCodexRuntimeProcess(proc) : false;
+      });
+      for (const pid of codexPids) {
+        const anchor = readCodexRenderAnchor(logs, pid, session.startedAtMs! - 1000);
+        if (anchor) anchors.add(anchor);
+      }
+      if (anchors.size !== 1) continue;
+      const [anchor] = [...anchors];
+      const processKey = [externalSessionInferenceKey(session), ...codexPids.sort((a, b) => a - b)].join('\0');
+      const previous = forkBindingsByTarget.get(key);
+      if (previous?.processKey === processKey && previous.anchor === anchor) {
+        resolved.set(key, previous.selectedId);
+        continue;
+      }
+      pending.push({ session, pane, key, processKey, anchor, ...(previous?.processKey === processKey ? { previous } : {}) });
+    }
+    for (const key of forkBindingsByTarget.keys()) {
+      if (!targets.some((session) => tmuxPaneIdentityKey(session.tmux) === key)) forkBindingsByTarget.delete(key);
+    }
+    if (!pending.length) return resolved;
+
+    state = new Database(join(codexHome, 'state_5.sqlite'), { readonly: true, fileMustExist: true, timeout: 100 });
+    const servers = args.procs.filter((proc) => processCliKind(proc) === 'codex' && /(?:^|\s)app-server(?:\s|$)/.test(proc.args ?? ''));
+    if (!servers.length || servers.length > 8) return resolved;
+    const openIds = new Set((await Promise.all(servers.map((proc) => readOpenCodexThreads(proc.pid, root)))).flat().map((thread) => thread.id));
+    if (!openIds.size || openIds.size > MAX_THREADS) return resolved;
+    const readRow = state.prepare('SELECT rollout_path, source, thread_source, agent_role FROM threads WHERE id = ?');
+    const transcripts = new Map<string, ForkTranscript | null>();
+    const read = async (id: string): Promise<ForkTranscript | null> => {
+      if (transcripts.has(id)) return transcripts.get(id)!;
+      if (transcripts.size >= MAX_THREADS * 2) return null;
+      const row = readRow.get(id) as { rollout_path: string; source?: string; thread_source?: string; agent_role?: string } | undefined;
+      const transcript = row && isCodexMainThreadMetadata(row) ? await readCodexForkTranscript(row.rollout_path, id, root) : null;
+      transcripts.set(id, transcript);
+      return transcript;
+    };
+    const forks: ForkTranscript[] = [];
+    // Large rollouts can have large individual records; keep scratch buffers
+    // sequential rather than multiplying them by the number of loaded threads.
+    for (const id of openIds) {
+      const transcript = await read(id);
+      if (transcript?.parentId) forks.push(transcript);
+    }
+    if (!forks.length) return resolved;
+    for (const target of pending) {
+      const candidates: ForkTranscript[] = [];
+      for (const fork of forks) {
+        let parent = fork.parentId;
+        const visited = new Set([fork.id]);
+        for (let depth = 0; parent && depth < MAX_ANCESTORS && !visited.has(parent); depth += 1) {
+          if (parent === target.session.providerSessionId) { candidates.push(fork); break; }
+          visited.add(parent);
+          parent = (await read(parent))?.parentId;
+        }
+      }
+      if (!candidates.length) {
+        if (target.previous) resolved.set(target.key, target.previous.selectedId);
+        continue;
+      }
+      // Most turns need no extra tmux command: first check whether any child
+      // transcript even contains this process's current rendered content.
+      if (!candidates.some((candidate) => candidate.messages.some((message) => normalizeCodexDisplayText(message).includes(target.anchor)))) {
+        if (target.previous) resolved.set(target.key, target.previous.selectedId);
+        continue;
+      }
+      const output = await runCommand('tmux', ['-S', target.pane.tmux.socketPath, 'capture-pane', '-p', '-J', '-S', '-500', '-t', target.pane.tmux.paneId]).catch(() => '');
+      const identity = await runCommand('tmux', ['-S', target.pane.tmux.socketPath, 'display-message', '-p', '-t', target.pane.tmux.paneId, '#{socket_path}\t#{session_id}\t#{window_id}\t#{pane_id}\t#{pane_pid}']).catch(() => '');
+      const expected = [target.pane.tmux.socketPath, target.pane.tmux.sessionId, target.pane.tmux.windowId, target.pane.tmux.paneId, target.pane.pid].join('\t');
+      if (identity.trimEnd() !== expected) {
+        if (target.previous) resolved.set(target.key, target.previous.selectedId);
+        continue;
+      }
+      const selected = selectCodexForkByDisplay({ anchor: target.anchor, paneOutput: output.slice(-131072), candidates });
+      if (selected) {
+        forkBindingsByTarget.set(target.key, { processKey: target.processKey, anchor: target.anchor, selectedId: selected });
+        resolved.set(target.key, selected);
+      } else if (target.previous) {
+        resolved.set(target.key, target.previous.selectedId);
+      }
+    }
+  } catch {
+    // Optional format/schema/permission failure leaves proven legacy paths alone.
+  } finally {
+    logs?.close();
+    state?.close();
+  }
+  return resolved;
+}

--- a/server/modules/providers/services/external-cli-sessions/discovery.ts
+++ b/server/modules/providers/services/external-cli-sessions/discovery.ts
@@ -159,6 +159,7 @@ export async function discoverExternalCliSessions(
     sessions,
     inference.ids,
     inference.authoritativeTargetKeys,
+    inference.displayOverrideTargetKeys,
   );
   retryBackoff.recordResults(resolvedSessions, attemptableSessions);
   return { ok: true, sessions: resolvedSessions };

--- a/server/modules/providers/services/external-cli-sessions/inference-and-spawn.ts
+++ b/server/modules/providers/services/external-cli-sessions/inference-and-spawn.ts
@@ -15,6 +15,7 @@ import type { ExternalCliSession, ExternalLocalCliKind, ExternalPane, ProcessTre
 import type { ExternalProviderSessionInference } from './provider-runtime-inference.js';
 import { applyInferredProviderSessionIds, inferClaudeSessionIds, inferIndexedProviderSessionIds, inferOpenPiSessionIds } from './provider-runtime-inference.js';
 import { inferFreshCodexThreadIds, inferOpenCodexThreadIds } from './codex-runtime-inference.js';
+import { inferSharedCodexForkIds } from './codex-fork-inference.js';
 import { runCommand } from './process-classification.js';
 
 
@@ -52,6 +53,9 @@ export async function inferExternalProviderSessionIds(args: {
   const inferredFreshCodex = new Map(
     [...freshCodex].filter(([targetKey]) => attemptableTargetKeys.has(targetKey)),
   );
+  const inferredForks = await inferSharedCodexForkIds({
+    sessions: safeSessions, panes: args.panes, procs: args.procs, observed: observedCodex,
+  });
   const authoritativeTargetKeys = new Set([
     ...observedCodex.keys(),
     ...inferredClaude.keys(),
@@ -59,6 +63,7 @@ export async function inferExternalProviderSessionIds(args: {
   ]);
   const directIds = new Map([
     ...inferredFreshCodex,
+    ...inferredForks,
     ...inferredClaude,
     ...inferredOmp,
     ...observedCodex,
@@ -67,6 +72,7 @@ export async function inferExternalProviderSessionIds(args: {
     safeSessions,
     directIds,
     authoritativeTargetKeys,
+    new Set(inferredForks.keys()),
   );
   const inferredIndexed = args.attemptableSessions.some((session) => (
     session.kind === 'cursor' || session.kind === 'opencode' || session.kind === 'omp' || session.kind === 'omo'
@@ -76,6 +82,7 @@ export async function inferExternalProviderSessionIds(args: {
   return {
     ids: new Map([...directIds, ...inferredIndexed]),
     authoritativeTargetKeys,
+    displayOverrideTargetKeys: new Set(inferredForks.keys()),
   };
 }
 

--- a/server/modules/providers/services/external-cli-sessions/provider-runtime-inference.ts
+++ b/server/modules/providers/services/external-cli-sessions/provider-runtime-inference.ts
@@ -223,6 +223,7 @@ export function applyInferredProviderSessionIds(
   sessions: ExternalCliSession[],
   inferredIds: ReadonlyMap<string, string>,
   authoritativeTargetKeys: ReadonlySet<string> = new Set(),
+  displayOverrideTargetKeys: ReadonlySet<string> = new Set(),
 ): ExternalCliSession[] {
   return sessions.map((session) => {
     if (session.connectionIssue || session.kind === 'shell' || session.kind === 'ssh') {
@@ -236,7 +237,7 @@ export function applyInferredProviderSessionIds(
     // from a cwd or time-window guess and is graded accordingly.
     const binding: ExternalSessionBinding = authoritativeTargetKeys.has(targetKey) ? 'observed' : 'inferred';
     return providerSessionId
-      && (!session.providerSessionId || authoritativeTargetKeys.has(targetKey))
+      && (!session.providerSessionId || authoritativeTargetKeys.has(targetKey) || displayOverrideTargetKeys.has(targetKey))
       ? { ...session, providerSessionId, binding }
       : session;
   });
@@ -245,4 +246,5 @@ export function applyInferredProviderSessionIds(
 export type ExternalProviderSessionInference = {
   ids: Map<string, string>;
   authoritativeTargetKeys: Set<string>;
+  displayOverrideTargetKeys?: Set<string>;
 };

--- a/server/modules/providers/tests/codex-fork-inference.test.ts
+++ b/server/modules/providers/tests/codex-fork-inference.test.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm, symlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+
+import Database from 'better-sqlite3';
+
+import { codexRenderAnchor, normalizeCodexDisplayText, readCodexForkTranscript, readCodexRenderAnchor, selectCodexForkByDisplay } from '../services/external-cli-sessions/codex-fork-inference.js';
+import { applyInferredProviderSessionIds } from '../services/external-cli-sessions/provider-runtime-inference.js';
+import { assertProvenSessionBinding } from '../services/tmux-session-binding.service.js';
+import { tmuxPaneIdentityKey } from '../../../../shared/tmux.js';
+
+const parent = '019fb5d7-1bd6-7b11-a95b-dfc5da6193de';
+const child = '01a09a56-518a-7d92-83d8-e7a7de0d3e5f';
+const sibling = '01a09a35-5c5f-7830-94f7-4a1854613531';
+const message = '분기된 대화를 해당 터미널 화면과 대조합니다. 같은 작업폴더에서 동시에 실행 중인 다른 창을 선택하지 않고 현재 창의 최신 답변을 확인합니다. 직접적인 세션 ID 증명이 없으므로 자동 승인 권한은 부여하지 않습니다.';
+const delta = (text: string) => `push_delta: ${JSON.stringify(text)}`;
+const anchor = normalizeCodexDisplayText(message).slice(-96);
+
+test('render anchor joins streamed deltas and normalizes Markdown and Korean whitespace', () => {
+  assert.equal(codexRenderAnchor([delta(message.slice(0,40)), delta(message.slice(40))]), anchor);
+  assert.equal(normalizeCodexDisplayText('**연결** · A\n B'), '연결AB');
+});
+
+test('render anchor does not concatenate separate short assistant messages', () => {
+  assert.equal(codexRenderAnchor([delta(message), 'ConsolidateAgentMessage: source_len=180', delta('네, 확인했습니다.')]), null);
+  assert.equal(codexRenderAnchor([delta(message), 'ConsolidateAgentMessage: source_len=180']), anchor);
+  assert.equal(codexRenderAnchor([delta(message), 'push_delta: "broken', delta('짧은 답변')]), null);
+  assert.equal(codexRenderAnchor([delta('a'.repeat(300))]), null);
+});
+
+test('display matching requires both the exact pane output and a unique candidate', () => {
+  const candidates = [{ id: child, messages: [message] }, { id: sibling, messages: ['unrelated transcript'] }];
+  assert.equal(selectCodexForkByDisplay({ anchor, paneOutput: message, candidates }), child);
+  assert.equal(selectCodexForkByDisplay({ anchor, paneOutput: 'another pane', candidates }), null);
+  assert.equal(selectCodexForkByDisplay({ anchor, paneOutput: message, candidates: [...candidates, { id: sibling, messages: [message] }] }), null);
+  assert.equal(selectCodexForkByDisplay({ anchor: 'too short', paneOutput: message, candidates }), null);
+});
+
+test('a new Codex welcome card invalidates matching old scrollback', () => {
+  const candidates = [{ id: child, messages: [message] }];
+  assert.equal(selectCodexForkByDisplay({ anchor, paneOutput: `${message}\n│ >_ OpenAI Codex (v0.154.0) │\n› Ask anything`, candidates }), null);
+  assert.equal(selectCodexForkByDisplay({ anchor, paneOutput: `OpenAI Codex (v0.154.0)\n${message}`, candidates }), child);
+});
+
+test('log reader is process-generation scoped and does not require recent wall-clock activity', () => {
+  const db = new Database(':memory:');
+  try {
+    db.exec(`CREATE TABLE logs(id INTEGER PRIMARY KEY, ts INTEGER, ts_nanos INTEGER, process_uuid TEXT, thread_id TEXT, target TEXT, feedback_log_body TEXT);
+      CREATE INDEX idx_logs_process_uuid_threadless_ts ON logs(process_uuid, ts DESC, ts_nanos DESC, id DESC) WHERE thread_id IS NULL;`);
+    const insert = db.prepare('INSERT INTO logs VALUES (?, ?, 0, ?, ?, ?, ?)');
+    insert.run(1, 101, 'pid:10:old', null, 'codex_tui::markdown_stream', delta(message));
+    insert.run(2, 201, 'pid:20:current', null, 'codex_tui::markdown_stream', delta(message));
+    insert.run(3, 202, 'pid:10:new', 'a-different-thread', 'codex_core::stream', delta(message));
+    assert.equal(readCodexRenderAnchor(db, 20, 200000), anchor);
+    assert.equal(readCodexRenderAnchor(db, 10, 200000), null);
+    assert.equal(readCodexRenderAnchor(db, 999, 0), null);
+    insert.run(4, 203, 'pid:20:conflicting-generation', null, 'codex_tui::markdown_stream', delta(message));
+    assert.equal(readCodexRenderAnchor(db, 20, 200000), null);
+  } finally { db.close(); }
+});
+
+test('unsupported log schemas fail closed', () => {
+  const db = new Database(':memory:');
+  try { assert.equal(readCodexRenderAnchor(db, 20, 0), null); } finally { db.close(); }
+});
+
+const header = (id: string, parentId = parent) => JSON.stringify({ type: 'session_meta', payload: { id, forked_from_id: parentId, base_instructions: 'x'.repeat(20000) } });
+const assistant = (text: string) => JSON.stringify({ type: 'response_item', payload: { type: 'message', role: 'assistant', content: [{ type: 'output_text', text }] } });
+const taskComplete = (text: string) => JSON.stringify({ type: 'event_msg', payload: { type: 'task_complete', last_agent_message: text } });
+
+test('bounded rollout reader handles large metadata, cached unchanged files, append, and replacement', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'chatmux-fork-test-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const path = join(root, 'rollout.jsonl');
+  await writeFile(path, `${header(child)}\n${assistant(message)}\n`);
+  const initial = await readCodexForkTranscript(path, child, root);
+  assert.deepEqual(initial, { id: child, parentId: parent, messages: [message] });
+  assert.equal(await readCodexForkTranscript(path, child, root), initial);
+  await writeFile(path, `${header(child)}\n${assistant(message)}\n${assistant('new response')}\n`);
+  assert.deepEqual((await readCodexForkTranscript(path, child, root))?.messages, [message, 'new response']);
+  await writeFile(path, `${header(child)}\n${taskComplete(message)}\n`);
+  assert.deepEqual((await readCodexForkTranscript(path, child, root))?.messages, [message]);
+  await writeFile(path, `${header(sibling)}\n${assistant(message)}\n`);
+  assert.equal(await readCodexForkTranscript(path, child, root), null);
+  await writeFile(path, 'invalid JSON\n');
+  assert.equal(await readCodexForkTranscript(path, child, root), null);
+});
+
+test('rollout reader rejects escaped paths, symlinks outside root, wrong IDs and malformed parents', async (t) => {
+  const temp = await mkdtemp(join(tmpdir(), 'chatmux-fork-test-'));
+  t.after(() => rm(temp, { recursive: true, force: true }));
+  const root = join(temp, 'sessions');
+  await mkdir(root);
+  const outside = join(temp, 'outside.jsonl');
+  await writeFile(outside, `${header(child)}\n${assistant(message)}\n`);
+  assert.equal(await readCodexForkTranscript(outside, child, root), null);
+  await symlink(outside, join(root, 'link.jsonl'));
+  assert.equal(await readCodexForkTranscript(join(root, 'link.jsonl'), child, root), null);
+  const path = join(root, 'invalid.jsonl');
+  await writeFile(path, `${header(child, '../not-an-id')}\n`);
+  assert.equal(await readCodexForkTranscript(path, child, root), null);
+});
+
+test('an oversized record and partial tail cannot manufacture assistant evidence', async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'chatmux-fork-test-'));
+  t.after(() => rm(root, { recursive: true, force: true }));
+  const path = join(root, 'large.jsonl');
+  await writeFile(path, `${header(child)}\n${assistant('x'.repeat(2*1024*1024))}\n${assistant(message)}\n{"partial":`);
+  assert.deepEqual((await readCodexForkTranscript(path, child, root))?.messages, [message]);
+});
+
+test('fork display override never grants transcript input or approval authority', () => {
+  const tmux = { socketPath: '/tmp/test-socket', sessionId: '$1', windowId: '@1', paneId: '%1' };
+  const key = tmuxPaneIdentityKey(tmux);
+  const session = { tmuxName: 'test', tmux, kind: 'codex' as const, providerSessionId: parent, binding: 'observed' as const, agentPid: 10, startedAtMs: 100 };
+  const [mapped] = applyInferredProviderSessionIds([session], new Map([[key, child]]), new Set(), new Set([key]));
+  assert.equal(mapped.providerSessionId, child);
+  assert.equal(mapped.binding, 'inferred');
+  assert.throws(() => assertProvenSessionBinding(mapped), { code: 'TMUX_SESSION_BINDING_INFERRED' });
+  const [proven] = applyInferredProviderSessionIds([session], new Map([[key, child]]), new Set([key]), new Set([key]));
+  assert.equal(proven.binding, 'observed');
+  assert.doesNotThrow(() => assertProvenSessionBinding(proven));
+  const [otherSocket] = applyInferredProviderSessionIds([{ ...session, tmux: { ...tmux, socketPath: '/tmp/other' } }], new Map([[key, child]]), new Set(), new Set([key]));
+  assert.equal(otherSocket.providerSessionId, parent);
+});


### PR DESCRIPTION
## 문제

최근 Codex CLI는 TUI별 프로세스가 아니라 공유 `app-server`가 rollout 파일을 열어 둡니다. 이 상태에서 사용자가 `Esc`로 이전 시점으로 돌아가 새 분기를 시작하면:

- TUI 실행 인자에는 처음 연 대화 ID가 계속 남고
- 실제 답변은 `forked_from_id`를 가진 새 대화에 기록되어
- ChatMux가 오래된 부모 대화를 계속 표시할 수 있습니다.

같은 작업 폴더에 Codex 창이 여러 개 있으면 cwd나 최신 생성 시각만으로는 어느 분기인지 안전하게 구분할 수도 없습니다.

## 변경 내용

- Codex TUI의 프로세스 세대별 렌더 로그에서 현재 답변의 정규화된 suffix를 읽습니다.
- 공유 app-server가 실제로 열어 둔 rollout만 후보로 수집합니다.
- `session_meta.forked_from_id` 계보가 현재 pane의 기존 대화로 이어지는 후보만 남깁니다.
- 정확한 tmux socket/session/window/pane/PID 세대를 다시 확인합니다.
- 현재 pane 화면과 rollout 양쪽에서 답변이 **한 후보에만** 일치할 때 그 분기로 표시를 전환합니다.
- 첫 탐색 이후에는 프로세스 세대·렌더 suffix·transcript stat 기반의 제한된 캐시를 사용합니다.

시간창이나 cwd만으로 연결하지 않으며, 모호하거나 파일/DB 형식이 예상과 다르면 기존 연결을 유지하고 실패를 닫힌 상태로 처리합니다.

## 안전 범위

이 경로는 대화 **표시용 추론**으로만 유지됩니다. 직접적인 provider identity receipt가 아니므로 `observed` 권한으로 승격하지 않고, 승인이나 session-addressed 입력 권한도 부여하지 않습니다. Codex 설정·터미널 제목·tmux pane 태그는 변경하지 않습니다.

자원 사용도 다음처럼 제한했습니다.

- 열린 thread 후보 최대 32개
- fork 조상 탐색 최대 16단계
- transcript tail 최대 1 MiB, 최근 메시지 최대 8개
- 프로세스 로그 최대 256행
- transcript 캐시 최대 32개

## 확인

- 동일 프로젝트에서 동시에 실행 중인 Codex pane 2개가 각각 자신의 활성 Esc 분기로 연결됨
- 로컬 실제 탐색: 최초 약 99 ms, 캐시 후 약 13 ms
- 두 활성 분기의 transcript history API에서 기존 메시지와 최신 메시지 로딩 확인
- 신규 집중 테스트 10개 통과
- 전체 `npm test`: 720 tests 통과
- `npm run typecheck`, `npm run check:core`, `npm run lint`, `npm run check:identity`, `npm run build` 통과

`npm run verify`는 변경하지 않은 upstream `package-lock.json`의 현재 npm advisory 4건(`hono`, `js-yaml`, `multer`, `sharp`) 때문에 audit 단계에서 중단됩니다. 이 PR은 의존성 파일을 변경하지 않습니다.

## 제한 사항

새 분기의 첫 답변이 화면과 transcript를 안전하게 대조할 만큼 충분한 길이가 된 뒤 연결됩니다. 너무 짧거나 여러 후보가 같은 문장을 포함하면 오연결하지 않고 다음 명확한 답변까지 기존 대화를 유지합니다.
